### PR TITLE
Remove Pipetable

### DIFF
--- a/src/safeposix/cage.rs
+++ b/src/safeposix/cage.rs
@@ -11,11 +11,6 @@ use super::filesystem::normpath;
 
 pub static CAGE_TABLE: interface::RustLazyGlobal<interface::RustHashMap<u64, interface::RustRfc<Cage>>> = interface::RustLazyGlobal::new(|| interface::new_hashmap());
 
-pub static PIPE_TABLE: interface::RustLazyGlobal<interface::RustHashMap<i32, interface::RustRfc<interface::EmulatedPipe>>> = 
-    interface::RustLazyGlobal::new(|| 
-        interface::new_hashmap()
-);
-
 #[derive(Debug, Clone)]
 pub enum FileDescriptor {
     File(FileDesc),
@@ -64,7 +59,7 @@ pub struct SocketDesc {
 
 #[derive(Debug, Clone)]
 pub struct PipeDesc {
-    pub pipe: i32,
+    pub pipe: interface::RustRfc<interface::EmulatedPipe>,
     pub flags: i32,
     pub advlock: interface::RustRfc<interface::AdvisoryLock>
 }
@@ -141,15 +136,4 @@ impl Cage {
         fdtable.insert(2, stderr);
     }
 
-}
-
-pub fn insert_next_pipe(pipe: interface::EmulatedPipe) -> Option<i32> {
-    for fd in STARTINGPIPE..MAXPIPE {
-        if let interface::RustHashEntry::Vacant(v) = PIPE_TABLE.entry(fd) {
-            v.insert(interface::RustRfc::new(pipe));
-            return Some(fd);
-        }
-    }
-
-    return None;
 }

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1933,7 +1933,8 @@ impl Cage {
         let accflags = [O_RDONLY, O_WRONLY];
         for accflag in accflags {
 
-            let thisfd = self.get_next_fd(None, Pipe(PipeDesc {pipe: pipe.clone(), flags: accflag | actualflags, advlock: interface::RustRfc::new(interface::AdvisoryLock::new())}));
+            let filedesc_enum = Pipe(PipeDesc {pipe: pipe.clone(), flags: accflag | actualflags, advlock: interface::RustRfc::new(interface::AdvisoryLock::new())});
+            let thisfd = self.get_next_fd(None, filedesc_enum);
 
             match accflag {
                 O_RDONLY => {pipefd.readfd = thisfd;},

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -654,11 +654,9 @@ impl Cage {
                         return syscall_error(Errno::EBADF, "read", "specified file not open for reading");
                     }
 
-                    // get the pipe, read from it, and return bytes read
-                    let pipe = PIPE_TABLE.get(&pipe_filedesc_obj.pipe).unwrap().clone();
                     let mut nonblocking = false;
                     if pipe_filedesc_obj.flags & O_NONBLOCK != 0 { nonblocking = true;}
-                    let ret = pipe.read_from_pipe(buf, count, nonblocking) as i32;
+                    let ret = pipe_filedesc_obj.pipe.read_from_pipe(buf, count, nonblocking) as i32;
                     if ret < 0 { return syscall_error(Errno::EAGAIN, "read", "there is no data available right now, try again later") }
                     else { return ret };
   
@@ -826,11 +824,10 @@ impl Cage {
                     if is_rdonly(pipe_filedesc_obj.flags) {
                         return syscall_error(Errno::EBADF, "write", "specified pipe not open for writing");
                     }
-                    // get the pipe, write to it, and return bytes written
-                    let pipe = PIPE_TABLE.get(&pipe_filedesc_obj.pipe).unwrap().clone();
+
                     let mut nonblocking = false;
                     if pipe_filedesc_obj.flags & O_NONBLOCK != 0 { nonblocking = true;}
-                    let ret = pipe.write_to_pipe(buf, count, nonblocking) as i32;
+                    let ret = pipe_filedesc_obj.pipe.write_to_pipe(buf, count, nonblocking) as i32;
                     if ret < 0 { return syscall_error(Errno::EAGAIN, "write", "there is no data available right now, try again later") }
                     else { return ret };
   
@@ -1173,8 +1170,7 @@ impl Cage {
                 }
             }
             Pipe(pipe_filedesc_obj) => {
-                let pipe = PIPE_TABLE.get(&pipe_filedesc_obj.pipe).unwrap().clone();
-                pipe.incr_ref(pipe_filedesc_obj.flags);
+                pipe_filedesc_obj.pipe.incr_ref(pipe_filedesc_obj.flags);
             }
             Socket(socket_filedesc_obj) => {
                 if let Some(socknum) = socket_filedesc_obj.socketobjectid {
@@ -1285,20 +1281,14 @@ impl Cage {
 
 
             }
-            Pipe(pipe_filedesc_obj) => {
-                let pipe = PIPE_TABLE.get(&pipe_filedesc_obj.pipe).unwrap().clone();
-           
+            Pipe(pipe_filedesc_obj) => {   
+                let pipe = &pipe_filedesc_obj.pipe;    
                 pipe.decr_ref(pipe_filedesc_obj.flags);
 
                 //Code below needs to reflect addition of pipes
                 if pipe.get_write_ref() == 0 && (pipe_filedesc_obj.flags & O_RDWRFLAGS) == O_WRONLY {
                     // we're closing the last write end, lets set eof
                     pipe.set_eof();
-                }
-
-                if pipe.get_write_ref() + pipe.get_read_ref() == 0 {
-                    // last reference, lets remove it
-                    PIPE_TABLE.remove(&pipe_filedesc_obj.pipe).unwrap();
                 }
 
             }
@@ -1935,12 +1925,7 @@ impl Cage {
         let flagsmask = O_CLOEXEC | O_NONBLOCK;
         let actualflags = flags & flagsmask;
 
-        // get next available pipe number, and set up pipe
-        let pipenumber = if let Some(pipeno) = insert_next_pipe(interface::new_pipe(PIPE_CAPACITY)) {
-            pipeno
-        } else {
-            return syscall_error(Errno::ENFILE, "pipe", "no available pipe number could be found");
-        };
+        let pipe = interface::RustRfc::new(interface::new_pipe(PIPE_CAPACITY));
         
         // get an fd for each end of the pipe and set flags to RD_ONLY and WR_ONLY
         // append each to pipefds list
@@ -1948,12 +1933,7 @@ impl Cage {
         let accflags = [O_RDONLY, O_WRONLY];
         for accflag in accflags {
 
-            let thisfd = self.get_next_fd(None, Pipe(PipeDesc {pipe: pipenumber, flags: accflag | actualflags, advlock: interface::RustRfc::new(interface::AdvisoryLock::new())}));
-
-            if thisfd < 0 {
-                PIPE_TABLE.remove(&pipenumber).unwrap();
-                return thisfd;
-            };
+            let thisfd = self.get_next_fd(None, Pipe(PipeDesc {pipe: pipe.clone(), flags: accflag | actualflags, advlock: interface::RustRfc::new(interface::AdvisoryLock::new())}));
 
             match accflag {
                 O_RDONLY => {pipefd.readfd = thisfd;},

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -8,7 +8,7 @@ use crate::interface::errnos::{Errno, syscall_error};
 use super::net_constants::*;
 use super::fs_constants::*;
 use super::sys_constants::*;
-use crate::safeposix::cage::{CAGE_TABLE, PIPE_TABLE, Cage, FileDescriptor::*, SocketDesc, EpollDesc, EpollEvent, FdTable, PollStruct, FileDescriptor};
+use crate::safeposix::cage::{CAGE_TABLE, Cage, FileDescriptor::*, SocketDesc, EpollDesc, EpollEvent, FdTable, PollStruct, FileDescriptor};
 use crate::safeposix::filesystem::*;
 use crate::safeposix::net::*;
 
@@ -1112,8 +1112,7 @@ impl Cage {
 
                         //not supported yet
                         Pipe(pipefdobj) => {
-                            let pipe = PIPE_TABLE.get(&pipefdobj.pipe).unwrap().clone();
-                            if pipe.check_select_read() {
+                            if pipefdobj.pipe.check_select_read() {
                                 new_readfds.insert(*fd);
                                 retval += 1;
                             }
@@ -1158,8 +1157,7 @@ impl Cage {
 
                         //not supported yet
                         Pipe(pipefdobj) => {
-                            let pipe = PIPE_TABLE.get(&pipefdobj.pipe).unwrap().clone();
-                            if pipe.check_select_write() {
+                            if pipefdobj.pipe.check_select_write() {
                                 new_writefds.insert(*fd);
                                 retval += 1;
                             }

--- a/src/safeposix/syscalls/sys_calls.rs
+++ b/src/safeposix/syscalls/sys_calls.rs
@@ -2,7 +2,7 @@
 
 // System related system calls
 use crate::interface;
-use crate::safeposix::cage::{Arg, CAGE_TABLE, PIPE_TABLE, Cage, Errno, syscall_error, FileDescriptor::*, FSData, Rlimit, StatData};
+use crate::safeposix::cage::{Arg, CAGE_TABLE, Cage, Errno, syscall_error, FileDescriptor::*, FSData, Rlimit, StatData};
 use crate::safeposix::filesystem::{FS_METADATA, Inode, metawalk, decref_dir};
 use crate::safeposix::net::{NET_METADATA};
 use crate::safeposix::shm::{SHM_METADATA};
@@ -104,8 +104,7 @@ impl Cage {
                         }
                     }
                     Pipe(pipe_filedesc_obj) => {
-                        let pipe = PIPE_TABLE.get(&pipe_filedesc_obj.pipe).unwrap().clone();
-                        pipe.incr_ref(pipe_filedesc_obj.flags)
+                        pipe_filedesc_obj.pipe.incr_ref(pipe_filedesc_obj.flags)
                     }
                     Socket(socket_filedesc_obj) => {
                         if let Some(socknum) = socket_filedesc_obj.socketobjectid {


### PR DESCRIPTION
This PR removes the idea of the pipetable, and transfers the pipe references to be internal to pipe fds.

This gives us a performance boost because we don't need to go through a locked structure on every I/O command.