### PR TITLE
Pipe sanity fixes

### DIFF
--- a/src/interface/pipe.rs
+++ b/src/interface/pipe.rs
@@ -61,7 +61,7 @@ impl EmulatedPipe {
 
     // Write length bytes from pointer into pipe
     // BUG: This only currently works as SPSC
-    pub fn write_to_pipe(&self, ptr: *const u8, length: usize, blocking: bool) -> i32 {
+    pub fn write_to_pipe(&self, ptr: *const u8, length: usize, nonblocking: bool) -> i32 {
 
         let mut bytes_written = 0;
 
@@ -73,7 +73,7 @@ impl EmulatedPipe {
         let mut write_end = self.write_end.lock();
 
         let pipe_space = write_end.remaining();
-        if blocking && (pipe_space == self.size) {
+        if nonblocking && (pipe_space == self.size) {
             return -1;
         }
 
@@ -89,7 +89,7 @@ impl EmulatedPipe {
     // Read length bytes from the pipe into pointer
     // Will wait for bytes unless pipe is empty and eof is set.
     // BUG: This only currently works as SPSC
-    pub fn read_from_pipe(&self, ptr: *mut u8, length: usize, blocking: bool) -> i32 {
+    pub fn read_from_pipe(&self, ptr: *mut u8, length: usize, nonblocking: bool) -> i32 {
 
         let mut bytes_read = 0;
 
@@ -100,13 +100,13 @@ impl EmulatedPipe {
 
         let mut read_end = self.read_end.lock();
         let mut pipe_space = read_end.len();
-        if blocking && (pipe_space == 0) {
+        if nonblocking && (pipe_space == 0) {
             return -1;
         }
 
         while bytes_read < length {
             pipe_space = read_end.len();
-            if (pipe_space == 0) & self.eof.load(Ordering::Relaxed) { break; }
+            if (pipe_space == 0) && self.eof.load(Ordering::Relaxed) { break; }
             let bytes_to_read = min(length, bytes_read + pipe_space);
             read_end.pop_slice(&mut buf[bytes_read..bytes_to_read]);
             bytes_read = bytes_to_read;

--- a/src/interface/pipe.rs
+++ b/src/interface/pipe.rs
@@ -106,7 +106,7 @@ impl EmulatedPipe {
 
         while bytes_read < length {
             pipe_space = read_end.len();
-            if (pipe_space == 0) && self.eof.load(Ordering::Relaxed) { break; }
+            if (pipe_space == 0) && self.eof.load(Ordering::SeqCst) { break; }
             let bytes_to_read = min(length, bytes_read + pipe_space);
             read_end.pop_slice(&mut buf[bytes_read..bytes_to_read]);
             bytes_read = bytes_to_read;


### PR DESCRIPTION
This PR:

- Fixes an error where I was using & instead of && ... though it somehow worked
- Matches the variables nonblocking to the actual calls and the inner functions
- Changes the eof check to SeqCst, which after testing doesnt add any performance overhead but esnsures correctness. (Somehow this would error when testing very large multi-gig pipelines when using Relaxed).