### PR TITLE
swap error order in shmget

### DIFF
--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1987,7 +1987,6 @@ impl Cage {
 
     pub fn shmget_syscall(&self, key: i32, size: usize, shmflg: i32)-> i32 {
         if key == IPC_PRIVATE {return syscall_error(Errno::ENOENT, "shmget", "IPC_PRIVATE not implemented");}
-        if (size as u32) < SHMMIN || (size as u32) > SHMMAX { return syscall_error(Errno::EINVAL, "shmget", "Size is less than SHMMIN or more than SHMMAX"); }
         let shmid: i32;
         let metadata = &SHM_METADATA;
 
@@ -2002,6 +2001,9 @@ impl Cage {
                 if 0 == (shmflg & IPC_CREAT) {
                     return syscall_error(Errno::ENOENT, "shmget", "tried to use a key that did not exist, and IPC_CREAT was not specified");
                 }
+
+                if (size as u32) < SHMMIN || (size as u32) > SHMMAX { return syscall_error(Errno::EINVAL, "shmget", "Size is less than SHMMIN or more than SHMMAX"); }
+
                 shmid = metadata.new_keyid();
                 vacant.insert(shmid);
                 let mode = (shmflg & 0x1FF) as u16; // mode is 9 least signficant bits of shmflag, even if we dont really do anything with them


### PR DESCRIPTION
## Description
Swap error order in shmget
Fixes # (issue)

Apparently shmget checks if the key exists before it does a size check. It seems trivial but apparently postgres utilizes this to do something when it returns EEXIST. This fix fixes the order so pg can operate correctly.

### Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

I tested this with a simple test calling shmget twice and checking the errnos

## Checklist:

- [x ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
