### PR TITLE
Fix exit after exec issue

### DIFF
--- a/src/safeposix/cage.rs
+++ b/src/safeposix/cage.rs
@@ -8,6 +8,7 @@ pub use super::syscalls::fs_constants::*;
 pub use super::syscalls::sys_constants::*;
 pub use super::syscalls::net_constants::*;
 use super::filesystem::normpath;
+use super::syscall_numbers::MAX_SYSCALL_NUMBER;
 
 pub static CAGE_TABLE: interface::RustLazyGlobal<interface::RustHashMap<u64, interface::RustRfc<Cage>>> = interface::RustLazyGlobal::new(|| interface::new_hashmap());
 
@@ -89,10 +90,18 @@ pub struct Cage {
     pub getgid: interface::RustAtomicI32,
     pub getuid: interface::RustAtomicI32,
     pub getegid: interface::RustAtomicI32,
-    pub geteuid: interface::RustAtomicI32
+    pub geteuid: interface::RustAtomicI32,
+    pub syscall_allowlist: Vec<interface::RustAtomicBool>
 }
 
 impl Cage {
+    pub fn get_init_syscall_allowlist() -> Vec<interface::RustAtomicBool> {
+        let mut syscall_allowlist = Vec::new();
+        for _ in 0..MAX_SYSCALL_NUMBER {
+            syscall_allowlist.push(interface::RustAtomicBool::new(true));
+        }
+        syscall_allowlist
+    }
 
     pub fn get_next_fd(&self, startfd: Option<i32>, fdobj: FileDescriptor) -> i32 {
 

--- a/src/safeposix/dispatcher.rs
+++ b/src/safeposix/dispatcher.rs
@@ -1,82 +1,7 @@
 #![allow(dead_code)]
 #![allow(unused_variables)]
 // retreive cage table
-
-const ACCESS_SYSCALL: i32 = 2;
-const UNLINK_SYSCALL: i32 = 4;
-const LINK_SYSCALL: i32 = 5;
-const RENAME_SYSCALL: i32 = 6;
-
-const XSTAT_SYSCALL: i32 = 9;
-const OPEN_SYSCALL: i32 = 10;
-const CLOSE_SYSCALL: i32 = 11;
-const READ_SYSCALL: i32 = 12;
-const WRITE_SYSCALL: i32 = 13;
-const LSEEK_SYSCALL: i32 = 14;
-const IOCTL_SYSCALL: i32 = 15;
-const FXSTAT_SYSCALL: i32 = 17;
-const FSTATFS_SYSCALL: i32 = 19;
-const MMAP_SYSCALL: i32 = 21;
-const MUNMAP_SYSCALL: i32 = 22;
-const GETDENTS_SYSCALL: i32 = 23;
-const DUP_SYSCALL: i32 = 24;
-const DUP2_SYSCALL: i32 = 25;
-const STATFS_SYSCALL: i32 = 26;
-const FCNTL_SYSCALL: i32 = 28;
-
-const GETPPID_SYSCALL: i32 = 29;
-const EXIT_SYSCALL: i32 = 30;
-const GETPID_SYSCALL: i32 = 31;
-
-const BIND_SYSCALL: i32 = 33;
-const SEND_SYSCALL: i32 = 34;
-const SENDTO_SYSCALL: i32 = 35;
-const RECV_SYSCALL: i32 = 36;
-const RECVFROM_SYSCALL: i32 = 37;
-const CONNECT_SYSCALL: i32 = 38;
-const LISTEN_SYSCALL: i32 = 39;
-const ACCEPT_SYSCALL: i32 = 40;
-
-const GETSOCKOPT_SYSCALL: i32 = 43;
-const SETSOCKOPT_SYSCALL: i32 = 44;
-const SHUTDOWN_SYSCALL: i32 = 45;
-const SELECT_SYSCALL: i32 = 46;
-const GETCWD_SYSCALL: i32 = 47;
-const POLL_SYSCALL: i32 = 48;
-const SOCKETPAIR_SYSCALL: i32 = 49;
-const GETUID_SYSCALL: i32 = 50;
-const GETEUID_SYSCALL: i32 = 51;
-const GETGID_SYSCALL: i32 = 52;
-const GETEGID_SYSCALL: i32 = 53;
-const FLOCK_SYSCALL: i32 = 54;
-const EPOLL_CREATE_SYSCALL: i32 = 56;
-const EPOLL_CTL_SYSCALL: i32 = 57;
-const EPOLL_WAIT_SYSCALL: i32 = 58;
-
-const SHMGET_SYSCALL: i32 = 62;
-const SHMAT_SYSCALL: i32 = 63;
-const SHMDT_SYSCALL: i32 = 64;
-const SHMCTL_SYSCALL: i32 = 65;
-
-const PIPE_SYSCALL: i32 = 66;
-const PIPE2_SYSCALL: i32 = 67;
-const FORK_SYSCALL: i32 = 68;
-const EXEC_SYSCALL: i32 = 69;
-
-const GETHOSTNAME_SYSCALL: i32 = 125;
-const PREAD_SYSCALL: i32 = 126;
-const PWRITE_SYSCALL: i32 = 127;
-const CHDIR_SYSCALL: i32 = 130;
-const MKDIR_SYSCALL: i32 = 131;
-const RMDIR_SYSCALL: i32 = 132;
-const CHMOD_SYSCALL: i32 = 133;
-
-const SOCKET_SYSCALL: i32 = 136;
-
-const GETSOCKNAME_SYSCALL: i32 = 144;
-const GETPEERNAME_SYSCALL: i32 = 145;
-const GETIFADDRS_SYSCALL: i32 = 146;
-
+use std::sync::atomic::Ordering;
 
 use crate::interface;
 use super::cage::{Arg, CAGE_TABLE, Cage, FSData, StatData, IoctlPtrUnion};
@@ -84,6 +9,7 @@ use super::filesystem::{FS_METADATA, load_fs, incref_root, remove_domain_sock, p
 use super::net::{NET_METADATA};
 use crate::interface::errnos::*;
 use super::syscalls::sys_constants::*;
+use super::syscall_nubmers::*;
 
 macro_rules! get_onearg {
     ($arg: expr) => {
@@ -115,6 +41,9 @@ pub extern "C" fn dispatcher(cageid: u64, callnum: i32, arg1: Arg, arg2: Arg, ar
 
     // need to match based on if cage exists
     let cage = { CAGE_TABLE.get(&cageid).unwrap().clone() };
+    if !cage.syscall_allowlist[callnum as usize].load(Ordering::Relaxed) {
+        return syscall_error(Errno::EPERM, &(callnum.to_string()), "Syscall is not permitted in this cage");
+    }
 
     match callnum {
         ACCESS_SYSCALL => {
@@ -431,7 +360,8 @@ pub extern "C" fn lindrustinit(verbosity: isize) {
         getgid: interface::RustAtomicI32::new(-1), 
         getuid: interface::RustAtomicI32::new(-1), 
         getegid: interface::RustAtomicI32::new(-1), 
-        geteuid: interface::RustAtomicI32::new(-1)
+        geteuid: interface::RustAtomicI32::new(-1),
+        syscall_allowlist: Cage::get_init_syscall_allowlist()
     };
     cagetable.insert(0, interface::RustRfc::new(utilcage));
 
@@ -444,7 +374,8 @@ pub extern "C" fn lindrustinit(verbosity: isize) {
         getgid: interface::RustAtomicI32::new(-1), 
         getuid: interface::RustAtomicI32::new(-1), 
         getegid: interface::RustAtomicI32::new(-1), 
-        geteuid: interface::RustAtomicI32::new(-1)
+        geteuid: interface::RustAtomicI32::new(-1),
+        syscall_allowlist: Cage::get_init_syscall_allowlist()
     };
     initcage.load_lower_handle_stubs();
     cagetable.insert(1, interface::RustRfc::new(initcage));

--- a/src/safeposix/mod.rs
+++ b/src/safeposix/mod.rs
@@ -4,3 +4,4 @@ pub mod filesystem;
 pub mod cage;
 pub mod net;
 pub mod shm;
+pub mod syscall_numbers;

--- a/src/safeposix/syscall_numbers.rs
+++ b/src/safeposix/syscall_numbers.rs
@@ -1,0 +1,84 @@
+// Define all syscall numbers
+#![allow(dead_code)]
+#![allow(unused_variables)]
+
+use crate::interface;
+
+// Define constants using static or const
+
+pub const MAX_SYSCALL_NUMBER: usize = 256;
+
+pub const ACCESS_SYSCALL: i32 = 2;
+pub const UNLINK_SYSCALL: i32 = 4;
+pub const LINK_SYSCALL: i32 = 5;
+pub const RENAME_SYSCALL: i32 = 6;
+ 
+pub const XSTAT_SYSCALL: i32 = 9;
+pub const OPEN_SYSCALL: i32 = 10;
+pub const CLOSE_SYSCALL: i32 = 11;
+pub const READ_SYSCALL: i32 = 12;
+pub const WRITE_SYSCALL: i32 = 13;
+pub const LSEEK_SYSCALL: i32 = 14;
+pub const IOCTL_SYSCALL: i32 = 15;
+pub const FXSTAT_SYSCALL: i32 = 17;
+pub const FSTATFS_SYSCALL: i32 = 19;
+pub const MMAP_SYSCALL: i32 = 21;
+pub const MUNMAP_SYSCALL: i32 = 22;
+pub const GETDENTS_SYSCALL: i32 = 23;
+pub const DUP_SYSCALL: i32 = 24;
+pub const DUP2_SYSCALL: i32 = 25;
+pub const STATFS_SYSCALL: i32 = 26;
+pub const FCNTL_SYSCALL: i32 = 28;
+ 
+pub const GETPPID_SYSCALL: i32 = 29;
+pub const EXIT_SYSCALL: i32 = 30;
+pub const GETPID_SYSCALL: i32 = 31;
+ 
+pub const BIND_SYSCALL: i32 = 33;
+pub const SEND_SYSCALL: i32 = 34;
+pub const SENDTO_SYSCALL: i32 = 35;
+pub const RECV_SYSCALL: i32 = 36;
+pub const RECVFROM_SYSCALL: i32 = 37;
+pub const CONNECT_SYSCALL: i32 = 38;
+pub const LISTEN_SYSCALL: i32 = 39;
+pub const ACCEPT_SYSCALL: i32 = 40;
+ 
+pub const GETSOCKOPT_SYSCALL: i32 = 43;
+pub const SETSOCKOPT_SYSCALL: i32 = 44;
+pub const SHUTDOWN_SYSCALL: i32 = 45;
+pub const SELECT_SYSCALL: i32 = 46;
+pub const GETCWD_SYSCALL: i32 = 47;
+pub const POLL_SYSCALL: i32 = 48;
+pub const SOCKETPAIR_SYSCALL: i32 = 49;
+pub const GETUID_SYSCALL: i32 = 50;
+pub const GETEUID_SYSCALL: i32 = 51;
+pub const GETGID_SYSCALL: i32 = 52;
+pub const GETEGID_SYSCALL: i32 = 53;
+pub const FLOCK_SYSCALL: i32 = 54;
+pub const EPOLL_CREATE_SYSCALL: i32 = 56;
+pub const EPOLL_CTL_SYSCALL: i32 = 57;
+pub const EPOLL_WAIT_SYSCALL: i32 = 58;
+ 
+pub const SHMGET_SYSCALL: i32 = 62;
+pub const SHMAT_SYSCALL: i32 = 63;
+pub const SHMDT_SYSCALL: i32 = 64;
+pub const SHMCTL_SYSCALL: i32 = 65;
+ 
+pub const PIPE_SYSCALL: i32 = 66;
+pub const PIPE2_SYSCALL: i32 = 67;
+pub const FORK_SYSCALL: i32 = 68;
+pub const EXEC_SYSCALL: i32 = 69;
+ 
+pub const GETHOSTNAME_SYSCALL: i32 = 125;
+pub const PREAD_SYSCALL: i32 = 126;
+pub const PWRITE_SYSCALL: i32 = 127;
+pub const CHDIR_SYSCALL: i32 = 130;
+pub const MKDIR_SYSCALL: i32 = 131;
+pub const RMDIR_SYSCALL: i32 = 132;
+pub const CHMOD_SYSCALL: i32 = 133;
+ 
+pub const SOCKET_SYSCALL: i32 = 136;
+ 
+pub const GETSOCKNAME_SYSCALL: i32 = 144;
+pub const GETPEERNAME_SYSCALL: i32 = 145;
+pub const GETIFADDRS_SYSCALL: i32 = 146;

--- a/src/tools/fs_utils.rs
+++ b/src/tools/fs_utils.rs
@@ -113,7 +113,8 @@ fn main() {
                         getgid: interface::RustAtomicI32::new(-1), 
                         getuid: interface::RustAtomicI32::new(-1), 
                         getegid: interface::RustAtomicI32::new(-1), 
-                        geteuid: interface::RustAtomicI32::new(-1)};
+                        geteuid: interface::RustAtomicI32::new(-1),
+                        syscall_allowlist: Cage::get_init_syscall_allowlist()};
 
     args.next();//first arg is executable, we don't care
     let command = if let Some(cmd) = args.next() {


### PR DESCRIPTION
This PR fixes the ![exit after exec issue](https://github.com/Lind-Project/lind_project/issues/235) by adding a syscall allowlist in the cage struct and only allow close and exit syscall in the parent cage when executing exec syscall. It also moves the syscall numbers definitions from dispatcher.rs into its own file.