### PR TITLE
Fix/advisory unlock

### DIFF
--- a/src/interface/misc.rs
+++ b/src/interface/misc.rs
@@ -4,49 +4,38 @@
 // Random, locks, etc.
 #![allow(dead_code)]
 
-pub use dashmap::{
-    mapref::entry::Entry as RustHashEntry, DashMap as RustHashMap, DashSet as RustHashSet,
-};
-pub use std::cmp::{max as rust_max, min as rust_min};
-pub use std::collections::VecDeque as RustDeque;
 use std::fs::File;
 use std::io::{self, Read, Write};
-use std::str::{from_utf8, Utf8Error};
-pub use std::sync::atomic::{
-    AtomicBool as RustAtomicBool, AtomicI32 as RustAtomicI32, AtomicU16 as RustAtomicU16,
-    AtomicUsize as RustAtomicUsize, Ordering as RustAtomicOrdering,
-};
+pub use dashmap::{DashSet as RustHashSet, DashMap as RustHashMap, mapref::entry::Entry as RustHashEntry};
+pub use std::collections::{VecDeque as RustDeque};
+pub use std::cmp::{max as rust_max, min as rust_min};
+pub use std::sync::atomic::{AtomicBool as RustAtomicBool, Ordering as RustAtomicOrdering, AtomicU16 as RustAtomicU16, AtomicI32 as RustAtomicI32, AtomicUsize as RustAtomicUsize};
 pub use std::thread::spawn as helper_thread;
+use std::str::{from_utf8, Utf8Error};
 
-pub use parking_lot::{Condvar, Mutex, RwLock as RustLock, RwLockWriteGuard as RustLockGuard};
-pub use std::sync::Arc as RustRfc;
+pub use std::sync::{Arc as RustRfc};
+pub use parking_lot::{RwLock as RustLock, RwLockWriteGuard as RustLockGuard, Mutex, Condvar};
 
-use libc::{mmap, pthread_exit, pthread_self, sched_yield};
+use libc::{mmap, pthread_self, pthread_exit, sched_yield};
 
 use std::ffi::c_void;
 
-pub use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
+pub use serde::{Serialize as SerdeSerialize, Deserialize as SerdeDeserialize};
 
-pub use serde_cbor::{
-    from_slice as serde_deserialize_from_bytes, ser::to_vec_packed as serde_serialize_to_bytes,
-};
+pub use serde_cbor::{ser::to_vec_packed as serde_serialize_to_bytes, from_slice as serde_deserialize_from_bytes};
 
-use crate::interface::errnos::VERBOSE;
+use crate::interface::errnos::{VERBOSE};
 use std::time::Duration;
 
 const MAXCAGEID: i32 = 1024;
-const EXIT_SUCCESS: i32 = 0;
+const EXIT_SUCCESS : i32 = 0;
 
