### PR TITLE
Move Cancel Out of Interface Pipe Loop

### DIFF
--- a/src/interface/pipe.rs
+++ b/src/interface/pipe.rs
@@ -121,7 +121,7 @@ impl EmulatedPipe {
 
     // Read length bytes from the pipe into pointer
     // Will wait for bytes unless pipe is empty and eof is set.
-    pub fn read_from_pipe(&self, ptr: *mut u8, length: usize, nonblocking: bool, cageid: u64) -> i32 {
+    pub fn read_from_pipe(&self, ptr: *mut u8, length: usize, nonblocking: bool) -> i32 {
 
         let buf = unsafe {
             assert!(!ptr.is_null());
@@ -141,8 +141,7 @@ impl EmulatedPipe {
             if self.eof.load(Ordering::SeqCst) { return 0; }
 
             if count == CANCEL_CHECK_INTERVAL { 
-                interface::cancelpoint(cageid); 
-                count = 0;
+                return -(Errno::EAGAIN as i32); // we've tried enough, return to pipe
             }
             
             pipe_space = read_end.len();

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -636,7 +636,7 @@ impl Cage {
                     let mut nonblocking = false;
                     if pipe_filedesc_obj.flags & O_NONBLOCK != 0 { nonblocking = true;}
 
-                    loop {
+                    loop { // loop over pipe reads so we can periodically check for cancellation
                         let ret = pipe_filedesc_obj.pipe.read_from_pipe(buf, count, nonblocking) as i32;
                         if pipe_filedesc_obj.flags & O_NONBLOCK == 0 && ret == -(Errno::EAGAIN as i32) {
                             if self.cancelstatus.load(interface::RustAtomicOrdering::Relaxed) {


### PR DESCRIPTION
This PR moves the cancel point function out of the interface pipe loop, and handles pipe reads similarly to how we now handle inner recv calls. This is to standardize how cancellation works and this format will eventually let us handle Domain Socket recvs much easier. We also no longer have to add the cageid as a parameter to read_from_pipe which was ugly.