### PR TITLE
Fix semaphore fork deadlock

### DIFF
--- a/src/safeposix/syscalls/sys_calls.rs
+++ b/src/safeposix/syscalls/sys_calls.rs
@@ -160,7 +160,8 @@ impl Cage {
             let mut shment = shmtable.get_mut(&rev_mapping.1).unwrap();
             shment.shminfo.shm_nattch += 1;
             let refs = shment.attached_cages.get(&self.cageid).unwrap();
-            shment.attached_cages.insert(child_cageid, *refs);
+            let childrefs = *refs;
+            shment.attached_cages.insert(child_cageid, childrefs);
         }
         drop(shmtable);
         interface::cagetable_insert(child_cageid, cageobj);


### PR DESCRIPTION
## Description

Fixes # (issue)

This fixes an issue where fork would deadlock when duplicating multiply referenced semaphores

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Fixes pgbench
Test suite

## Checklist:

- [ x] My code follows the style guidelines of this project
- [x ] My changes generate no new warnings
