### PR TITLE
Develop test getpid

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -42,6 +42,7 @@ pub mod fs_tests {
         chardevtest();
         ut_lind_fs_exec_cloexec();
         ut_lind_fs_shm();
+        ut_lind_fs_getpid_getppid()
     }
 
 

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -1004,4 +1004,28 @@ pub mod fs_tests {
         
         lindrustfinalize();
     }
+
+    pub fn ut_lind_fs_getpid_getppid() {
+        lindrustinit(0);
+        
+        let cage1 = interface::cagetable_getref(1);
+        let pid1 = cage1.getpid_syscall();
+    
+        assert_eq!(cage1.fork_syscall(2), 0);
+        
+        let child = std::thread::spawn(move || {
+            let cage2 = interface::cagetable_getref(2);
+            let pid2 = cage2.getpid_syscall();
+            let ppid2 = cage2.getppid_syscall();
+            
+            assert_ne!(pid2, pid1); // make sure the child and the parent have different pids
+            assert_eq!(ppid2, pid1); // make sure the child's getppid is correct
+            
+            assert_eq!(cage2.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        });
+        
+        child.join().unwrap();
+        assert_eq!(cage1.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
 }


### PR DESCRIPTION
## Description
Simple 20 lines addition, adding a unit test function to fstests for `getpid` and `getppid` syscalls. It runs successfully without error.

<!-- Please include a summary of the changes and the related issue. --> 
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

### Type of change

- [x] New feature (non-breaking change which adds functionality)