-use crate::safeposix::cage::Cage;
+use crate::safeposix::cage::{Cage};
 
 pub static mut CAGE_TABLE: Vec<Option<RustRfc<Cage>>> = Vec::new();
 
 pub fn cagetable_init() {
-    unsafe {
-        for _cage in 0..MAXCAGEID {
-            CAGE_TABLE.push(None);
-        }
-    }
+   unsafe { for _cage in 0..MAXCAGEID { CAGE_TABLE.push(None); }}
 }
 
 pub fn cagetable_insert(cageid: u64, cageobj: Cage) {
@@ -54,7 +43,7 @@ pub fn cagetable_insert(cageid: u64, cageobj: Cage) {
 }
 
 pub fn cagetable_remove(cageid: u64) {
-    unsafe { CAGE_TABLE[cageid as usize].take() };
+    unsafe{ CAGE_TABLE[cageid as usize].take() };
 }
 
 pub fn cagetable_getref(cageid: u64) -> RustRfc<Cage> {
@@ -66,9 +55,7 @@ pub fn cagetable_clear() {
     unsafe {
         for cage in CAGE_TABLE.iter_mut() {
             let cageopt = cage.take();
-            if cageopt.is_some() {
-                exitvec.push(cageopt.unwrap());
-            }
+            if cageopt.is_some() { exitvec.push(cageopt.unwrap()); }
         }
     }
 
@@ -78,8 +65,8 @@ pub fn cagetable_clear() {
 }
 
 pub fn log_from_ptr(buf: *const u8, length: usize) {
-    if let Ok(s) = from_utf8(unsafe { std::slice::from_raw_parts(buf, length) }) {
-        log_to_stdout(s);
+    if let Ok(s) = from_utf8(unsafe{std::slice::from_raw_parts(buf, length)}) {
+      log_to_stdout(s);
     }
 }
 
@@ -105,25 +92,21 @@ pub fn flush_stdout() {
 }
 
 pub fn get_errno() -> i32 {
-    (unsafe { *libc::__errno_location() }) as i32
+    (unsafe{*libc::__errno_location()}) as i32
 }
 
 // Cancellation functions
 
 pub fn lind_threadexit() {
-    unsafe {
-        pthread_exit(0 as *mut c_void);
-    }
+    unsafe { pthread_exit(0 as *mut c_void); }
 }
 
 pub fn get_pthreadid() -> u64 {
-    unsafe { pthread_self() as u64 }
+    unsafe { pthread_self() as u64 } 
 }
 
 pub fn lind_yield() {
-    unsafe {
-        sched_yield();
-    }
+    unsafe { sched_yield(); }
 }
 
 // this function checks if a thread is killable and returns that state
@@ -139,30 +122,24 @@ pub fn cancelpoint(cageid: u64) {
     let pthread_id = get_pthreadid();
     if check_thread(cageid, pthread_id) {
         let cage = cagetable_getref(cageid);
-        cage.thread_table.insert(pthread_id, false);
-        lind_threadexit();
+        cage.thread_table.insert(pthread_id, false); 
+        lind_threadexit(); 
     }
 }
 
 pub fn fillrandom(bufptr: *mut u8, count: usize) -> i32 {
-    let slice = unsafe { std::slice::from_raw_parts_mut(bufptr, count) };
-    let mut f = std::fs::OpenOptions::new()
-        .read(true)
-        .write(false)
-        .open("/dev/urandom")
-        .unwrap();
+    let slice = unsafe{std::slice::from_raw_parts_mut(bufptr, count)};
+    let mut f = std::fs::OpenOptions::new().read(true).write(false).open("/dev/urandom").unwrap();
     f.read(slice).unwrap() as i32
 }
 pub fn fillzero(bufptr: *mut u8, count: usize) -> i32 {
-    let slice = unsafe { std::slice::from_raw_parts_mut(bufptr, count) };
-    for i in 0..count {
-        slice[i] = 0u8;
-    }
+    let slice = unsafe{std::slice::from_raw_parts_mut(bufptr, count)};
+    for i in 0..count {slice[i] = 0u8;}
     count as i32
 }
 
-pub fn fill(bufptr: *mut u8, count: usize, values: &Vec<u8>) -> i32 {
-    let slice = unsafe { std::slice::from_raw_parts_mut(bufptr, count) };
+pub fn fill(bufptr: *mut u8, count: usize, values:&Vec<u8>) -> i32 {
+    let slice = unsafe{std::slice::from_raw_parts_mut(bufptr, count)};
     slice.copy_from_slice(&values[..count]);
     count as i32
 }
@@ -170,25 +147,15 @@ pub fn fill(bufptr: *mut u8, count: usize, values: &Vec<u8>) -> i32 {
 pub fn copy_fromrustdeque_sized(bufptr: *mut u8, count: usize, vecdeq: &RustDeque<u8>) {
     let (slice1, slice2) = vecdeq.as_slices();
     if slice1.len() >= count {
-        unsafe {
-            std::ptr::copy(slice1.as_ptr(), bufptr, count);
-        }
+        unsafe {std::ptr::copy(slice1.as_ptr(), bufptr, count);}
     } else {
-        unsafe {
-            std::ptr::copy(slice1.as_ptr(), bufptr, slice1.len());
-        }
-        unsafe {
-            std::ptr::copy(
-                slice2.as_ptr(),
-                bufptr.wrapping_offset(slice1.len() as isize),
-                count - slice1.len(),
-            );
-        }
+        unsafe {std::ptr::copy(slice1.as_ptr(), bufptr, slice1.len());}
+        unsafe {std::ptr::copy(slice2.as_ptr(), bufptr.wrapping_offset(slice1.len() as isize), count - slice1.len());}
     }
 }
 
 pub fn extend_fromptr_sized(bufptr: *const u8, count: usize, vecdeq: &mut RustDeque<u8>) {
-    let byteslice = unsafe { std::slice::from_raw_parts(bufptr, count) };
+    let byteslice = unsafe {std::slice::from_raw_parts(bufptr, count)};
     vecdeq.extend(byteslice.iter());
 }
 
@@ -198,27 +165,23 @@ pub fn new_hashmap<K: std::cmp::Eq + std::hash::Hash, V>() -> RustHashMap<K, V> 
 }
 
 pub unsafe fn charstar_to_ruststr<'a>(cstr: *const i8) -> Result<&'a str, Utf8Error> {
-    return std::ffi::CStr::from_ptr(cstr).to_str(); //returns a result to be unwrapped later
+    return std::ffi::CStr::from_ptr(cstr).to_str();         //returns a result to be unwrapped later
 }
 
 pub fn libc_mmap(addr: *mut u8, len: usize, prot: i32, flags: i32, fildes: i32, off: i64) -> i32 {
-    return ((unsafe { mmap(addr as *mut c_void, len, prot, flags, fildes, off) } as i64)
-        & 0xffffffff) as i32;
+    return ((unsafe{mmap(addr as *mut c_void, len, prot, flags, fildes, off)} as i64) & 0xffffffff) as i32;
 }
 
 #[derive(Debug)]
 pub struct AdvisoryLock {
     //0 signifies unlocked, -1 signifies locked exclusively, positive number signifies that many shared lock holders
     advisory_lock: RustRfc<Mutex<i32>>,
-    advisory_condvar: Condvar,
+    advisory_condvar: Condvar
 }
 
 impl AdvisoryLock {
     pub fn new() -> Self {
-        Self {
-            advisory_lock: RustRfc::new(Mutex::new(0)),
-            advisory_condvar: Condvar::new(),
-        }
+        Self {advisory_lock: RustRfc::new(Mutex::new(0)), advisory_condvar: Condvar::new()}
     }
 
     pub fn lock_ex(&self) {
@@ -239,8 +202,8 @@ impl AdvisoryLock {
     pub fn try_lock_ex(&self) -> bool {
         if let Some(mut guard) = self.advisory_lock.try_lock() {
             if *guard == 0 {
-                *guard = -1;
-                return true;
+              *guard = -1;
+              return true
             }
         }
         false
@@ -248,8 +211,8 @@ impl AdvisoryLock {
     pub fn try_lock_sh(&self) -> bool {
         if let Some(mut guard) = self.advisory_lock.try_lock() {
             if *guard >= 0 {
-                *guard += 1;
-                return true;
+              *guard += 1;
+              return true
             }
         }
         false
@@ -260,71 +223,44 @@ impl AdvisoryLock {
 
         if *guard > 0 {
             *guard -= 1;
-
+  
             //only a writer could be waiting at this point
-            if *guard == 0 {
-                self.advisory_condvar.notify_one();
-            }
+            if *guard == 0 {self.advisory_condvar.notify_one();}
             true
         } else if *guard == -1 {
-            if *guard != -1 {
-                return false;
-            }
+            if *guard != -1 {return false;}
             *guard = 0;
-
+  
             self.advisory_condvar.notify_all(); //in case readers are waiting
             true
-        } else {
-            false
-        }
+        } else {false}
     }
 }
 
 pub struct RawMutex {
-    inner: libc::pthread_mutex_t,
+    inner: libc::pthread_mutex_t
 }
 
 impl RawMutex {
     pub fn create() -> Result<Self, i32> {
         let libcret;
-        let mut retval = Self {
-            inner: unsafe { std::mem::zeroed() },
-        };
+        let mut retval = Self {inner: unsafe{std::mem::zeroed()}};
         unsafe {
-            libcret = libc::pthread_mutex_init(
-                (&mut retval.inner) as *mut libc::pthread_mutex_t,
-                std::ptr::null(),
-            );
+            libcret = libc::pthread_mutex_init((&mut retval.inner) as *mut libc::pthread_mutex_t, std::ptr::null());
         }
-        if libcret < 0 {
-            Err(libcret)
-        } else {
-            Ok(retval)
-        }
+        if libcret < 0 { Err(libcret) } else { Ok(retval) }
     }
 
     pub fn lock(&self) -> i32 {
-        unsafe {
-            libc::pthread_mutex_lock(
-                (&self.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t,
-            )
-        }
+        unsafe {libc::pthread_mutex_lock((&self.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t)}
     }
 
     pub fn trylock(&self) -> i32 {
-        unsafe {
-            libc::pthread_mutex_trylock(
-                (&self.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t,
-            )
-        }
+        unsafe {libc::pthread_mutex_trylock((&self.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t)}
     }
 
     pub fn unlock(&self) -> i32 {
-        unsafe {
-            libc::pthread_mutex_unlock(
-                (&self.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t,
-            )
-        }
+        unsafe {libc::pthread_mutex_unlock((&self.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t)}
     }
 }
 
@@ -336,80 +272,55 @@ impl std::fmt::Debug for RawMutex {
 
 impl Drop for RawMutex {
     fn drop(&mut self) {
-        unsafe {
-            libc::pthread_mutex_destroy((&mut self.inner) as *mut libc::pthread_mutex_t);
-        }
+        unsafe{ libc::pthread_mutex_destroy((&mut self.inner) as *mut libc::pthread_mutex_t); }
     }
 }
 
 pub struct RawCondvar {
-    inner: libc::pthread_cond_t,
+    inner: libc::pthread_cond_t
 }
 
 impl RawCondvar {
     pub fn create() -> Result<Self, i32> {
         let libcret;
-        let mut retval = Self {
-            inner: unsafe { std::mem::zeroed() },
-        };
+        let mut retval = Self {inner: unsafe{std::mem::zeroed()}};
         unsafe {
-            libcret = libc::pthread_cond_init(
-                (&mut retval.inner) as *mut libc::pthread_cond_t,
-                std::ptr::null(),
-            );
+            libcret = libc::pthread_cond_init((&mut retval.inner) as *mut libc::pthread_cond_t, std::ptr::null());
         }
-        if libcret < 0 {
-            Err(libcret)
-        } else {
-            Ok(retval)
-        }
+        if libcret < 0 { Err(libcret) } else { Ok(retval) }
     }
 
     pub fn signal(&self) -> i32 {
-        unsafe {
-            libc::pthread_cond_signal(
-                (&self.inner) as *const libc::pthread_cond_t as *mut libc::pthread_cond_t,
-            )
-        }
+        unsafe {libc::pthread_cond_signal((&self.inner) as *const libc::pthread_cond_t as *mut libc::pthread_cond_t)}
     }
 
     pub fn broadcast(&self) -> i32 {
-        unsafe {
-            libc::pthread_cond_broadcast(
-                (&self.inner) as *const libc::pthread_cond_t as *mut libc::pthread_cond_t,
-            )
-        }
+        unsafe {libc::pthread_cond_broadcast((&self.inner) as *const libc::pthread_cond_t as *mut libc::pthread_cond_t)}
     }
 
     pub fn wait(&self, mutex: &RawMutex) -> i32 {
         unsafe {
-            libc::pthread_cond_wait(
-                (&self.inner) as *const libc::pthread_cond_t as *mut libc::pthread_cond_t,
-                (&mutex.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t,
-            )
+            libc::pthread_cond_wait((&self.inner) as *const libc::pthread_cond_t as *mut libc::pthread_cond_t,
+                                    (&mutex.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t)
         }
     }
 
     pub fn timedwait(&self, mutex: &RawMutex, abs_duration: Duration) -> i32 {
         let abstime = libc::timespec {
             tv_sec: abs_duration.as_secs() as i64,
-            tv_nsec: (abs_duration.as_nanos() % 1000000000) as i64,
+            tv_nsec: (abs_duration.as_nanos() % 1000000000) as i64
         };
         unsafe {
-            libc::pthread_cond_timedwait(
-                (&self.inner) as *const libc::pthread_cond_t as *mut libc::pthread_cond_t,
-                (&mutex.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t,
-                (&abstime) as *const libc::timespec,
-            )
+            libc::pthread_cond_timedwait((&self.inner) as *const libc::pthread_cond_t as *mut libc::pthread_cond_t,
+                                        (&mutex.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t,
+                                        (&abstime) as *const libc::timespec)
         }
     }
 }
 
 impl Drop for RawCondvar {
     fn drop(&mut self) {
-        unsafe {
-            libc::pthread_cond_destroy((&mut self.inner) as *mut libc::pthread_cond_t);
-        }
+        unsafe { libc::pthread_cond_destroy((&mut self.inner) as *mut libc::pthread_cond_t); }
     }
 }
 

--- a/src/interface/misc.rs
+++ b/src/interface/misc.rs
@@ -4,38 +4,49 @@
 // Random, locks, etc.
 #![allow(dead_code)]
 
+pub use dashmap::{
+    mapref::entry::Entry as RustHashEntry, DashMap as RustHashMap, DashSet as RustHashSet,
+};
+pub use std::cmp::{max as rust_max, min as rust_min};
+pub use std::collections::VecDeque as RustDeque;
 use std::fs::File;
 use std::io::{self, Read, Write};
-pub use dashmap::{DashSet as RustHashSet, DashMap as RustHashMap, mapref::entry::Entry as RustHashEntry};
-pub use std::collections::{VecDeque as RustDeque};
-pub use std::cmp::{max as rust_max, min as rust_min};
-pub use std::sync::atomic::{AtomicBool as RustAtomicBool, Ordering as RustAtomicOrdering, AtomicU16 as RustAtomicU16, AtomicI32 as RustAtomicI32, AtomicUsize as RustAtomicUsize};
-pub use std::thread::spawn as helper_thread;
 use std::str::{from_utf8, Utf8Error};
+pub use std::sync::atomic::{
+    AtomicBool as RustAtomicBool, AtomicI32 as RustAtomicI32, AtomicU16 as RustAtomicU16,
+    AtomicUsize as RustAtomicUsize, Ordering as RustAtomicOrdering,
+};
+pub use std::thread::spawn as helper_thread;
 
-pub use std::sync::{Arc as RustRfc};
-pub use parking_lot::{RwLock as RustLock, RwLockWriteGuard as RustLockGuard, Mutex, Condvar};
+pub use parking_lot::{Condvar, Mutex, RwLock as RustLock, RwLockWriteGuard as RustLockGuard};
+pub use std::sync::Arc as RustRfc;
 
-use libc::{mmap, pthread_self, pthread_exit, sched_yield};
+use libc::{mmap, pthread_exit, pthread_self, sched_yield};
 
 use std::ffi::c_void;
 
-pub use serde::{Serialize as SerdeSerialize, Deserialize as SerdeDeserialize};
+pub use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 
-pub use serde_cbor::{ser::to_vec_packed as serde_serialize_to_bytes, from_slice as serde_deserialize_from_bytes};
+pub use serde_cbor::{
+    from_slice as serde_deserialize_from_bytes, ser::to_vec_packed as serde_serialize_to_bytes,
+};
 
-use crate::interface::errnos::{VERBOSE};
+use crate::interface::errnos::VERBOSE;
 use std::time::Duration;
 
 const MAXCAGEID: i32 = 1024;
-const EXIT_SUCCESS : i32 = 0;
+const EXIT_SUCCESS: i32 = 0;
 
-use crate::safeposix::cage::{Cage};
+use crate::safeposix::cage::Cage;
 
 pub static mut CAGE_TABLE: Vec<Option<RustRfc<Cage>>> = Vec::new();
 
 pub fn cagetable_init() {
-   unsafe { for _cage in 0..MAXCAGEID { CAGE_TABLE.push(None); }}
+    unsafe {
+        for _cage in 0..MAXCAGEID {
+            CAGE_TABLE.push(None);
+        }
+    }
 }
 
 pub fn cagetable_insert(cageid: u64, cageobj: Cage) {
@@ -43,7 +54,7 @@ pub fn cagetable_insert(cageid: u64, cageobj: Cage) {
 }
 
 pub fn cagetable_remove(cageid: u64) {
-    unsafe{ CAGE_TABLE[cageid as usize].take() };
+    unsafe { CAGE_TABLE[cageid as usize].take() };
 }
 
 pub fn cagetable_getref(cageid: u64) -> RustRfc<Cage> {
@@ -55,7 +66,9 @@ pub fn cagetable_clear() {
     unsafe {
         for cage in CAGE_TABLE.iter_mut() {
             let cageopt = cage.take();
-            if cageopt.is_some() { exitvec.push(cageopt.unwrap()); }
+            if cageopt.is_some() {
+                exitvec.push(cageopt.unwrap());
+            }
         }
     }
 
@@ -65,8 +78,8 @@ pub fn cagetable_clear() {
 }
 
 pub fn log_from_ptr(buf: *const u8, length: usize) {
-    if let Ok(s) = from_utf8(unsafe{std::slice::from_raw_parts(buf, length)}) {
-      log_to_stdout(s);
+    if let Ok(s) = from_utf8(unsafe { std::slice::from_raw_parts(buf, length) }) {
+        log_to_stdout(s);
     }
 }
 
@@ -92,21 +105,25 @@ pub fn flush_stdout() {
 }
 
 pub fn get_errno() -> i32 {
-    (unsafe{*libc::__errno_location()}) as i32
+    (unsafe { *libc::__errno_location() }) as i32
 }
 
 // Cancellation functions
 
 pub fn lind_threadexit() {
-    unsafe { pthread_exit(0 as *mut c_void); }
+    unsafe {
+        pthread_exit(0 as *mut c_void);
+    }
 }
 
 pub fn get_pthreadid() -> u64 {
-    unsafe { pthread_self() as u64 } 
+    unsafe { pthread_self() as u64 }
 }
 
 pub fn lind_yield() {
-    unsafe { sched_yield(); }
+    unsafe {
+        sched_yield();
+    }
 }
 
 // this function checks if a thread is killable and returns that state
@@ -122,24 +139,30 @@ pub fn cancelpoint(cageid: u64) {
     let pthread_id = get_pthreadid();
     if check_thread(cageid, pthread_id) {
         let cage = cagetable_getref(cageid);
-        cage.thread_table.insert(pthread_id, false); 
-        lind_threadexit(); 
+        cage.thread_table.insert(pthread_id, false);
+        lind_threadexit();
     }
 }
 
 pub fn fillrandom(bufptr: *mut u8, count: usize) -> i32 {
-    let slice = unsafe{std::slice::from_raw_parts_mut(bufptr, count)};
-    let mut f = std::fs::OpenOptions::new().read(true).write(false).open("/dev/urandom").unwrap();
+    let slice = unsafe { std::slice::from_raw_parts_mut(bufptr, count) };
+    let mut f = std::fs::OpenOptions::new()
+        .read(true)
+        .write(false)
+        .open("/dev/urandom")
+        .unwrap();
     f.read(slice).unwrap() as i32
 }
 pub fn fillzero(bufptr: *mut u8, count: usize) -> i32 {
-    let slice = unsafe{std::slice::from_raw_parts_mut(bufptr, count)};
-    for i in 0..count {slice[i] = 0u8;}
+    let slice = unsafe { std::slice::from_raw_parts_mut(bufptr, count) };
+    for i in 0..count {
+        slice[i] = 0u8;
+    }
     count as i32
 }
 
-pub fn fill(bufptr: *mut u8, count: usize, values:&Vec<u8>) -> i32 {
-    let slice = unsafe{std::slice::from_raw_parts_mut(bufptr, count)};
+pub fn fill(bufptr: *mut u8, count: usize, values: &Vec<u8>) -> i32 {
+    let slice = unsafe { std::slice::from_raw_parts_mut(bufptr, count) };
     slice.copy_from_slice(&values[..count]);
     count as i32
 }
@@ -147,15 +170,25 @@ pub fn fill(bufptr: *mut u8, count: usize, values:&Vec<u8>) -> i32 {
 pub fn copy_fromrustdeque_sized(bufptr: *mut u8, count: usize, vecdeq: &RustDeque<u8>) {
     let (slice1, slice2) = vecdeq.as_slices();
     if slice1.len() >= count {
-        unsafe {std::ptr::copy(slice1.as_ptr(), bufptr, count);}
+        unsafe {
+            std::ptr::copy(slice1.as_ptr(), bufptr, count);
+        }
     } else {
-        unsafe {std::ptr::copy(slice1.as_ptr(), bufptr, slice1.len());}
-        unsafe {std::ptr::copy(slice2.as_ptr(), bufptr.wrapping_offset(slice1.len() as isize), count - slice1.len());}
+        unsafe {
+            std::ptr::copy(slice1.as_ptr(), bufptr, slice1.len());
+        }
+        unsafe {
+            std::ptr::copy(
+                slice2.as_ptr(),
+                bufptr.wrapping_offset(slice1.len() as isize),
+                count - slice1.len(),
+            );
+        }
     }
 }
 
 pub fn extend_fromptr_sized(bufptr: *const u8, count: usize, vecdeq: &mut RustDeque<u8>) {
-    let byteslice = unsafe {std::slice::from_raw_parts(bufptr, count)};
+    let byteslice = unsafe { std::slice::from_raw_parts(bufptr, count) };
     vecdeq.extend(byteslice.iter());
 }
 
@@ -165,23 +198,27 @@ pub fn new_hashmap<K: std::cmp::Eq + std::hash::Hash, V>() -> RustHashMap<K, V> 
 }
 
 pub unsafe fn charstar_to_ruststr<'a>(cstr: *const i8) -> Result<&'a str, Utf8Error> {
-    return std::ffi::CStr::from_ptr(cstr).to_str();         //returns a result to be unwrapped later
+    return std::ffi::CStr::from_ptr(cstr).to_str(); //returns a result to be unwrapped later
 }
 
 pub fn libc_mmap(addr: *mut u8, len: usize, prot: i32, flags: i32, fildes: i32, off: i64) -> i32 {
-    return ((unsafe{mmap(addr as *mut c_void, len, prot, flags, fildes, off)} as i64) & 0xffffffff) as i32;
+    return ((unsafe { mmap(addr as *mut c_void, len, prot, flags, fildes, off) } as i64)
+        & 0xffffffff) as i32;
 }
 
 #[derive(Debug)]
 pub struct AdvisoryLock {
     //0 signifies unlocked, -1 signifies locked exclusively, positive number signifies that many shared lock holders
     advisory_lock: RustRfc<Mutex<i32>>,
-    advisory_condvar: Condvar
+    advisory_condvar: Condvar,
 }
 
 impl AdvisoryLock {
     pub fn new() -> Self {
-        Self {advisory_lock: RustRfc::new(Mutex::new(0)), advisory_condvar: Condvar::new()}
+        Self {
+            advisory_lock: RustRfc::new(Mutex::new(0)),
+            advisory_condvar: Condvar::new(),
+        }
     }
 
     pub fn lock_ex(&self) {
@@ -202,8 +239,8 @@ impl AdvisoryLock {
     pub fn try_lock_ex(&self) -> bool {
         if let Some(mut guard) = self.advisory_lock.try_lock() {
             if *guard == 0 {
-              *guard = -1;
-              return true
+                *guard = -1;
+                return true;
             }
         }
         false
@@ -211,8 +248,8 @@ impl AdvisoryLock {
     pub fn try_lock_sh(&self) -> bool {
         if let Some(mut guard) = self.advisory_lock.try_lock() {
             if *guard >= 0 {
-              *guard += 1;
-              return true
+                *guard += 1;
+                return true;
             }
         }
         false
@@ -221,46 +258,73 @@ impl AdvisoryLock {
     pub fn unlock(&self) -> bool {
         let mut guard = self.advisory_lock.lock();
 
-        if *guard < 0 {
+        if *guard > 0 {
             *guard -= 1;
-  
+
             //only a writer could be waiting at this point
-            if *guard == 0 {self.advisory_condvar.notify_one();}
+            if *guard == 0 {
+                self.advisory_condvar.notify_one();
+            }
             true
         } else if *guard == -1 {
-            if *guard != -1 {return false;}
+            if *guard != -1 {
+                return false;
+            }
             *guard = 0;
-  
+
             self.advisory_condvar.notify_all(); //in case readers are waiting
             true
-        } else {false}
+        } else {
+            false
+        }
     }
 }
 
 pub struct RawMutex {
-    inner: libc::pthread_mutex_t
+    inner: libc::pthread_mutex_t,
 }
 
 impl RawMutex {
     pub fn create() -> Result<Self, i32> {
         let libcret;
-        let mut retval = Self {inner: unsafe{std::mem::zeroed()}};
+        let mut retval = Self {
+            inner: unsafe { std::mem::zeroed() },
+        };
         unsafe {
-            libcret = libc::pthread_mutex_init((&mut retval.inner) as *mut libc::pthread_mutex_t, std::ptr::null());
+            libcret = libc::pthread_mutex_init(
+                (&mut retval.inner) as *mut libc::pthread_mutex_t,
+                std::ptr::null(),
+            );
         }
-        if libcret < 0 { Err(libcret) } else { Ok(retval) }
+        if libcret < 0 {
+            Err(libcret)
+        } else {
+            Ok(retval)
+        }
     }
 
     pub fn lock(&self) -> i32 {
-        unsafe {libc::pthread_mutex_lock((&self.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t)}
+        unsafe {
+            libc::pthread_mutex_lock(
+                (&self.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t,
+            )
+        }
     }
 
     pub fn trylock(&self) -> i32 {
-        unsafe {libc::pthread_mutex_trylock((&self.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t)}
+        unsafe {
+            libc::pthread_mutex_trylock(
+                (&self.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t,
+            )
+        }
     }
 
     pub fn unlock(&self) -> i32 {
-        unsafe {libc::pthread_mutex_unlock((&self.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t)}
+        unsafe {
+            libc::pthread_mutex_unlock(
+                (&self.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t,
+            )
+        }
     }
 }
 
@@ -272,55 +336,80 @@ impl std::fmt::Debug for RawMutex {
 
 impl Drop for RawMutex {
     fn drop(&mut self) {
-        unsafe{ libc::pthread_mutex_destroy((&mut self.inner) as *mut libc::pthread_mutex_t); }
+        unsafe {
+            libc::pthread_mutex_destroy((&mut self.inner) as *mut libc::pthread_mutex_t);
+        }
     }
 }
 
 pub struct RawCondvar {
-    inner: libc::pthread_cond_t
+    inner: libc::pthread_cond_t,
 }
 
 impl RawCondvar {
     pub fn create() -> Result<Self, i32> {
         let libcret;
-        let mut retval = Self {inner: unsafe{std::mem::zeroed()}};
+        let mut retval = Self {
+            inner: unsafe { std::mem::zeroed() },
+        };
         unsafe {
-            libcret = libc::pthread_cond_init((&mut retval.inner) as *mut libc::pthread_cond_t, std::ptr::null());
+            libcret = libc::pthread_cond_init(
+                (&mut retval.inner) as *mut libc::pthread_cond_t,
+                std::ptr::null(),
+            );
         }
-        if libcret < 0 { Err(libcret) } else { Ok(retval) }
+        if libcret < 0 {
+            Err(libcret)
+        } else {
+            Ok(retval)
+        }
     }
 
     pub fn signal(&self) -> i32 {
-        unsafe {libc::pthread_cond_signal((&self.inner) as *const libc::pthread_cond_t as *mut libc::pthread_cond_t)}
+        unsafe {
+            libc::pthread_cond_signal(
+                (&self.inner) as *const libc::pthread_cond_t as *mut libc::pthread_cond_t,
+            )
+        }
     }
 
     pub fn broadcast(&self) -> i32 {
-        unsafe {libc::pthread_cond_broadcast((&self.inner) as *const libc::pthread_cond_t as *mut libc::pthread_cond_t)}
+        unsafe {
+            libc::pthread_cond_broadcast(
+                (&self.inner) as *const libc::pthread_cond_t as *mut libc::pthread_cond_t,
+            )
+        }
     }
 
     pub fn wait(&self, mutex: &RawMutex) -> i32 {
         unsafe {
-            libc::pthread_cond_wait((&self.inner) as *const libc::pthread_cond_t as *mut libc::pthread_cond_t,
-                                    (&mutex.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t)
+            libc::pthread_cond_wait(
+                (&self.inner) as *const libc::pthread_cond_t as *mut libc::pthread_cond_t,
+                (&mutex.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t,
+            )
         }
     }
 
     pub fn timedwait(&self, mutex: &RawMutex, abs_duration: Duration) -> i32 {
         let abstime = libc::timespec {
             tv_sec: abs_duration.as_secs() as i64,
-            tv_nsec: (abs_duration.as_nanos() % 1000000000) as i64
+            tv_nsec: (abs_duration.as_nanos() % 1000000000) as i64,
         };
         unsafe {
-            libc::pthread_cond_timedwait((&self.inner) as *const libc::pthread_cond_t as *mut libc::pthread_cond_t,
-                                        (&mutex.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t,
-                                        (&abstime) as *const libc::timespec)
+            libc::pthread_cond_timedwait(
+                (&self.inner) as *const libc::pthread_cond_t as *mut libc::pthread_cond_t,
+                (&mutex.inner) as *const libc::pthread_mutex_t as *mut libc::pthread_mutex_t,
+                (&abstime) as *const libc::timespec,
+            )
         }
     }
 }
 
 impl Drop for RawCondvar {
     fn drop(&mut self) {
-        unsafe { libc::pthread_cond_destroy((&mut self.inner) as *mut libc::pthread_cond_t); }
+        unsafe {
+            libc::pthread_cond_destroy((&mut self.inner) as *mut libc::pthread_cond_t);
+        }
     }
 }
 


### PR DESCRIPTION
## Description



<!-- Please include a summary of the changes and the related issue. --> 

This change fixes the unlock function of Advisory Locks in safeposix.

EDIT: This issue was discovered while testing the flock syscall; the other relevant PRs are: https://github.com/Lind-Project/lind_project/pull/315 and https://github.com/Lind-Project/native_client/pull/139.

<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->

Advisory Locks are used by the `flock` syscall. 

The way it is intended to work is as follows:

When a lock is acquired, a `guard` value is used to indicate whether the lock is exclusive or shared.
- Guard is set to -1 to indicate an exclusive lock.
- Guard is incremented by 1 for shared locks.

When unlocking this mutex:
- If a shared lock is held, the guard is decremented by 1.
- If an exclusive lock is held, the guard is set to 0.

Currently, the `unlock` function was decrementing the value of `guard` if it was less than 0, and not performing any action when it was more than 0.

This meant that neither exclusive locks nor shared locks would be released once acquired, even though the function would run correctly.

<!-- List any dependencies that are required for this change. -->

### Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

This was tested by running the `flock.c` test successfully.
Note that this test will be added to the Lind test suite in a future PR in `lind_project`, but the file can be found under this branch for now: https://github.com/Lind-Project/lind_project/blob/feature/new-tests-to-debug/tests/test_cases/flock.c

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)


