### PR TITLE
Fixed the gethostname syscall

### DIFF
--- a/src/interface/misc.rs
+++ b/src/interface/misc.rs
@@ -55,7 +55,7 @@ pub fn fillzero(bufptr: *mut u8, count: usize) -> i32 {
 }
 pub fn fill(bufptr: *mut u8, count: usize, values:&Vec<u8>) -> i32 {
     let slice = unsafe{std::slice::from_raw_parts_mut(bufptr, count)};
-    slice.copy_from_slice(&values);
+    slice.copy_from_slice(&values[..count]);
     count as i32
 }
 

--- a/src/interface/misc.rs
+++ b/src/interface/misc.rs
@@ -53,6 +53,11 @@ pub fn fillzero(bufptr: *mut u8, count: usize) -> i32 {
     for i in 0..count {slice[i] = 0u8;}
     count as i32
 }
+pub fn fill(bufptr: *mut u8, count: usize, values:&Vec<u8>) -> i32 {
+    let slice = unsafe{std::slice::from_raw_parts_mut(bufptr, count)};
+    slice.copy_from_slice(&values);
+    count as i32
+}
 
 pub fn copy_fromrustdeque_sized(bufptr: *mut u8, count: usize, vecdeq: &RustDeque<u8>) {
     let (slice1, slice2) = vecdeq.as_slices();

--- a/src/safeposix/dispatcher.rs
+++ b/src/safeposix/dispatcher.rs
@@ -378,6 +378,9 @@ pub extern "C" fn dispatcher(cageid: u64, callnum: i32, arg1: Arg, arg2: Arg, ar
         PIPE_SYSCALL => {
             check_and_dispatch!(cage.pipe_syscall, interface::get_pipearray(arg1))
         }
+        GETHOSTNAME_SYSCALL => {
+            check_and_dispatch!(cage.gethostname_syscall, interface::get_mutcbuf(arg1), interface::get_usize(arg2))
+        }
         _ => {//unknown syscall
             -1
         }

--- a/src/safeposix/dispatcher.rs
+++ b/src/safeposix/dispatcher.rs
@@ -379,7 +379,7 @@ pub extern "C" fn dispatcher(cageid: u64, callnum: i32, arg1: Arg, arg2: Arg, ar
             check_and_dispatch!(cage.pipe_syscall, interface::get_pipearray(arg1))
         }
         GETHOSTNAME_SYSCALL => {
-            check_and_dispatch!(cage.gethostname_syscall, interface::get_mutcbuf(arg1), interface::get_usize(arg2))
+            check_and_dispatch!(cage.gethostname_syscall, interface::get_mutcbuf(arg1), interface::get_isize(arg2))
         }
         _ => {//unknown syscall
             -1

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -1167,7 +1167,7 @@ impl Cage {
     }
 
     //we only return the default host name because we do not allow for the user to change the host name right now
-    pub fn gethostname_syscall(&self, address_ptr: *mut u8, length: usize) -> i32 {
+    pub fn gethostname_syscall(&self, address_ptr: *mut u8, length: isize) -> i32 {
         if length < 0 {
             return syscall_error(Errno::EINVAL, "gethostname_syscall", "provided length argument is invalid");
         }
@@ -1177,8 +1177,8 @@ impl Cage {
         let name_length = bytes.len();
         
         let mut len = name_length;
-        if length < len {
-            len = length;
+        if (length as usize) < len {
+            len = (length as usize);
         }
 
         interface::fill(address_ptr, len, &bytes);

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -1168,18 +1168,21 @@ impl Cage {
 
     //we only return the default host name because we do not allow for the user to change the host name right now
     pub fn gethostname_syscall(&self, address_ptr: &mut [u8], length: usize) -> i32 {
-
         if length < 0 {
             return syscall_error(Errno::EINVAL, "gethostname_syscall", "provided length argument is invalid");
         }
+
+        let mut bytes: Vec<u8> = DEFAULT_HOSTNAME.as_bytes().to_vec();
+        bytes.push(0u8); //Adding a null terminator to the end of the string
+        let name_length = bytes.len();
         
-        let hostname = format!("{}{}", DEFAULT_HOSTNAME, "\0");
-        let name_length: usize = hostname.chars().count();
-        if name_length > length {
-            address_ptr[..length].copy_from_slice(&hostname[..length].as_bytes());
-        } else {
-            address_ptr[..name_length].copy_from_slice(&hostname.as_bytes());
+        let len = name_length;
+        if (lengt < len){
+            len = lengt;
         }
+
+        interface::fill(address_ptr, len, &bytes);
+
         return 0;
     }
 

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -1167,7 +1167,7 @@ impl Cage {
     }
 
     //we only return the default host name because we do not allow for the user to change the host name right now
-    pub fn gethostname_syscall(&self, address_ptr: &mut [u8], length: usize) -> i32 {
+    pub fn gethostname_syscall(&self, address_ptr: *mut u8, length: usize) -> i32 {
         if length < 0 {
             return syscall_error(Errno::EINVAL, "gethostname_syscall", "provided length argument is invalid");
         }
@@ -1176,9 +1176,9 @@ impl Cage {
         bytes.push(0u8); //Adding a null terminator to the end of the string
         let name_length = bytes.len();
         
-        let len = name_length;
-        if (lengt < len){
-            len = lengt;
+        let mut len = name_length;
+        if length < len {
+            len = length;
         }
 
         interface::fill(address_ptr, len, &bytes);

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -1168,11 +1168,17 @@ impl Cage {
 
     //we only return the default host name because we do not allow for the user to change the host name right now
     pub fn gethostname_syscall(&self, address_ptr: &mut [u8], length: usize) -> i32 {
-        let name_length: usize = DEFAULT_HOSTNAME.chars().count();
+
+        if length < 0 {
+            return syscall_error(Errno::EINVAL, "gethostname_syscall", "provided length argument is invalid");
+        }
+        
+        let hostname = format!("{}{}", DEFAULT_HOSTNAME, "\0");
+        let name_length: usize = hostname.chars().count();
         if name_length > length {
-            address_ptr[..length].copy_from_slice(&DEFAULT_HOSTNAME[..length].as_bytes());
+            address_ptr[..length].copy_from_slice(&hostname[..length].as_bytes());
         } else {
-            address_ptr[..name_length].copy_from_slice(&DEFAULT_HOSTNAME.as_bytes());
+            address_ptr[..name_length].copy_from_slice(&hostname.as_bytes());
         }
         return 0;
     }

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -7,7 +7,7 @@ pub mod fs_tests {
     use std::os::unix::fs::PermissionsExt;
     use std::fs::OpenOptions;
 
-    pub fn test_fs() {
+    pub fn test_fs() {/*
         ut_lind_fs_simple(); // has to go first, else the data files created screw with link count test
 
         lindrustinit();
@@ -44,7 +44,7 @@ pub mod fs_tests {
         persistencetest();
         rdwrtest();
         prdwrtest();
-        chardevtest();
+        chardevtest();*/
     }
 
 

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -7,7 +7,7 @@ pub mod fs_tests {
     use std::os::unix::fs::PermissionsExt;
     use std::fs::OpenOptions;
 
-    pub fn test_fs() {/*
+    pub fn test_fs() {
         ut_lind_fs_simple(); // has to go first, else the data files created screw with link count test
 
         lindrustinit();
@@ -44,7 +44,7 @@ pub mod fs_tests {
         persistencetest();
         rdwrtest();
         prdwrtest();
-        chardevtest();*/
+        chardevtest();
     }
 
 

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -5,7 +5,7 @@ pub mod net_tests {
     use super::super::*;
     use std::mem::size_of;
 
-    pub fn net_tests() {
+    pub fn net_tests() {/*
         ut_lind_net_bind();
         ut_lind_net_bind_multiple();
         ut_lind_net_bind_on_zero();
@@ -19,7 +19,7 @@ pub mod net_tests {
         ut_lind_net_socketoptions();
         ut_lind_net_udp_bad_bind();
         ut_lind_net_udp_simple();
-        ut_lind_net_udp_connect();
+        ut_lind_net_udp_connect();*/
         ut_lind_net_gethostname();
     }
 

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -826,15 +826,17 @@ pub mod net_tests {
 
         let mut buf = vec![0u8; 5];
         let bufptr: *mut u8 = &mut buf[0];
-
         assert_eq!(cage.gethostname_syscall(bufptr, -1), -(Errno::EINVAL as i32));
-
         assert_eq!(cage.gethostname_syscall(bufptr, 5), 0);
         assert_eq!(std::str::from_utf8(&buf).unwrap(), "Lind\0");
 
+        let mut buf = vec![0u8; 5];
+        let bufptr: *mut u8 = &mut buf[0];
         assert_eq!(cage.gethostname_syscall(bufptr, 4), 0);
         assert_eq!(std::str::from_utf8(&buf).unwrap(), "Lind\0");
 
+        let mut buf = vec![0u8; 5];
+        let bufptr: *mut u8 = &mut buf[0];
         assert_eq!(cage.gethostname_syscall(bufptr, 2), 0);
         assert_eq!(std::str::from_utf8(&buf).unwrap(), "Li\0\0\0");
 

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -5,7 +5,7 @@ pub mod net_tests {
     use super::super::*;
     use std::mem::size_of;
 
-    pub fn net_tests() {/*
+    pub fn net_tests() {
         ut_lind_net_bind();
         ut_lind_net_bind_multiple();
         ut_lind_net_bind_on_zero();
@@ -19,7 +19,7 @@ pub mod net_tests {
         ut_lind_net_socketoptions();
         ut_lind_net_udp_bad_bind();
         ut_lind_net_udp_simple();
-        ut_lind_net_udp_connect();*/
+        ut_lind_net_udp_connect();
         ut_lind_net_gethostname();
     }
 

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -20,6 +20,7 @@ pub mod net_tests {
         ut_lind_net_udp_bad_bind();
         ut_lind_net_udp_simple();
         ut_lind_net_udp_connect();
+        ut_lind_net_gethostname();
     }
 
 
@@ -813,6 +814,40 @@ pub mod net_tests {
         assert_eq!(cage.send_syscall(sendfd, str2cbuf("UDP Connect Test"), 16, 0), 16); 
         thread.join().unwrap();
 
+        assert_eq!(cage.exit_syscall(), 0);
+        lindrustfinalize();
+    }
+
+    pub fn ut_lind_net_gethostname() { //Assuming DEFAULT_HOSTNAME == "Lind" and change of hostname is not allowed
+        lindrustinit();
+        let cage = {CAGE_TABLE.read().unwrap().get(&1).unwrap().clone()};
+
+        let hostnme = format!("{}{}", DEFAULT_HOSTNAME, "\0");
+
+        let mut buf = vec![0u8; 5];
+        let bufptr: *mut u8 = &mut buf[0];
+
+        assert_eq!(cage.gethostname_syscall(bufptr, -1), -(Errno::EINVAL as i32));
+
+        assert_eq!(cage.gethostname_syscall(bufptr, 5), 0);
+        assert_eq!(std::str::from_utf8(&buf).unwrap(), "Lind\0");
+
+        assert_eq!(cage.gethostname_syscall(bufptr, 4), 0);
+        assert_eq!(std::str::from_utf8(&buf).unwrap(), "Lind\0");
+
+        assert_eq!(cage.gethostname_syscall(bufptr, 2), 0);
+        assert_eq!(std::str::from_utf8(&buf).unwrap(), "Li\0\0\0");
+
+        let mut buf = vec![0u8; 4];
+        let bufptr: *mut u8 = &mut buf[0];        
+        assert_eq!(cage.gethostname_syscall(bufptr, 4), 0);
+        assert_eq!(std::str::from_utf8(&buf).unwrap(), "Lind");
+
+        let mut buf = vec![0u8; 2];
+        let bufptr: *mut u8 = &mut buf[0];        
+        assert_eq!(cage.gethostname_syscall(bufptr, 2), 0);
+        assert_eq!(std::str::from_utf8(&buf).unwrap(), "Li");
+        
         assert_eq!(cage.exit_syscall(), 0);
         lindrustfinalize();
     }


### PR DESCRIPTION
I took an approach similar to getcwd and used the fill function (copied here with a small fix to allow for length < hostname_length). We should choose to opt for this implementation of the fill function instead of the one in develop when merging networking to develop.

In POSIX, it is not specified whether the returned string should have the null terminator or not when truncating happens. I chose to not include it just like our safeposix implementation.