### PR TITLE
Sched yield

### DIFF
--- a/src/interface/misc.rs
+++ b/src/interface/misc.rs
@@ -16,7 +16,8 @@ use std::str::{from_utf8, Utf8Error};
 pub use std::sync::{Arc as RustRfc};
 pub use parking_lot::{RwLock as RustLock, RwLockWriteGuard as RustLockGuard, Mutex, Condvar};
 
-use libc::{mmap, pthread_self, pthread_exit};
+use libc::{mmap, pthread_self, pthread_exit, sched_yield};
+
 use std::ffi::c_void;
 
 pub use serde::{Serialize as SerdeSerialize, Deserialize as SerdeDeserialize};
@@ -102,6 +103,10 @@ pub fn lind_threadexit() {
 
 pub fn get_pthreadid() -> u64 {
     unsafe { pthread_self() as u64 } 
+}
+
+pub fn lind_yield() {
+    unsafe { sched_yield(); }
 }
 
 // this function checks if a thread is killable and returns that state

--- a/src/interface/pipe.rs
+++ b/src/interface/pipe.rs
@@ -107,7 +107,7 @@ impl EmulatedPipe {
             let bytes_to_write = min(length, bytes_written as usize + remaining);
             write_end.push_slice(&buf[bytes_written..bytes_to_write]);
             bytes_written = bytes_to_write;
-            unsafe { sched_yield(); }
+            // unsafe { sched_yield(); }
         }   
 
         bytes_written as i32

--- a/src/interface/pipe.rs
+++ b/src/interface/pipe.rs
@@ -13,6 +13,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use ringbuf::{RingBuffer, Producer, Consumer};
 use std::cmp::min;
 use std::fmt;
+use libc::sched_yield;
 
 const O_RDONLY: i32 = 0o0;
 const O_WRONLY: i32 = 0o1;
@@ -106,6 +107,7 @@ impl EmulatedPipe {
             let bytes_to_write = min(length, bytes_written as usize + remaining);
             write_end.push_slice(&buf[bytes_written..bytes_to_write]);
             bytes_written = bytes_to_write;
+            sched_yield();
         }   
 
         bytes_written as i32
@@ -130,6 +132,7 @@ impl EmulatedPipe {
         while pipe_space == 0 {
             if self.eof.load(Ordering::SeqCst) { return 0; }
             pipe_space = read_end.len();
+            sched_yield();
         }
 
         let bytes_to_read = min(length, pipe_space);

--- a/src/interface/pipe.rs
+++ b/src/interface/pipe.rs
@@ -107,7 +107,7 @@ impl EmulatedPipe {
             let bytes_to_write = min(length, bytes_written as usize + remaining);
             write_end.push_slice(&buf[bytes_written..bytes_to_write]);
             bytes_written = bytes_to_write;
-            sched_yield();
+            unsafe { sched_yield(); }
         }   
 
         bytes_written as i32
@@ -132,7 +132,7 @@ impl EmulatedPipe {
         while pipe_space == 0 {
             if self.eof.load(Ordering::SeqCst) { return 0; }
             pipe_space = read_end.len();
-            sched_yield();
+            unsafe { sched_yield(); }
         }
 
         let bytes_to_read = min(length, pipe_space);


### PR DESCRIPTION
Per previous conversation with @moyix. 

This adds sched_yield() calls to pipe loops when we encounter a full or empty pipe. This doesn't change overall pipe performance and avoids us busy looping when there are more cages than processors.