### PR TITLE
No Lock Cagetable

### DIFF
--- a/src/interface/misc.rs
+++ b/src/interface/misc.rs
@@ -56,10 +56,10 @@ pub fn cagetable_clear() {
             let cageopt = cage.take();
             if cageopt.is_some() { exitvec.push(cageopt.unwrap()); }
         }
+    }
 
-        for cage in exitvec {
-            cage.exit_syscall(EXIT_SUCCESS);
-        }
+    for cage in exitvec {
+        cage.exit_syscall(EXIT_SUCCESS);
     }
 }
 

--- a/src/interface/misc.rs
+++ b/src/interface/misc.rs
@@ -33,7 +33,7 @@ use crate::safeposix::cage::{Cage};
 
 pub static mut CAGE_TABLE: Vec<Option<RustRfc<Cage>>> = Vec::new();
 
-fn cagetable_init() {
+pub fn cagetable_init() {
    unsafe { for _cage in 0..MAXCAGEID { CAGE_TABLE.push(None); }}
 }
 

--- a/src/interface/misc.rs
+++ b/src/interface/misc.rs
@@ -50,10 +50,15 @@ pub fn cagetable_getref(cageid: u64) -> RustRfc<Cage> {
 }
 
 pub fn cagetable_clear() {
+    let mut exitvec = Vec::new();
     unsafe {
         for cage in CAGE_TABLE.iter_mut() {
             let cageopt = cage.take();
-            if cageopt.is_some() { cageopt.unwrap().exit_syscall(EXIT_SUCCESS); }
+            if cageopt.is_some() { exitvec.push(cageopt.unwrap()); }
+        }
+
+        for cage in exitvec {
+            cage.exit_syscall(EXIT_SUCCESS);
         }
     }
 }

--- a/src/interface/misc.rs
+++ b/src/interface/misc.rs
@@ -26,6 +26,38 @@ pub use serde_cbor::{ser::to_vec_packed as serde_serialize_to_bytes, from_slice 
 use crate::interface::errnos::{VERBOSE};
 use std::time::Duration;
 
+const MAXCAGEID: i32 = 1024;
+const EXIT_SUCCESS : i32 = 0;
+
+use crate::safeposix::cage::{Cage};
+
+pub static mut CAGE_TABLE: Vec<Option<RustRfc<Cage>>> = Vec::new();
+
+fn cagetable_init() {
+   unsafe { for _cage in 0..MAXCAGEID { CAGE_TABLE.push(None); }}
+}
+
+pub fn cagetable_insert(cageid: u64, cageobj: Cage) {
+    let _insertret = unsafe { CAGE_TABLE[cageid as usize].insert(RustRfc::new(cageobj)) };
+}
+
+pub fn cagetable_remove(cageid: u64) {
+    unsafe{ CAGE_TABLE[cageid as usize].take() };
+}
+
+pub fn cagetable_getref(cageid: u64) -> RustRfc<Cage> {
+    unsafe { CAGE_TABLE[cageid as usize].as_ref().unwrap().clone() }
+}
+
+pub fn cagetable_clear() {
+    unsafe {
+        for cage in CAGE_TABLE.iter_mut() {
+            let cageopt = cage.take();
+            if cageopt.is_some() { cageopt.unwrap().exit_syscall(EXIT_SUCCESS); }
+        }
+    }
+}
+
 pub fn log_from_ptr(buf: *const u8, length: usize) {
     if let Ok(s) = from_utf8(unsafe{std::slice::from_raw_parts(buf, length)}) {
       log_to_stdout(s);

--- a/src/safeposix/cage.rs
+++ b/src/safeposix/cage.rs
@@ -9,7 +9,7 @@ pub use super::syscalls::sys_constants::*;
 pub use super::syscalls::net_constants::*;
 use super::filesystem::normpath;
 
-pub static CAGE_TABLE: interface::RustLazyGlobal<interface::RustHashMap<u64, interface::RustRfc<Cage>>> = interface::RustLazyGlobal::new(|| interface::new_hashmap());
+pub static mut CAGE_TABLE: Vec<Option<interface::RustRfc<Cage>>> = Vec::new();
 
 pub static PIPE_TABLE: interface::RustLazyGlobal<interface::RustHashMap<i32, interface::RustRfc<interface::EmulatedPipe>>> = 
     interface::RustLazyGlobal::new(|| 

--- a/src/safeposix/cage.rs
+++ b/src/safeposix/cage.rs
@@ -9,7 +9,7 @@ pub use super::syscalls::sys_constants::*;
 pub use super::syscalls::net_constants::*;
 use super::filesystem::normpath;
 
-pub static mut CAGE_TABLE: Vec<Option<interface::RustRfc<Cage>>> = Vec::new();
+pub use crate::interface::{CAGE_TABLE};
 
 #[derive(Debug, Clone)]
 pub enum FileDescriptor {

--- a/src/safeposix/dispatcher.rs
+++ b/src/safeposix/dispatcher.rs
@@ -482,7 +482,7 @@ pub extern "C" fn dispatcher(cageid: u64, callnum: i32, arg1: Arg, arg2: Arg, ar
 pub extern "C" fn lindrustinit(verbosity: isize) {
 
     let _ = interface::VERBOSE.set(verbosity); //assigned to suppress unused result warning
-    
+    interface::cagetable_init();
     load_fs();
     incref_root();
     incref_root();

--- a/src/safeposix/syscalls/sys_calls.rs
+++ b/src/safeposix/syscalls/sys_calls.rs
@@ -156,7 +156,7 @@ impl Cage {
     }
 
     pub fn exec_syscall(&self, child_cageid: u64) -> i32 {
-        interface::cagetable_remove(child_cageid);
+        interface::cagetable_remove(self.cageid);
 
         let mut cloexecvec = vec!();
         let iterator = self.filedescriptortable.iter();

--- a/src/safeposix/syscalls/sys_constants.rs
+++ b/src/safeposix/syscalls/sys_constants.rs
@@ -7,6 +7,7 @@ use crate::interface;
 // Define constants using static or const
 // Imported into fs_calls file
 
+pub const MAXCAGEID: i32 = 1024;
 
 //GID AND UID DEFAULT VALUES
 

--- a/src/safeposix/syscalls/sys_constants.rs
+++ b/src/safeposix/syscalls/sys_constants.rs
@@ -7,8 +7,6 @@ use crate::interface;
 // Define constants using static or const
 // Imported into fs_calls file
 
-pub const MAXCAGEID: i32 = 1024;
-
 //GID AND UID DEFAULT VALUES
 
 pub const DEFAULT_UID : u32 = 1000;

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -48,7 +48,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_simple() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         assert_eq!(cage.access_syscall("/", F_OK), 0);
         assert_eq!(cage.access_syscall("/", X_OK|R_OK), 0);
@@ -71,7 +71,7 @@ pub mod fs_tests {
 
     pub fn rdwrtest() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let fd = cage.open_syscall("/foobar", O_CREAT | O_TRUNC | O_RDWR, S_IRWXA);
         assert!(fd >= 0);
@@ -102,7 +102,7 @@ pub mod fs_tests {
 
     pub fn prdwrtest() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let fd = cage.open_syscall("/foobar2", O_CREAT | O_TRUNC | O_RDWR, S_IRWXA);
         assert!(fd >= 0);
@@ -129,7 +129,7 @@ pub mod fs_tests {
 
     pub fn chardevtest() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let fd = cage.open_syscall("/dev/zero", O_RDWR, S_IRWXA);
         assert!(fd >= 0);
@@ -159,7 +159,7 @@ pub mod fs_tests {
         //testing a muck up with the inode table where the regular close does not work as intended
 
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         //write should work
         let mut fd = cage.open_syscall("/broken_close_file", O_CREAT | O_EXCL | O_RDWR, S_IRWXA);
@@ -194,7 +194,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_chmod() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
         let filepath = "/chmodTestFile";
@@ -220,7 +220,7 @@ pub mod fs_tests {
 
    pub fn ut_lind_fs_fchmod() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
         let filepath = "/fchmodTestFile";
@@ -248,7 +248,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_dir_chdir() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
         
         //testing the ability to make and change to directories
 
@@ -274,7 +274,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_dir_mode() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let filepath1 = "/subdirDirMode1";
         let filepath2 = "/subdirDirMode2";
@@ -297,7 +297,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_dir_multiple() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         assert_eq!(cage.mkdir_syscall("/subdirMultiple1", S_IRWXA), 0);
         assert_eq!(cage.mkdir_syscall("/subdirMultiple1/subdirMultiple2", S_IRWXA), 0);
@@ -320,7 +320,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_dup() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
         let filepath = "/dupfile";
@@ -376,7 +376,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_dup2() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
         let filepath = "/dup2file";
@@ -420,7 +420,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_fcntl() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let sockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
         let filefd = cage.open_syscall("/fcntl_file", O_CREAT | O_EXCL, S_IRWXA);
@@ -446,7 +446,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_ioctl() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
         
         let mut arg0: i32 = 0;
         let mut arg1: i32 = 1;
@@ -487,7 +487,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_fdflags() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let path = "/fdFlagsFile";
 
@@ -522,7 +522,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_file_link_unlink() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let path = "/fileLink";
         let path2 = "/fileLink2";
@@ -564,7 +564,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_file_lseek_past_end() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let path = "/lseekPastEnd";
 
@@ -590,7 +590,7 @@ pub mod fs_tests {
     pub fn ut_lind_fs_fstat_complex() {
         lindrustinit(0);
 
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
         let path = "/complexFile";
 
         let fd = cage.open_syscall(path, O_CREAT | O_WRONLY, S_IRWXA);
@@ -611,7 +611,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_getuid() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         //let's get the initial -1s out of the way
         cage.getgid_syscall();
@@ -633,7 +633,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_load_fs() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let mut statdata = StatData::default();
 
@@ -658,7 +658,7 @@ pub mod fs_tests {
     pub fn ut_lind_fs_mknod() {
         // let's create /dev/null
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
         let dev = makedev(&DevNo {major: 1, minor: 3});
         let path = "/null";
 
@@ -707,7 +707,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_multiple_open() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         //try to open several files at once -- the fd's should not be overwritten
         let fd1 = cage.open_syscall("/foo", O_CREAT | O_EXCL | O_RDWR, S_IRWXA);
@@ -743,7 +743,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_rmdir() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let path = "/parent_dir/dir";
         assert_eq!(cage.mkdir_syscall("/parent_dir", S_IRWXA), 0);
@@ -758,7 +758,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_stat_file_complex() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
         let fd = cage.open_syscall("/fooComplex", O_CREAT | O_EXCL | O_WRONLY, S_IRWXA);
 
         assert_eq!(cage.write_syscall(fd, str2cbuf("hi"), 2), 2);
@@ -786,7 +786,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_stat_file_mode() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
         let path = "/fooFileMode";
         let _fd = cage.open_syscall(path, O_CREAT | O_EXCL | O_WRONLY, S_IRWXA);
 
@@ -811,7 +811,7 @@ pub mod fs_tests {
     
     pub fn  ut_lind_fs_statfs() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
         let mut fsdata = FSData::default();
 
         assert_eq!(cage.statfs_syscall("/", &mut fsdata), 0);
@@ -826,7 +826,7 @@ pub mod fs_tests {
     
     pub fn ut_lind_fs_rename() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let old_path = "/test_dir";
         assert_eq!(cage.mkdir_syscall(old_path, S_IRWXA), 0);
@@ -838,7 +838,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_ftruncate() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let fd = cage.open_syscall("/ftruncate", O_CREAT | O_TRUNC | O_RDWR, S_IRWXA);
         assert!(fd >= 0);
@@ -864,7 +864,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_truncate() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let path = String::from("/truncate");
         let fd = cage.open_syscall(&path, O_CREAT | O_TRUNC | O_RDWR, S_IRWXA);
@@ -891,7 +891,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_getdents() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let bufsize = 50;
         let mut vec = vec![0u8; bufsize as usize];
@@ -923,7 +923,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_dir_chdir_getcwd() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
         let needed = "/subdir1\0".as_bytes().to_vec().len();
 
         let needed_u32: u32 = needed as u32;
@@ -952,7 +952,7 @@ pub mod fs_tests {
 
     pub fn ut_lind_fs_exec_cloexec() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
         let mut uselessstatdata = StatData::default();
 
         let fd1 = cage.open_syscall("/cloexecuted", O_CREAT | O_TRUNC | O_RDWR | O_CLOEXEC, S_IRWXA);
@@ -964,8 +964,7 @@ pub mod fs_tests {
 
         assert_eq!(cage.exec_syscall(2), 0);
 
-        let execcage = {CAGE_TABLE.get(&2).unwrap().clone()};
-
+        let execcage = interface::cagetable_getref(2);
         assert_eq!(execcage.fstat_syscall(fd1, &mut uselessstatdata), -(Errno::EBADF as i32));
         assert_eq!(execcage.fstat_syscall(fd2, &mut uselessstatdata), 0);
 
@@ -980,7 +979,7 @@ pub mod fs_tests {
     use libc::c_void;
     pub fn ut_lind_fs_shm() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
         let key = 31337;
         let mut shmidstruct = ShmidsStruct::default();
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -15,6 +15,7 @@ mod main_tests {
     use crate::tests::pipe_tests::pipe_tests::test_pipe;
 
     use crate::safeposix::{cage::*, dispatcher::*, filesystem::*};
+    use crate::interface;
 
     use std::process::Command;
 
@@ -22,8 +23,8 @@ mod main_tests {
     pub fn tests() {
         lindrustinit(0);
         {
-            let cage = &CAGE_TABLE.get(&1).unwrap().clone();
-            crate::lib_fs_utils::lind_deltree(cage, "/");
+            let cage = interface::cagetable_getref(1);
+            crate::lib_fs_utils::lind_deltree(&cage, "/");
             assert_eq!(cage.mkdir_syscall("/dev", S_IRWXA), 0);
             assert_eq!(cage.mknod_syscall("/dev/null", S_IFCHR as u32| 0o777, makedev(&DevNo {major: 1, minor: 3})), 0);
             assert_eq!(cage.mknod_syscall("/dev/zero", S_IFCHR as u32| 0o777, makedev(&DevNo {major: 1, minor: 5})), 0);

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -30,7 +30,7 @@ pub mod net_tests {
 
     pub fn ut_lind_net_bind() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
         let sockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
 
         let socket = interface::GenSockaddr::V4(interface::SockaddrV4{ sin_family: AF_INET as u16, sin_port: 50102u16.to_be(), sin_addr: interface::V4Addr{ s_addr: u32::from_ne_bytes([127, 0, 0, 1]) }, padding: 0}); //127.0.0.1
@@ -55,7 +55,7 @@ pub mod net_tests {
 
     pub fn ut_lind_net_bind_on_zero() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         //both the server and the socket are run from this file
         let serversockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
@@ -81,7 +81,7 @@ pub mod net_tests {
         //creating a thread for the server so that the information can be sent between the two threads
         let thread = interface::helper_thread(move || {
             
-            let cage2 = {CAGE_TABLE.get(&2).unwrap().clone()};
+            let cage2 = interface::cagetable_getref(2);
             let mut socket2 = interface::GenSockaddr::V4(interface::SockaddrV4{ sin_family: AF_INET as u16, sin_port: port.to_be(), sin_addr: interface::V4Addr{ s_addr: 0 }, padding: 0}); //0.0.0.0
 
             let mut sockfd = cage2.accept_syscall(serversockfd, &mut socket2); //really can only make sure that the fd is valid
@@ -270,7 +270,7 @@ pub mod net_tests {
 
     pub fn ut_lind_net_bind_multiple() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let mut sockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
         let socket = interface::GenSockaddr::V4(interface::SockaddrV4{ sin_family: AF_INET as u16, sin_port: 50103u16.to_be(), sin_addr: interface::V4Addr{ s_addr: u32::from_ne_bytes([127, 0, 0, 1]) }, padding: 0}); //127.0.0.1
@@ -300,7 +300,7 @@ pub mod net_tests {
 
     pub fn ut_lind_net_connect_basic_udp() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         //should be okay...
         let sockfd = cage.socket_syscall(AF_INET, SOCK_DGRAM, 0);
@@ -319,7 +319,7 @@ pub mod net_tests {
 
     pub fn ut_lind_net_getpeername() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         //doing a few things with connect -- only UDP right now
         let sockfd = cage.socket_syscall(AF_INET, SOCK_DGRAM, 0);
@@ -344,7 +344,7 @@ pub mod net_tests {
 
     pub fn ut_lind_net_getsockname() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
         
         let sockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
         let mut retsocket = interface::GenSockaddr::V4(interface::SockaddrV4::default()); 
@@ -372,7 +372,7 @@ pub mod net_tests {
     
     pub fn ut_lind_net_listen() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
         
         let serversockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
         let clientsockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
@@ -390,7 +390,7 @@ pub mod net_tests {
         assert_eq!(cage.fork_syscall(2), 0);
         
         let thread = interface::helper_thread(move || {
-            let cage2 = {CAGE_TABLE.get(&2).unwrap().clone()};
+            let cage2 = interface::cagetable_getref(2);
             let mut socket2 = interface::GenSockaddr::V4(interface::SockaddrV4::default());
             assert!(cage2.accept_syscall(serversockfd, &mut socket2) > 0); //really can only make sure that the fd is valid
             
@@ -417,7 +417,7 @@ pub mod net_tests {
 
     pub fn ut_lind_net_poll() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let filefd = cage.open_syscall("/netpolltest.txt", O_CREAT | O_EXCL | O_RDWR, S_IRWXA);
         assert!(filefd > 0);
@@ -440,7 +440,7 @@ pub mod net_tests {
         //client 1 connects to the server to send and recv data...
         let thread1 = interface::helper_thread(move || {
             interface::sleep(interface::RustDuration::from_millis(100));
-            let cage2 = {CAGE_TABLE.get(&2).unwrap().clone()};
+            let cage2 = interface::cagetable_getref(2);
 
             assert_eq!(cage2.connect_syscall(clientsockfd1, &socket), 0);
             assert_eq!(cage2.send_syscall(clientsockfd1, str2cbuf(&"test"), 4, 0), 4);
@@ -456,7 +456,7 @@ pub mod net_tests {
         let thread2 = interface::helper_thread(move || {
             //give it a longer time so that it can sufficiently process all of the data
             interface::sleep(interface::RustDuration::from_millis(200));
-            let cage3 = {CAGE_TABLE.get(&3).unwrap().clone()};
+            let cage3 = interface::cagetable_getref(3);
 
             assert_eq!(cage3.connect_syscall(clientsockfd2, &socket), 0);
             assert_eq!(cage3.send_syscall(clientsockfd2, str2cbuf(&"test"), 4, 0), 4);
@@ -565,7 +565,7 @@ pub mod net_tests {
 
     pub fn ut_lind_net_recvfrom() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let serversockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
         let clientsockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
@@ -588,7 +588,7 @@ pub mod net_tests {
         //creating a thread for the server so that the information can be sent between the two threads
         let thread = interface::helper_thread(move || {
             
-            let cage2 = {CAGE_TABLE.get(&2).unwrap().clone()};
+            let cage2 = interface::cagetable_getref(2);
             interface::sleep(interface::RustDuration::from_millis(100)); 
 
             let mut socket2 = interface::GenSockaddr::V4(interface::SockaddrV4{ sin_family: AF_INET as u16, sin_port: port.to_be(), sin_addr: interface::V4Addr{ s_addr: u32::from_ne_bytes([127, 0, 0, 1]) }, padding: 0}); //127.0.0.1
@@ -676,7 +676,7 @@ pub mod net_tests {
 
     pub fn ut_lind_net_select () {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let filefd = cage.open_syscall("/netselecttest.txt", O_CREAT | O_EXCL | O_RDWR, S_IRWXA);
         assert!(filefd > 0);
@@ -707,7 +707,7 @@ pub mod net_tests {
 
         //client 1 connects to the server to send and recv data...
         let threadclient1 = interface::helper_thread(move || {
-            let cage2 = {CAGE_TABLE.get(&2).unwrap().clone()};
+            let cage2 = interface::cagetable_getref(2);
 
             assert_eq!(cage2.close_syscall(serversockfd), 0);
 
@@ -726,7 +726,7 @@ pub mod net_tests {
 
         //client 2 connects to the server to send and recv data...
         let threadclient2 = interface::helper_thread(move || {
-            let cage3 = {CAGE_TABLE.get(&3).unwrap().clone()};
+            let cage3 = interface::cagetable_getref(3);
 
             assert_eq!(cage3.close_syscall(serversockfd), 0);
 
@@ -809,7 +809,7 @@ pub mod net_tests {
 
     pub fn ut_lind_net_shutdown() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
         
         let serversockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
         let clientsockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
@@ -827,7 +827,7 @@ pub mod net_tests {
         assert_eq!(cage.fork_syscall(2), 0);
 
         let thread = interface::helper_thread(move || {
-            let cage2 = {CAGE_TABLE.get(&2).unwrap().clone()};
+            let cage2 = interface::cagetable_getref(2);
             
             interface::sleep(interface::RustDuration::from_millis(100)); 
 
@@ -859,7 +859,7 @@ pub mod net_tests {
 
     pub fn ut_lind_net_socket() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let mut sockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
         let sockfd2 = cage.socket_syscall(AF_INET, SOCK_STREAM, IPPROTO_TCP);
@@ -889,7 +889,7 @@ pub mod net_tests {
 
     pub fn ut_lind_net_socketoptions() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let sockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
         assert!(sockfd > 0);
@@ -975,7 +975,7 @@ pub mod net_tests {
 
     pub fn ut_lind_net_socketpair() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
         let mut socketpair = interface::SockPair::default();
         assert_eq!(Cage::socketpair_syscall(cage.clone(), AF_INET, SOCK_STREAM, 0, &mut socketpair), 0);
         let cage2 = cage.clone();
@@ -1036,7 +1036,7 @@ pub mod net_tests {
 
     pub fn ut_lind_net_udp_bad_bind() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let sockfd = cage.socket_syscall(AF_INET, SOCK_DGRAM, 0);
         assert!(sockfd > 0); //checking that the sockfd is valid
@@ -1061,7 +1061,7 @@ pub mod net_tests {
 
     pub fn ut_lind_net_udp_simple() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         //just going to test the basic connect with UDP now...
         let serverfd = cage.socket_syscall(AF_INET, SOCK_DGRAM, 0);
@@ -1075,7 +1075,7 @@ pub mod net_tests {
         //forking the cage to get another cage with the same information
         assert_eq!(cage.fork_syscall(2), 0);
         let thread = interface::helper_thread(move || {
-            let cage2 = {CAGE_TABLE.get(&2).unwrap().clone()};
+            let cage2 = interface::cagetable_getref(2);
             assert_eq!(cage2.bind_syscall(serverfd, &socket), 0);
 
             interface::sleep(interface::RustDuration::from_millis(30));
@@ -1118,7 +1118,7 @@ pub mod net_tests {
 
     pub fn ut_lind_net_udp_connect() {
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         //getting the sockets set up...
         let listenfd = cage.socket_syscall(AF_INET, SOCK_DGRAM, 0);
@@ -1136,7 +1136,7 @@ pub mod net_tests {
 
         let thread = interface::helper_thread(move || {
 
-            let cage2 = {CAGE_TABLE.get(&2).unwrap().clone()};
+            let cage2 = interface::cagetable_getref(2);
             
             interface::sleep(interface::RustDuration::from_millis(20));
             let mut buf = sizecbuf(16);
@@ -1159,7 +1159,7 @@ pub mod net_tests {
 
     pub fn ut_lind_net_gethostname() { //Assuming DEFAULT_HOSTNAME == "Lind" and change of hostname is not allowed
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let mut buf = vec![0u8; 5];
         let bufptr: *mut u8 = &mut buf[0];
@@ -1215,7 +1215,7 @@ pub mod net_tests {
         }
 
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         let dnssocket = cage.socket_syscall(AF_INET, SOCK_DGRAM, 0);
         assert!(dnssocket > 0);
@@ -1283,7 +1283,7 @@ pub mod net_tests {
         let serversockfilename = "/server.sock";
 
         lindrustinit(0);
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
+        let cage = interface::cagetable_getref(1);
 
         //both the server and the socket are run from this file
         let serversockfd = cage.socket_syscall(AF_UNIX, SOCK_STREAM, 0);
@@ -1309,7 +1309,7 @@ pub mod net_tests {
         //creating a thread for the server so that the information can be sent between the two threads
         let thread = interface::helper_thread(move || {
             
-            let cage2 = {CAGE_TABLE.get(&2).unwrap().clone()};
+            let cage2 = interface::cagetable_getref(2);
             let mut socket2 = interface::GenSockaddr::Unix(interface::new_sockaddr_unix(AF_UNIX as u16, "".as_bytes())); // blank unix sockaddr
 
             let sockfd = cage2.accept_syscall(serversockfd, &mut socket2); //really can only make sure that the fd is valid

--- a/src/tests/pipe_tests.rs
+++ b/src/tests/pipe_tests.rs
@@ -21,8 +21,7 @@ pub mod pipe_tests {
 
         lindrustinit(0);
 
-        let cage = {CAGE_TABLE.get(&1).unwrap().clone()};
-
+        let cage = interface::cagetable_getref(1);
 
         let filefd = cage.open_syscall("test1gb.txt", O_CREAT | O_WRONLY, S_IRWXA);
         
@@ -46,15 +45,15 @@ pub mod pipe_tests {
         
         lindrustinit(0);
 
-        let cage1 = {CAGE_TABLE.get(&1).unwrap().clone()};
-
+        let cage1 = interface::cagetable_getref(1);
+        
         let mut pipefds = PipeArray {readfd: -1, writefd: -1};
         assert_eq!(cage1.pipe_syscall(&mut pipefds), 0);
         assert_eq!(cage1.fork_syscall(2), 0);
 
         let sender = std::thread::spawn(move || {
 
-            let cage2 = {CAGE_TABLE.get(&2).unwrap().clone()};
+            let cage2 = interface::cagetable_getref(2);
 
             assert_eq!(cage2.close_syscall(pipefds.writefd), 0);
             assert_eq!(cage2.dup2_syscall(pipefds.readfd, 0), 0);

--- a/src/tests/pipe_tests.rs
+++ b/src/tests/pipe_tests.rs
@@ -46,7 +46,7 @@ pub mod pipe_tests {
         lindrustinit(0);
 
         let cage1 = interface::cagetable_getref(1);
-        
+
         let mut pipefds = PipeArray {readfd: -1, writefd: -1};
         assert_eq!(cage1.pipe_syscall(&mut pipefds), 0);
         assert_eq!(cage1.fork_syscall(2), 0);


### PR DESCRIPTION
This PR changes the CAGETABLE from a lazy global dashmap to a pub static mut vector without any concurrency primitives.

This is being implemented because it yields ~10-15% performance improvement in I/O heavy programs.

The safety proof here relies on that indexes for the table are assigned in NaCl and are concurrency safe. Inserts are only done on init and fork/exec, while deletes are only done via exit().

There is a problem with the situation when there are multiple threads in a cage and one of them calls exit(), though this is currently a problem as well [which results in deadlock](https://github.com/Lind-Project/lind_project/issues/285).
