### PR TITLE
Lazy updates

### DIFF
--- a/src/interface/errnos.rs
+++ b/src/interface/errnos.rs
@@ -2,9 +2,9 @@
 // Error handling for SafePOSIX
 use crate::interface;
 
-use std::lazy::SyncOnceCell;
+use std::sync::OnceLock;
 
-pub static VERBOSE: SyncOnceCell<isize> = SyncOnceCell::new();
+pub static VERBOSE: OnceLock<isize> = OnceLock::new();
 
 
 //A macro which takes the enum and adds to it a try_from trait which can convert values back to

--- a/src/interface/file.rs
+++ b/src/interface/file.rs
@@ -12,7 +12,7 @@ use std::slice;
 pub use std::path::{PathBuf as RustPathBuf, Path as RustPath, Component as RustPathComponent};
 pub use std::ffi::CStr as RustCStr;
 use std::io::{SeekFrom, Seek, Read, Write};
-pub use std::lazy::{SyncLazy as RustLazyGlobal};
+pub use std::sync::{LazyLock as RustLazyGlobal};
 
 use std::os::unix::io::{AsRawFd, RawFd};
 use libc::{mmap, mremap, munmap, PROT_READ, PROT_WRITE, MAP_SHARED, MREMAP_MAYMOVE};


### PR DESCRIPTION
Fixes issues for OnceCell and SyncLazy since they have been renamed in the[ latest rust update.](https://github.com/rust-lang/rust/pull/98165)