### PR TITLE
Add file descriptor boundary check

### DIFF
--- a/src/safeposix/cage.rs
+++ b/src/safeposix/cage.rs
@@ -116,6 +116,14 @@ impl Cage {
             }
         }
     }
+
+    pub fn get_filedescriptor(&self, fd: i32) -> Result<interface::RustRfc<interface::RustLock<Option<FileDescriptor>>>, ()> {
+        if (fd < 0) || (fd >= MAXFD) {
+            Err(())
+        } else {
+            Ok(self.filedescriptortable[fd as usize].clone())
+        }
+    }
 }
 
 pub fn init_fdtable() -> FdTable {

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -479,7 +479,8 @@ impl Cage {
     //------------------------------------FSTAT SYSCALL------------------------------------
 
     pub fn fstat_syscall(&self, fd: i32, statbuf: &mut StatData) -> i32 {
-        let unlocked_fd = self.filedescriptortable[fd as usize].read();
+        let tmp = self.get_filedescriptor(fd).unwrap();
+        let unlocked_fd = tmp.read();
         if let Some(filedesc_enum) = &*unlocked_fd {
 
             //Delegate populating statbuf to the relevant helper depending on the file type.
@@ -544,7 +545,8 @@ impl Cage {
     //------------------------------------FSTATFS SYSCALL------------------------------------
 
     pub fn fstatfs_syscall(&self, fd: i32, databuf: &mut FSData) -> i32 {
-        let unlocked_fd = self.filedescriptortable[fd as usize].read();
+        let tmp = self.get_filedescriptor(fd).unwrap();
+        let unlocked_fd = tmp.read();
         if let Some(filedesc_enum) = &*unlocked_fd {
             
             //populate the dev id field -- can be done outside of the helper
@@ -581,7 +583,8 @@ impl Cage {
     //------------------------------------READ SYSCALL------------------------------------
 
     pub fn read_syscall(&self, fd: i32, buf: *mut u8, count: usize) -> i32 {
-        let mut unlocked_fd = self.filedescriptortable[fd as usize].write();
+        let tmp = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = tmp.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
 
             //delegate to pipe, stream, or socket helper if specified by file descriptor enum type (none of them are implemented yet)
@@ -658,7 +661,8 @@ impl Cage {
 
     //------------------------------------PREAD SYSCALL------------------------------------
     pub fn pread_syscall(&self, fd: i32, buf: *mut u8, count: usize, offset: isize) -> i32 {
-        let mut unlocked_fd = self.filedescriptortable[fd as usize].write();
+        let tmp = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = tmp.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
 
             match filedesc_enum {
@@ -726,7 +730,8 @@ impl Cage {
     //------------------------------------WRITE SYSCALL------------------------------------
 
     pub fn write_syscall(&self, fd: i32, buf: *const u8, count: usize) -> i32 {
-        let mut unlocked_fd = self.filedescriptortable[fd as usize].write();
+        let tmp = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = tmp.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
 
             //delegate to pipe, stream, or socket helper if specified by file descriptor enum type
@@ -823,7 +828,8 @@ impl Cage {
     //------------------------------------PWRITE SYSCALL------------------------------------
 
     pub fn pwrite_syscall(&self, fd: i32, buf: *const u8, count: usize, offset: isize) -> i32 {
-        let mut unlocked_fd = self.filedescriptortable[fd as usize].write();
+        let tmp = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = tmp.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
 
             match filedesc_enum {
@@ -922,7 +928,8 @@ impl Cage {
 
     //------------------------------------LSEEK SYSCALL------------------------------------
     pub fn lseek_syscall(&self, fd: i32, offset: isize, whence: i32) -> i32 {
-        let mut unlocked_fd = self.filedescriptortable[fd as usize].write();
+        let tmp = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = tmp.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
 
             //confirm fd type is seekable
@@ -1042,7 +1049,8 @@ impl Cage {
     //------------------------------------FCHDIR SYSCALL------------------------------------
    
     pub fn fchdir_syscall(&self, fd: i32) -> i32 {
-        let unlocked_fd = self.filedescriptortable[fd as usize].read();
+        let tmp = self.get_filedescriptor(fd).unwrap();
+        let unlocked_fd = tmp.read();
 
         let path_string = match &*unlocked_fd {
             Some(File(normalfile_filedesc_obj)) => {
@@ -1114,14 +1122,16 @@ impl Cage {
             return syscall_error(Errno::EBADF, "dup or dup2", "provided file descriptor is out of range");
         }
 
-        let filedesc_enum = self.filedescriptortable[oldfd as usize].write();
+        let tmp = self.get_filedescriptor(oldfd).unwrap();
+        let filedesc_enum = tmp.write();
         let filedesc_enum = if let Some(f) = &*filedesc_enum {f} else {
             return syscall_error(Errno::EBADF, "dup2","Invalid old file descriptor.");
         };
 
         let (dupfd, mut dupfdguard) = if fromdup2 {
             if newfd == oldfd { return newfd; } //if the file descriptors are equal, return the new one
-            let mut fdguard = self.filedescriptortable[newfd as usize].write();
+            let tmp2 = self.get_filedescriptor(newfd).unwrap();
+            let mut fdguard = tmp2.write();
             if fdguard.is_some() {
                 drop(fdguard);
                 //close the fd in the way of the new fd. If an error is returned from the helper, return the error, else continue to end
@@ -1130,7 +1140,8 @@ impl Cage {
                     return close_result;
                 }
             } else { drop(fdguard); }
-            fdguard = self.filedescriptortable[newfd as usize].write();
+            let tmp3 = self.get_filedescriptor(newfd).unwrap();
+            fdguard = tmp3.write();
 
             (newfd, fdguard)
         } else {
@@ -1204,7 +1215,8 @@ impl Cage {
     }
 
     pub fn _close_helper_inner(&self, fd: i32) -> i32 {
-        let mut unlocked_fd = self.filedescriptortable[fd as usize].write();
+        let tmp = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = tmp.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
             //Decide how to proceed depending on the fd type.
             //First we check in the file descriptor to handle sockets (no-op), sockets (clean the socket), and pipes (clean the pipe),
@@ -1318,7 +1330,8 @@ impl Cage {
         if inner_result < 0 { return inner_result; }
         
         //removing inode from fd table
-        let mut unlocked_fd = self.filedescriptortable[fd as usize].write();
+        let tmp = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = tmp.write();
         if unlocked_fd.is_some() {
             let _discarded_fd = unlocked_fd.take();
         }
@@ -1328,7 +1341,8 @@ impl Cage {
     //------------------------------------FCNTL SYSCALL------------------------------------
     
     pub fn fcntl_syscall(&self, fd: i32, cmd: i32, arg: i32) -> i32 {
-        let mut unlocked_fd = self.filedescriptortable[fd as usize].write();
+        let tmp = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = tmp.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
 
             let flags = match filedesc_enum {
@@ -1407,7 +1421,8 @@ impl Cage {
     //------------------------------------IOCTL SYSCALL------------------------------------
 
     pub fn ioctl_syscall(&self, fd: i32, request: u32, ptrunion: IoctlPtrUnion) -> i32 {
-        let mut unlocked_fd = self.filedescriptortable[fd as usize].write();
+        let tmp = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = tmp.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
 
             match request {
@@ -1511,7 +1526,8 @@ impl Cage {
      //------------------------------------FCHMOD SYSCALL------------------------------------
 
     pub fn fchmod_syscall(&self, fd: i32, mode: u32) -> i32 {
-        let unlocked_fd = self.filedescriptortable[fd as usize].read();
+        let tmp = self.get_filedescriptor(fd).unwrap();
+        let unlocked_fd = tmp.read();
         if let Some(filedesc_enum) = &*unlocked_fd {
             match filedesc_enum {
                 File(normalfile_filedesc_obj) => {
@@ -1548,7 +1564,8 @@ impl Cage {
             return interface::libc_mmap(addr, len, prot, flags, -1, 0);
         }
 
-        let mut unlocked_fd = self.filedescriptortable[fildes as usize].write();
+        let tmp = self.get_filedescriptor(fildes).unwrap();
+        let mut unlocked_fd = tmp.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
 
             //confirm fd type is mappable
@@ -1603,7 +1620,8 @@ impl Cage {
     //------------------------------------FLOCK SYSCALL------------------------------------
 
     pub fn flock_syscall(&self, fd: i32, operation: i32) -> i32 {
-        let unlocked_fd = self.filedescriptortable[fd as usize].read();
+        let tmp = self.get_filedescriptor(fd).unwrap();
+        let unlocked_fd = tmp.read();
         if let Some(filedesc_enum) = &*unlocked_fd {
 
             let lock = match filedesc_enum {
@@ -1822,7 +1840,8 @@ impl Cage {
     //------------------FTRUNCATE SYSCALL------------------
     
     pub fn ftruncate_syscall(&self, fd: i32, length: isize) -> i32 {
-        let unlocked_fd = self.filedescriptortable[fd as usize].read();
+        let tmp = self.get_filedescriptor(fd).unwrap();
+        let unlocked_fd = tmp.read();
         if let Some(filedesc_enum) = &*unlocked_fd {
 
             match filedesc_enum {
@@ -1899,8 +1918,9 @@ impl Cage {
         if bufsize <= interface::CLIPPED_DIRENT_SIZE {
             return syscall_error(Errno::EINVAL, "getdents", "Result buffer is too small.");
         }
-        
-        let mut unlocked_fd = self.filedescriptortable[fd as usize].write();
+
+        let tmp = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = tmp.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
             
             match filedesc_enum {

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1130,8 +1130,7 @@ impl Cage {
 
         let (dupfd, mut dupfdguard) = if fromdup2 {
             if newfd == oldfd { return newfd; } //if the file descriptors are equal, return the new one
-            let tmp2 = self.get_filedescriptor(newfd).unwrap();
-            let mut fdguard = tmp2.write();
+            let mut fdguard = self.filedescriptortable[newfd as usize].write();
             if fdguard.is_some() {
                 drop(fdguard);
                 //close the fd in the way of the new fd. If an error is returned from the helper, return the error, else continue to end
@@ -1140,8 +1139,7 @@ impl Cage {
                     return close_result;
                 }
             } else { drop(fdguard); }
-            let tmp3 = self.get_filedescriptor(newfd).unwrap();
-            fdguard = tmp3.write();
+            fdguard = self.filedescriptortable[newfd as usize].write();
 
             (newfd, fdguard)
         } else {

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -479,8 +479,8 @@ impl Cage {
     //------------------------------------FSTAT SYSCALL------------------------------------
 
     pub fn fstat_syscall(&self, fd: i32, statbuf: &mut StatData) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let unlocked_fd = tmp.read();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let unlocked_fd = checkedfd.read();
         if let Some(filedesc_enum) = &*unlocked_fd {
 
             //Delegate populating statbuf to the relevant helper depending on the file type.
@@ -545,8 +545,8 @@ impl Cage {
     //------------------------------------FSTATFS SYSCALL------------------------------------
 
     pub fn fstatfs_syscall(&self, fd: i32, databuf: &mut FSData) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let unlocked_fd = tmp.read();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let unlocked_fd = checkedfd.read();
         if let Some(filedesc_enum) = &*unlocked_fd {
             
             //populate the dev id field -- can be done outside of the helper
@@ -583,8 +583,8 @@ impl Cage {
     //------------------------------------READ SYSCALL------------------------------------
 
     pub fn read_syscall(&self, fd: i32, buf: *mut u8, count: usize) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
 
             //delegate to pipe, stream, or socket helper if specified by file descriptor enum type (none of them are implemented yet)
@@ -661,8 +661,8 @@ impl Cage {
 
     //------------------------------------PREAD SYSCALL------------------------------------
     pub fn pread_syscall(&self, fd: i32, buf: *mut u8, count: usize, offset: isize) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
 
             match filedesc_enum {
@@ -730,8 +730,8 @@ impl Cage {
     //------------------------------------WRITE SYSCALL------------------------------------
 
     pub fn write_syscall(&self, fd: i32, buf: *const u8, count: usize) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
 
             //delegate to pipe, stream, or socket helper if specified by file descriptor enum type
@@ -828,8 +828,8 @@ impl Cage {
     //------------------------------------PWRITE SYSCALL------------------------------------
 
     pub fn pwrite_syscall(&self, fd: i32, buf: *const u8, count: usize, offset: isize) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
 
             match filedesc_enum {
@@ -928,8 +928,8 @@ impl Cage {
 
     //------------------------------------LSEEK SYSCALL------------------------------------
     pub fn lseek_syscall(&self, fd: i32, offset: isize, whence: i32) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
 
             //confirm fd type is seekable
@@ -1049,8 +1049,8 @@ impl Cage {
     //------------------------------------FCHDIR SYSCALL------------------------------------
    
     pub fn fchdir_syscall(&self, fd: i32) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let unlocked_fd = tmp.read();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let unlocked_fd = checkedfd.read();
 
         let path_string = match &*unlocked_fd {
             Some(File(normalfile_filedesc_obj)) => {
@@ -1122,8 +1122,8 @@ impl Cage {
             return syscall_error(Errno::EBADF, "dup or dup2", "provided file descriptor is out of range");
         }
 
-        let tmp = self.get_filedescriptor(oldfd).unwrap();
-        let filedesc_enum = tmp.write();
+        let checkedfd = self.get_filedescriptor(oldfd).unwrap();
+        let filedesc_enum = checkedfd.write();
         let filedesc_enum = if let Some(f) = &*filedesc_enum {f} else {
             return syscall_error(Errno::EBADF, "dup2","Invalid old file descriptor.");
         };
@@ -1213,8 +1213,8 @@ impl Cage {
     }
 
     pub fn _close_helper_inner(&self, fd: i32) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
             //Decide how to proceed depending on the fd type.
             //First we check in the file descriptor to handle sockets (no-op), sockets (clean the socket), and pipes (clean the pipe),
@@ -1328,8 +1328,8 @@ impl Cage {
         if inner_result < 0 { return inner_result; }
         
         //removing inode from fd table
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if unlocked_fd.is_some() {
             let _discarded_fd = unlocked_fd.take();
         }
@@ -1339,8 +1339,8 @@ impl Cage {
     //------------------------------------FCNTL SYSCALL------------------------------------
     
     pub fn fcntl_syscall(&self, fd: i32, cmd: i32, arg: i32) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
 
             let flags = match filedesc_enum {
@@ -1419,8 +1419,8 @@ impl Cage {
     //------------------------------------IOCTL SYSCALL------------------------------------
 
     pub fn ioctl_syscall(&self, fd: i32, request: u32, ptrunion: IoctlPtrUnion) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
 
             match request {
@@ -1524,8 +1524,8 @@ impl Cage {
      //------------------------------------FCHMOD SYSCALL------------------------------------
 
     pub fn fchmod_syscall(&self, fd: i32, mode: u32) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let unlocked_fd = tmp.read();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let unlocked_fd = checkedfd.read();
         if let Some(filedesc_enum) = &*unlocked_fd {
             match filedesc_enum {
                 File(normalfile_filedesc_obj) => {
@@ -1562,8 +1562,8 @@ impl Cage {
             return interface::libc_mmap(addr, len, prot, flags, -1, 0);
         }
 
-        let tmp = self.get_filedescriptor(fildes).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fildes).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
 
             //confirm fd type is mappable
@@ -1618,8 +1618,8 @@ impl Cage {
     //------------------------------------FLOCK SYSCALL------------------------------------
 
     pub fn flock_syscall(&self, fd: i32, operation: i32) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let unlocked_fd = tmp.read();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let unlocked_fd = checkedfd.read();
         if let Some(filedesc_enum) = &*unlocked_fd {
 
             let lock = match filedesc_enum {
@@ -1838,8 +1838,8 @@ impl Cage {
     //------------------FTRUNCATE SYSCALL------------------
     
     pub fn ftruncate_syscall(&self, fd: i32, length: isize) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let unlocked_fd = tmp.read();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let unlocked_fd = checkedfd.read();
         if let Some(filedesc_enum) = &*unlocked_fd {
 
             match filedesc_enum {
@@ -1917,8 +1917,8 @@ impl Cage {
             return syscall_error(Errno::EINVAL, "getdents", "Result buffer is too small.");
         }
 
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
             
             match filedesc_enum {

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -239,7 +239,8 @@ impl Cage {
     }
 
     pub fn bind_inner(&self, fd: i32, localaddr: &interface::GenSockaddr, prereserved: bool) -> i32 {
-        let mut unlocked_fd = self.filedescriptortable[fd as usize].write();
+        let mut tmp = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = tmp.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
             match filedesc_enum {
                 Socket(ref mut sockfdobj) => {

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -239,8 +239,8 @@ impl Cage {
     }
 
     pub fn bind_inner(&self, fd: i32, localaddr: &interface::GenSockaddr, prereserved: bool) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
             match filedesc_enum {
                 Socket(ref mut sockfdobj) => {
@@ -296,8 +296,8 @@ impl Cage {
     }
 
     pub fn connect_syscall(&self, fd: i32, remoteaddr: &interface::GenSockaddr) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
             match filedesc_enum {
                 Socket(ref mut sockfdobj) => {
@@ -431,8 +431,8 @@ impl Cage {
             return self.send_syscall(fd, buf, buflen, flags);
         }
 
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &*unlocked_fd {
             match filedesc_enum {
                 Socket(sockfdobj) => {
@@ -493,8 +493,8 @@ impl Cage {
         }
     }
     pub fn send_syscall(&self, fd: i32, buf: *const u8, buflen: usize, flags: i32) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
             match filedesc_enum {
                 Socket(ref mut sockfdobj) => {
@@ -696,8 +696,8 @@ impl Cage {
     }
 
     pub fn recv_common(&self, fd: i32, buf: *mut u8, buflen: usize, flags: i32, addr: &mut Option<&mut interface::GenSockaddr>) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(ref mut filedesc_enum) = &mut *unlocked_fd {
             return self.recv_common_inner(filedesc_enum, buf, buflen, flags, addr);
         } else {
@@ -715,8 +715,8 @@ impl Cage {
 
     //we currently ignore backlog
     pub fn listen_syscall(&self, fd: i32, _backlog: i32) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
             match filedesc_enum {
                 Socket(ref mut sockfdobj) => {
@@ -866,8 +866,8 @@ impl Cage {
     }
 
     pub fn _cleanup_socket(&self, fd: i32, how: i32) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(ref mut filedesc_enum) = &mut *unlocked_fd {
             let inner_result = self._cleanup_socket_inner(filedesc_enum, how, true);
             if inner_result < 0 {
@@ -888,8 +888,8 @@ impl Cage {
     
     //calls accept on the socket object with value depending on ipv4 or ipv6
     pub fn accept_syscall(&self, fd: i32, addr: &mut interface::GenSockaddr) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
 
             //we need to reserve this fd early to make sure that we don't need to
@@ -1012,8 +1012,8 @@ impl Cage {
         let flags = MSG_PEEK;
         let mut buf = [0u8; 1];
         let bufptr = buf.as_mut_ptr();
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(ref mut filedesc_enum) = &mut *unlocked_fd {
             let oldflags;
             if let Socket(ref mut sockfdobj) = filedesc_enum {
@@ -1057,8 +1057,8 @@ impl Cage {
         let mut retval = 0; 
         loop { //we must block manually
             for fd in readfds.iter() {
-                let tmp = self.get_filedescriptor(*fd).unwrap();
-                let mut unlocked_fd = tmp.write();
+                let checkedfd = self.get_filedescriptor(*fd).unwrap();
+                let mut unlocked_fd = checkedfd.write();
                 if let Some(filedesc_enum) = &mut *unlocked_fd {
                     match filedesc_enum {
                         Socket(ref mut sockfdobj) => {
@@ -1131,8 +1131,8 @@ impl Cage {
             }
 
             for fd in writefds.iter() {
-                let tmp = self.get_filedescriptor(*fd).unwrap();
-                let mut unlocked_fd = tmp.write();
+                let checkedfd = self.get_filedescriptor(*fd).unwrap();
+                let mut unlocked_fd = checkedfd.write();
                 if let Some(filedesc_enum) = &mut *unlocked_fd {
                     match filedesc_enum {
                         Socket(ref mut sockfdobj) => {
@@ -1176,8 +1176,8 @@ impl Cage {
             
             for fd in exceptfds.iter() {
                 //we say none of them ever have exceptional conditions
-                let tmp = self.get_filedescriptor(*fd).unwrap();
-                let unlocked_fd = tmp.read();
+                let checkedfd = self.get_filedescriptor(*fd).unwrap();
+                let unlocked_fd = checkedfd.read();
                 if let None = *unlocked_fd { return syscall_error(Errno::EBADF, "select", "invalid file descriptor"); }
             }
 
@@ -1193,8 +1193,8 @@ impl Cage {
     }
 
     pub fn getsockopt_syscall(&self, fd: i32, level: i32, optname: i32, optval: &mut i32) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
             if let Socket(ref mut sockfdobj) = filedesc_enum {
                 //checking that we recieved SOL_SOCKET
@@ -1267,8 +1267,8 @@ impl Cage {
     }
 
     pub fn setsockopt_syscall(&self, fd: i32, level: i32, optname: i32, optval: i32) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
             if let Socket(ref mut sockfdobj) = filedesc_enum {
                 //checking that we recieved SOL_SOCKET\
@@ -1363,8 +1363,8 @@ impl Cage {
     }
 
     pub fn getpeername_syscall(&self, fd: i32, ret_addr: &mut interface::GenSockaddr) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let unlocked_fd = tmp.read();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let unlocked_fd = checkedfd.read();
         if let Some(filedesc_enum) = &*unlocked_fd {
             if let Socket(sockfdobj) = filedesc_enum {
                 //if the socket is not connected, then we should return an error
@@ -1388,8 +1388,8 @@ impl Cage {
     }
 
     pub fn getsockname_syscall(&self, fd: i32, ret_addr: &mut interface::GenSockaddr) -> i32 {
-        let tmp = self.get_filedescriptor(fd).unwrap();
-        let unlocked_fd = tmp.read();
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        let unlocked_fd = checkedfd.read();
         if let Some(filedesc_enum) = &*unlocked_fd {
             if let Socket(sockfdobj) = filedesc_enum {
                 let sock_tmp = sockfdobj.handle.clone();
@@ -1519,14 +1519,14 @@ impl Cage {
     pub fn epoll_ctl_syscall(&self, epfd: i32, op: i32, fd: i32, event: &EpollEvent) -> i32 {
 
         //making sure that the epfd is really an epoll fd
-        let tmp = self.get_filedescriptor(epfd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(epfd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum_epollfd) = &mut *unlocked_fd {
             if let Epoll(epollfdobj) = filedesc_enum_epollfd {
 
                 //check if the other fd is an epoll or not...
-                let tmp = self.get_filedescriptor(fd).unwrap();
-                let unlocked_fd = tmp.read();
+                let checkedfd = self.get_filedescriptor(fd).unwrap();
+                let unlocked_fd = checkedfd.read();
                 if let Some(filedesc_enum) = &*unlocked_fd {
                     if let Epoll(_) = filedesc_enum {
                         return syscall_error(Errno::EBADF, "epoll ctl", "provided fd is not a valid file descriptor")
@@ -1568,8 +1568,8 @@ impl Cage {
     }
 
     pub fn epoll_wait_syscall(&self, epfd: i32, events: &mut [EpollEvent], maxevents: i32, timeout: Option<interface::RustDuration>) -> i32 {
-        let tmp = self.get_filedescriptor(epfd).unwrap();
-        let mut unlocked_fd = tmp.write();
+        let checkedfd = self.get_filedescriptor(epfd).unwrap();
+        let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
             if let Epoll(epollfdobj) = filedesc_enum {
                 if  maxevents <  0 {

--- a/src/safeposix/syscalls/sys_calls.rs
+++ b/src/safeposix/syscalls/sys_calls.rs
@@ -79,7 +79,8 @@ impl Cage {
         //construct new cage struct with a cloned fdtable
         let newfdtable = init_fdtable();
         for fd in 0..MAXFD {
-            let unlocked_fd = self.filedescriptortable[fd as usize].read();
+            let tmp = self.get_filedescriptor(fd).unwrap();
+            let unlocked_fd = tmp.read();
             if let Some(filedesc_enum) = &*unlocked_fd {
                 match filedesc_enum {
                     File(_normalfile_filedesc_obj) => {
@@ -158,7 +159,8 @@ impl Cage {
 
         let mut cloexecvec = vec!();
         for fd in 0..MAXFD {
-            let unlocked_fd = self.filedescriptortable[fd as usize].read();
+            let tmp = self.get_filedescriptor(fd).unwrap();
+            let unlocked_fd = tmp.read();
             if let Some(filedesc_enum) = &*unlocked_fd {
                 if match filedesc_enum {
                     File(f) => f.flags & O_CLOEXEC,

--- a/src/safeposix/syscalls/sys_calls.rs
+++ b/src/safeposix/syscalls/sys_calls.rs
@@ -79,8 +79,8 @@ impl Cage {
         //construct new cage struct with a cloned fdtable
         let newfdtable = init_fdtable();
         for fd in 0..MAXFD {
-            let tmp = self.get_filedescriptor(fd).unwrap();
-            let unlocked_fd = tmp.read();
+            let checkedfd = self.get_filedescriptor(fd).unwrap();
+            let unlocked_fd = checkedfd.read();
             if let Some(filedesc_enum) = &*unlocked_fd {
                 match filedesc_enum {
                     File(_normalfile_filedesc_obj) => {
@@ -159,8 +159,8 @@ impl Cage {
 
         let mut cloexecvec = vec!();
         for fd in 0..MAXFD {
-            let tmp = self.get_filedescriptor(fd).unwrap();
-            let unlocked_fd = tmp.read();
+            let checkedfd = self.get_filedescriptor(fd).unwrap();
+            let unlocked_fd = checkedfd.read();
             if let Some(filedesc_enum) = &*unlocked_fd {
                 if match filedesc_enum {
                     File(f) => f.flags & O_CLOEXEC,


### PR DESCRIPTION
## Description

Fixes [#317](https://github.com/Lind-Project/lind_project/issues/317)

<!-- Please include a summary of the changes and the related issue. --> 
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

### Type of change

Found a bug when fixing libc errno returns: safeposix didn't have boundary check for file descriptors. Then, when users don't initialize fd, it will cause error since the value of the variable would depend on random data in memory.

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

- `make test` under /lind_project
- `cargo test --lib` under /lind_project/src/safeposix-rust

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
