### PR TITLE
Fixed incorrect error being returned when the path does not exist.

### DIFF
--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1631,7 +1631,7 @@ impl Cage {
         // try to get inodenum of input path and its parent
         match metawalkandparent(truepath.as_path()) {
             (None, ..) => {
-                syscall_error(Errno::EEXIST, "rmdir", "Path does not exist")
+                syscall_error(Errno::ENOENT, "rmdir", "Path does not exist")
             }
             (Some(_), None) => { // path exists but parent does not => path is root dir
                 syscall_error(Errno::EBUSY, "rmdir", "Cannot remove root directory")


### PR DESCRIPTION
Changed error being returned from `EEXIST` to `ENOENT` when path does not exist.