### PR TITLE
Pipeclose reffix

### DIFF
--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1221,7 +1221,7 @@ impl Cage {
                     pipe.decr_ref(pipe_filedesc_obj.flags);
 
                     //Code below needs to reflect addition of pipes
-                    if pipe.get_write_ref() == 0 && (pipe_filedesc_obj.flags O_RDWRFLAGS) == O_WRONLY {
+                    if pipe.get_write_ref() == 0 && (pipe_filedesc_obj.flags & O_RDWRFLAGS) == O_WRONLY {
                         // we're closing the last write end, lets set eof
                         pipe.set_eof();
                     }

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1221,7 +1221,7 @@ impl Cage {
                     pipe.decr_ref(pipe_filedesc_obj.flags);
 
                     //Code below needs to reflect addition of pipes
-                    if pipe.get_write_ref() == 0 && pipe_filedesc_obj.flags == O_WRONLY {
+                    if pipe.get_write_ref() == 0 && (pipe_filedesc_obj.flags O_RDWRFLAGS) == O_WRONLY {
                         // we're closing the last write end, lets set eof
                         pipe.set_eof();
                     }


### PR DESCRIPTION
Minor fix that amends the close_helper to account for CLOEXEC w/ pipes.