### PR TITLE
O_NONBLOCK and O_TRUNC fixes

### DIFF
--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1749,7 +1749,7 @@ impl Cage {
 
     pub fn pipe2_syscall(&self, pipefd: &mut PipeArray, flags: i32) -> i32 {
 
-        let flagsmask = O_CLOEXEC & O_NONBLOCK;
+        let flagsmask = O_CLOEXEC | O_NONBLOCK;
         let actualflags = flags & flagsmask;
 
         // get next available pipe number, and set up pipe

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1749,7 +1749,7 @@ impl Cage {
 
     pub fn pipe2_syscall(&self, pipefd: &mut PipeArray, flags: i32) -> i32 {
 
-        let flagsmask = O_CLOEXEC;
+        let flagsmask = O_CLOEXEC & O_NONBLOCK;
         let actualflags = flags & flagsmask;
 
         // get next available pipe number, and set up pipe

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -95,9 +95,11 @@ impl Cage {
                     }
 
                     //set size of file to 0
-                    if let Inode::File(ref mut g) = *(FS_METADATA.inodetable.get_mut(&inodenum).unwrap()) {g.size = 0;} else {
-                        return syscall_error(Errno::EINVAL, "open", "file is not a normal file and thus cannot be truncated");
-                    }
+                    if let Inode::File(ref mut g) = *(FS_METADATA.inodetable.get_mut(&inodenum).unwrap()) {g.size = 0;} 
+                    
+                    // else {
+                    //     return syscall_error(Errno::EINVAL, "open", "file is not a normal file and thus cannot be truncated");
+                    // }
 
                     //remove the previous file and add a new one of 0 length
                     if let interface::RustHashEntry::Occupied(occ) = entry {

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1336,7 +1336,7 @@ impl Cage {
                     *flags & !O_CLOEXEC
                 }
                 (F_SETFL, arg) if arg >= 0 => {
-                    *flags = arg;
+                    *flags |= arg;
                     0
                 }
                 (F_DUPFD, arg) if arg >= 0 => {

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -620,7 +620,9 @@ impl Cage {
 
                     // get the pipe, read from it, and return bytes read
                     let pipe = PIPE_TABLE.get(&pipe_filedesc_obj.pipe).unwrap().clone();
-                    pipe.read_from_pipe(buf, count) as i32
+                    let blocking = false;
+                    if pipe_filedesc_obj.flags & O_NONBLOCK != 0 { blocking = true;} 
+                    pipe.read_from_pipe(buf, count, blocking) as i32
                 }
                 Epoll(_) => {syscall_error(Errno::EINVAL, "read", "fd is attached to an object which is unsuitable for reading")}
             }
@@ -779,7 +781,9 @@ impl Cage {
                     }
                     // get the pipe, write to it, and return bytes written
                     let pipe = PIPE_TABLE.get(&pipe_filedesc_obj.pipe).unwrap().clone();
-                    pipe.write_to_pipe(buf, count) as i32
+                    let blocking = false;
+                    if pipe_filedesc_obj.flags & O_NONBLOCK != 0 { blocking = true;}
+                    pipe.write_to_pipe(buf, count, blocking) as i32
   
                 }
                 Epoll(_) => {syscall_error(Errno::EINVAL, "write", "fd is attached to an object which is unsuitable for writing")}


### PR DESCRIPTION
This PR adds NON_BLOCK for pipes as well as fixes fcntl for non-block, as well as fixed a problem where open was trying to apply O_TRUNC to non regular files.