### PR TITLE
netshutdown

### DIFF
--- a/src/interface/comm.rs
+++ b/src/interface/comm.rs
@@ -338,6 +338,11 @@ impl Socket {
         sor
     }
 
+    pub fn shutdown(&self, how: i32) -> i32 {
+        let ret = unsafe {libc::shutdown(self.raw_sys_fd, how)};
+        ret
+    }
+
     pub fn check_rawconnection(&self) -> bool {
         let mut valbuf = 0;
         let mut len = size_of::<i32>() as u32;

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1276,7 +1276,7 @@ impl Cage {
                 }
                 if cleanflag {
                     let mut fdclone = filedesc_enum.clone();
-                    let retval = self._cleanup_socket_inner(&mut fdclone, false, false);
+                    let retval = self._cleanup_socket_inner(&mut fdclone, -1, false);
                     if retval < 0 {
                         return retval;
                     }

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -476,7 +476,7 @@ impl Cage {
                             let sockobjwrapper = NET_METADATA.socket_object_table.get(&sid).unwrap();
                             let sockobj = &*sockobjwrapper.read();
 
-                            if (sockobj.1 != ConnState::CONNECTED) && (sockobj.1 != ConnState::CONNRDONLY) {
+                            if (sockobj.1 != ConnState::CONNECTED) && (sockobj.1 != ConnState::CONNWRONLY) {
                                 return syscall_error(Errno::ENOTCONN, "send", "The descriptor is not connected");
                             }
 

--- a/src/safeposix/syscalls/net_constants.rs
+++ b/src/safeposix/syscalls/net_constants.rs
@@ -384,5 +384,5 @@ pub const EPOLL_CTL_MOD: i32 = 3;
 //for internal use
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ConnState {
-    NOTCONNECTED, CONNECTED, LISTEN, INPROGRESS
+    NOTCONNECTED, CONNECTED, CONNRDONLY, CONNWRONLY, LISTEN, INPROGRESS
 }

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -835,6 +835,7 @@ pub mod net_tests {
             let fd = cage2.accept_syscall(serversockfd, &mut socket2); 
             assert!(fd > 0);
             
+            assert_eq!(cage2.netshutdown_syscall(fd, SHUT_RD), 0);
             assert_eq!(cage2.send_syscall(fd, str2cbuf("random string"), 13, 0), 13);
             assert_eq!(cage2.netshutdown_syscall(fd, SHUT_RDWR), 0);
             assert_ne!(cage2.netshutdown_syscall(fd, SHUT_RDWR), 0); //should fail


### PR DESCRIPTION
This adds the libc shutdown to the interface so we can use it to properly half-close sockets. This also let me implement SHUT_RD, and rearrange some of the function flow to make more sense.