### PR TITLE
CLOEXEC fixes (companion PR)

### DIFF
--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1137,6 +1137,7 @@ impl Cage {
             let locked_oldfiledesc = fdtable.get(&oldfd).unwrap();
             let oldfiledesc_enum = locked_oldfiledesc.read().unwrap();
             filedesc_clone = (*&oldfiledesc_enum).clone();
+            filedesc_clone.flags = filedesc_clone.flags & ~O_CLOEXEC; // we don't want to pass on the CLOEXEC flag
         }
 
         let wrappedfd = interface::RustRfc::new(interface::RustLock::new(filedesc_clone));

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1138,18 +1138,19 @@ impl Cage {
             let oldfiledesc_enum = locked_oldfiledesc.read().unwrap();
             filedesc_clone = (*&oldfiledesc_enum).clone();
             match filedesc_clone { // we don't want to pass on the CLOEXEC flag
-                File(normalfile_filedesc_obj) => {
+                File(mut normalfile_filedesc_obj) => {
                     normalfile_filedesc_obj.flags = normalfile_filedesc_obj.flags & !O_CLOEXEC; 
                 }
-                Pipe(pipe_filedesc_obj) => {
+                Pipe(mut pipe_filedesc_obj) => {
                     pipe_filedesc_obj.flags = pipe_filedesc_obj.flags & !O_CLOEXEC;
                 }
-                Socket(socket_filedesc_obj) => {
+                Socket(mut socket_filedesc_obj) => {
                     socket_filedesc_obj.flags = socket_filedesc_obj.flags & !O_CLOEXEC;
                 }
-                Stream(stream_filedesc_obj) => {
+                Stream(mut stream_filedesc_obj) => {
                     stream_filedesc_obj.flags = stream_filedesc_obj.flags & !O_CLOEXEC;
                 }
+                _ => {return syscall_error(Errno::EACCES, "dup or dup2", "can't dup the provided file");},
             }
 
         }

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1137,7 +1137,7 @@ impl Cage {
             let locked_oldfiledesc = fdtable.get(&oldfd).unwrap();
             let oldfiledesc_enum = locked_oldfiledesc.read().unwrap();
             filedesc_clone = (*&oldfiledesc_enum).clone();
-            match &*filedesc_clone { // we don't want to pass on the CLOEXEC flag
+            match filedesc_clone { // we don't want to pass on the CLOEXEC flag
                 File(normalfile_filedesc_obj) => {
                     normalfile_filedesc_obj.flags = normalfile_filedesc_obj.flags & !O_CLOEXEC; 
                 }

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1138,16 +1138,16 @@ impl Cage {
             let oldfiledesc_enum = locked_oldfiledesc.read().unwrap();
             filedesc_clone = (*&oldfiledesc_enum).clone();
             match filedesc_clone { // we don't want to pass on the CLOEXEC flag
-                File(mut normalfile_filedesc_obj) => {
+                File(ref mut normalfile_filedesc_obj) => {
                     normalfile_filedesc_obj.flags = normalfile_filedesc_obj.flags & !O_CLOEXEC; 
                 }
-                Pipe(mut pipe_filedesc_obj) => {
+                Pipe(ref mut pipe_filedesc_obj) => {
                     pipe_filedesc_obj.flags = pipe_filedesc_obj.flags & !O_CLOEXEC;
                 }
-                Socket(mut socket_filedesc_obj) => {
+                Socket(ref mut socket_filedesc_obj) => {
                     socket_filedesc_obj.flags = socket_filedesc_obj.flags & !O_CLOEXEC;
                 }
-                Stream(mut stream_filedesc_obj) => {
+                Stream(ref mut stream_filedesc_obj) => {
                     stream_filedesc_obj.flags = stream_filedesc_obj.flags & !O_CLOEXEC;
                 }
                 _ => {return syscall_error(Errno::EACCES, "dup or dup2", "can't dup the provided file");},

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1300,7 +1300,11 @@ impl Cage {
                 }
                 // set the flags but make sure that the flags are valid
                 (F_SETFD, arg) if arg >= 0 => {
-                    *flags = (*flags & !O_CLOEXEC) | (arg & O_CLOEXEC);
+                    if arg & O_CLOEXEC != 0 {
+                        *flags |= O_CLOEXEC;
+                    } else {
+                        *flags &= !O_CLOEXEC;
+                    }
                     0
                 }
                 (F_GETFL, ..) => {

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1300,7 +1300,7 @@ impl Cage {
                 }
                 // set the flags but make sure that the flags are valid
                 (F_SETFD, arg) if arg >= 0 => {
-                    *flags |= arg & O_CLOEXEC;
+                    *flags = (*flags & !O_CLOEXEC) | (arg & O_CLOEXEC);
                     0
                 }
                 (F_GETFL, ..) => {

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1137,7 +1137,21 @@ impl Cage {
             let locked_oldfiledesc = fdtable.get(&oldfd).unwrap();
             let oldfiledesc_enum = locked_oldfiledesc.read().unwrap();
             filedesc_clone = (*&oldfiledesc_enum).clone();
-            filedesc_clone.flags = filedesc_clone.flags & ~O_CLOEXEC; // we don't want to pass on the CLOEXEC flag
+            match &*filedesc_clone { // we don't want to pass on the CLOEXEC flag
+                File(normalfile_filedesc_obj) => {
+                    normalfile_filedesc_obj.flags = normalfile_filedesc_obj.flags & !O_CLOEXEC; 
+                }
+                Pipe(pipe_filedesc_obj) => {
+                    pipe_filedesc_obj.flags = pipe_filedesc_obj.flags & !O_CLOEXEC;
+                }
+                Socket(socket_filedesc_obj) => {
+                    socket_filedesc_obj.flags = socket_filedesc_obj.flags & !O_CLOEXEC;
+                }
+                Stream(stream_filedesc_obj) => {
+                    stream_filedesc_obj.flags = stream_filedesc_obj.flags & !O_CLOEXEC;
+                }
+            }
+
         }
 
         let wrappedfd = interface::RustRfc::new(interface::RustLock::new(filedesc_clone));

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1132,7 +1132,7 @@ impl Cage {
         }    
 
         // get and clone fd, wrap and insert into table.
-        let filedesc_clone;
+        let mut filedesc_clone;
         {
             let locked_oldfiledesc = fdtable.get(&oldfd).unwrap();
             let oldfiledesc_enum = locked_oldfiledesc.read().unwrap();


### PR DESCRIPTION
Fixes CLOEXEC in fcntl set, and stops dup/dup2 from passing flag per dup manpage.