### PR TITLE
Keep advisory lock on duplicate instead of creating new one

### DIFF
--- a/src/interface/misc.rs
+++ b/src/interface/misc.rs
@@ -125,9 +125,3 @@ impl AdvisoryLock {
         } else {false}
     }
 }
-
-impl Clone for AdvisoryLock {
-    fn clone(&self) -> Self {
-        AdvisoryLock::new()
-    }
-}

--- a/src/safeposix/cage.rs
+++ b/src/safeposix/cage.rs
@@ -129,9 +129,9 @@ impl Cage {
     }
 
     pub fn load_lower_handle_stubs(&mut self) {
-        let stdin = interface::RustRfc::new(interface::RustLock::new(FileDescriptor::Stream(StreamDesc {position: 0, stream: 0, flags: O_RDONLY, advlock: interface::AdvisoryLock::new()})));
-        let stdout = interface::RustRfc::new(interface::RustLock::new(FileDescriptor::Stream(StreamDesc {position: 0, stream: 1, flags: O_WRONLY, advlock: interface::AdvisoryLock::new()})));
-        let stderr = interface::RustRfc::new(interface::RustLock::new(FileDescriptor::Stream(StreamDesc {position: 0, stream: 2, flags: O_WRONLY, advlock: interface::AdvisoryLock::new()})));
+        let stdin = interface::RustRfc::new(interface::RustLock::new(FileDescriptor::Stream(StreamDesc {position: 0, stream: 0, flags: O_RDONLY, advlock: interface::RustRfc::new(interface::AdvisoryLock::new())})));
+        let stdout = interface::RustRfc::new(interface::RustLock::new(FileDescriptor::Stream(StreamDesc {position: 0, stream: 1, flags: O_WRONLY, advlock: interface::RustRfc::new(interface::AdvisoryLock::new())})));
+        let stderr = interface::RustRfc::new(interface::RustLock::new(FileDescriptor::Stream(StreamDesc {position: 0, stream: 2, flags: O_WRONLY, advlock: interface::RustRfc::new(interface::AdvisoryLock::new())})));
         let mut fdtable = self.filedescriptortable.write().unwrap();
         fdtable.insert(0, stdin);
         fdtable.insert(1, stdout);

--- a/src/safeposix/cage.rs
+++ b/src/safeposix/cage.rs
@@ -30,7 +30,7 @@ pub struct FileDesc {
     pub position: usize,
     pub inode: usize,
     pub flags: i32,
-    pub advlock: interface::AdvisoryLock
+    pub advlock: interface::RustRfc<interface::AdvisoryLock>
 }
 
 #[derive(Debug, Clone)]
@@ -38,7 +38,7 @@ pub struct StreamDesc {
     pub position: usize,
     pub stream: i32, //0 for stdin, 1 for stdout, 2 for stderr
     pub flags: i32,
-    pub advlock: interface::AdvisoryLock
+    pub advlock: interface::RustRfc<interface::AdvisoryLock>
 }
 
 #[derive(Debug, Clone)]
@@ -58,21 +58,21 @@ pub struct SocketDesc {
     //pub remoteaddr: Option<interface::GenSockaddr>,
     //pub last_peek: interface::RustDeque<u8>,
     pub socketobjectid: Option<i32>,
-    pub advlock: interface::AdvisoryLock
+    pub advlock: interface::RustRfc<interface::AdvisoryLock>
 }
 
 #[derive(Debug, Clone)]
 pub struct PipeDesc {
     pub pipe: i32,
     pub flags: i32,
-    pub advlock: interface::AdvisoryLock
+    pub advlock: interface::RustRfc<interface::AdvisoryLock>
 }
 
 #[derive(Debug, Clone)]
 pub struct EpollDesc {
     pub mode: i32,
     pub registered_fds: interface::RustHashMap<i32, EpollEvent>,
-    pub advlock: interface::AdvisoryLock,
+    pub advlock: interface::RustRfc<interface::AdvisoryLock>,
     pub errno: i32,
     pub flags: i32
 }

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -125,7 +125,7 @@ impl Cage {
 
             //insert file descriptor into fdtableable of the cage
             let position = if 0 != flags & O_APPEND {size} else {0};
-            let newfd = File(FileDesc {position: position, inode: inodenum, flags: flags & O_RDWRFLAGS, advlock: interface::AdvisoryLock::new()});
+            let newfd = File(FileDesc {position: position, inode: inodenum, flags: flags & O_RDWRFLAGS, advlock: interface::RustRfc::new(interface::AdvisoryLock::new())});
             let wrappedfd = interface::RustRfc::new(interface::RustLock::new(newfd));
             fdtable.insert(thisfd, wrappedfd);
         } else {panic!("Inode not created for some reason");}
@@ -1628,7 +1628,7 @@ impl Cage {
                 return syscall_error(Errno::ENFILE, "pipe", "no available file descriptor number could be found");
             };
 
-            let newfd = Pipe(PipeDesc {pipe: pipenumber, flags: flag, advlock: interface::AdvisoryLock::new()});
+            let newfd = Pipe(PipeDesc {pipe: pipenumber, flags: flag, advlock: interface::RustRfc::new(interface::AdvisoryLock::new())});
             let wrappedfd = interface::RustRfc::new(interface::RustLock::new(newfd));
             fdtable.insert(thisfd, wrappedfd);
 


### PR DESCRIPTION
New advisory locks were being created on fork/dup which is incorrect according to manpage:

```  Locks  created  by flock() are associated with an open file description (see open(2)).  This means that duplicate file descriptors (created by, for example, fork(2) or dup(2)) refer to the same lock, and this lock may be modified or released using any of these
       file descriptors.  Furthermore, the lock is released either by an explicit LOCK_UN operation on any of these duplicate file descriptors, or when all such file descriptors have been closed.

       If a process uses open(2) (or similar) to obtain more than one file descriptor for the same file, these file descriptors are treated independently by flock().  An attempt to lock the file using one of these file descriptors may be denied by  a  lock  that  the
       calling process has already placed via another file descriptor```

This PR fixes that.