### PR TITLE
Refactor implementation of RustSemaphore

### DIFF
--- a/src/interface/misc.rs
+++ b/src/interface/misc.rs
@@ -391,17 +391,18 @@ impl RustSemaphore {
             let mut value = self.value.lock();
             if *value == 0 {
                 interface::lind_yield();
-                continue;
+            } else {
+                *value = if *value > 0 { *value - 1 } else { 0 };
             }
-                
-            *value = if *value > 0 { *value - 1 } else { 0 };
-            break;
         }
     }
 
-    pub fn unlock(&self) {
+    pub fn unlock(&self) -> bool {
         let mut value = self.value.lock();
-        *value = if *value < (SEM_VALUE_MAX - 1) { *value + 1 } else { SEM_VALUE_MAX };
+        if *value < SEM_VALUE_MAX {
+            *value = *value + 1;
+            return true;
+        } else { return false; }
     }
 
     pub fn get_value(&self) -> i32 {
@@ -412,10 +413,10 @@ impl RustSemaphore {
         let mut value = self.value.lock();
         if *value == 0 {
             return false;
+        } else {
+            *value = if *value > 0 { *value - 1 } else { 0 };
+            return true;
         }
-
-        *value = if *value > 0 { *value - 1 } else { 0 };
-        return true;
     }
 
     pub fn timedlock(&self, timeout: Duration) -> bool {
@@ -428,11 +429,10 @@ impl RustSemaphore {
                     return false;
                 }
                 interface::lind_yield();
-                continue;
+            } else {
+                *value = if *value > 0 { *value - 1 } else { 0 };
+                return true;
             }
-
-            *value = if *value > 0 { *value - 1 } else { 0 };
-            return true;
         }
     }
 }

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2490,9 +2490,7 @@ impl Cage {
         let semtable = &self.sem_table;
         // Check whether semaphore exists
         if let Some(semaphore) = semtable.get_mut(&sem_handle) {
-            if !semaphore.lock() {
-                return syscall_error(Errno::EINVAL, "sem_wait", "sem wait failed");
-            }
+            semaphore.lock();
         } else {
             return syscall_error(Errno::EINVAL, "sem_wait", "sem is not a valid semaphore");
         }
@@ -2502,10 +2500,8 @@ impl Cage {
     pub fn sem_post_syscall(&self, sem_handle: u32) -> i32 {
         let semtable = &self.sem_table;
         if let Some(semaphore) = semtable.get_mut(&sem_handle) {
-            if !semaphore.unlock() {
-                return syscall_error(Errno::EOVERFLOW, "sem_post", "The maximum allowable value for a semaphore would be exceeded");
-            }
-         }else {
+            semaphore.unlock();
+         } else {
             return syscall_error(Errno::EINVAL, "sem_wait", "sem is not a valid semaphore");
         }
         return 0;

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2500,7 +2500,9 @@ impl Cage {
     pub fn sem_post_syscall(&self, sem_handle: u32) -> i32 {
         let semtable = &self.sem_table;
         if let Some(semaphore) = semtable.get_mut(&sem_handle) {
-            semaphore.unlock();
+            if !semaphore.unlock() {
+                return syscall_error(Errno::EOVERFLOW, "sem_post", "The maximum allowable value for a semaphore would be exceeded");
+            }
          } else {
             return syscall_error(Errno::EINVAL, "sem_wait", "sem is not a valid semaphore");
         }


### PR DESCRIPTION
## Description

Fixes https://github.com/Lind-Project/lind_project/issues/321

<!-- Please include a summary of the changes and the related issue. --> 
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->
Refactored the implementation of RustSemaphore struct because previously it was using `Atomicu32` to store the value variable but it was causing a [Time-of-check to time-of-use](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use) bug. If there were 2 processes waiting for the lock and a 3rd process released the lock then in such scenarios both the processes that were waiting used to get the lock which shouldn't be happening. 

This bug was fixed by using `Mutex<u32>` instead of `Atomicu32` making sure that only one thread/process can read/update the value of the variable at any given time.

### Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

- `lind_project/tests/test_cases/coreutils_suite/shm_sem_t.sh`
- `lind_project/tests/test_cases/coreutils_suite/shm_sem_fork_t.sh`

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
