### PR TITLE
Semaphore clone for threads

### DIFF
--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2491,6 +2491,7 @@ impl Cage {
         // Check whether semaphore exists
         if let Some(sementry) = semtable.get_mut(&sem_handle) {
             let semaphore = sementry.clone();
+            drop(sementry);
             semaphore.lock();
         } else {
             return syscall_error(Errno::EINVAL, "sem_wait", "sem is not a valid semaphore");
@@ -2502,6 +2503,7 @@ impl Cage {
         let semtable = &self.sem_table;
         if let Some(sementry) = semtable.get_mut(&sem_handle) {
             let semaphore = sementry.clone();
+            drop(sementry);
             if !semaphore.unlock() {
                 return syscall_error(Errno::EOVERFLOW, "sem_post", "The maximum allowable value for a semaphore would be exceeded");
             }
@@ -2546,6 +2548,7 @@ impl Cage {
         let semtable = &self.sem_table;
         if let Some(sementry) = semtable.get_mut(&sem_handle) {
             let semaphore = sementry.clone();
+            drop(sementry);
             return semaphore.get_value();
         }
         return syscall_error(Errno::EINVAL, "sem_getvalue", "sem is not a valid semaphore")
@@ -2556,6 +2559,7 @@ impl Cage {
         // Check whether semaphore exists
         if let Some(sementry) = semtable.get_mut(&sem_handle) {
             let semaphore = sementry.clone();
+            drop(sementry);
             if !semaphore.trylock() {
                 return syscall_error(Errno::EAGAIN, "sem_trywait", "The operation could not be performed without blocking");
             }
@@ -2577,6 +2581,7 @@ impl Cage {
         // Check whether semaphore exists
         if let Some(sementry) = semtable.get_mut(&sem_handle) {
             let semaphore = sementry.clone();
+            drop(sementry);
             if !semaphore.timedlock(time) {
                 return syscall_error(Errno::ETIMEDOUT, "sem_timedwait", "The call timed out before the semaphore could be locked");
             }

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2489,7 +2489,8 @@ impl Cage {
     pub fn sem_wait_syscall(&self, sem_handle: u32) -> i32 {
         let semtable = &self.sem_table;
         // Check whether semaphore exists
-        if let Some(semaphore) = semtable.get_mut(&sem_handle) {
+        if let Some(sementry) = semtable.get_mut(&sem_handle) {
+            let semaphore = sementry.clone();
             semaphore.lock();
         } else {
             return syscall_error(Errno::EINVAL, "sem_wait", "sem is not a valid semaphore");
@@ -2499,7 +2500,8 @@ impl Cage {
 
     pub fn sem_post_syscall(&self, sem_handle: u32) -> i32 {
         let semtable = &self.sem_table;
-        if let Some(semaphore) = semtable.get_mut(&sem_handle) {
+        if let Some(sementry) = semtable.get_mut(&sem_handle) {
+            let semaphore = sementry.clone();
             if !semaphore.unlock() {
                 return syscall_error(Errno::EOVERFLOW, "sem_post", "The maximum allowable value for a semaphore would be exceeded");
             }
@@ -2542,7 +2544,8 @@ impl Cage {
     */
     pub fn sem_getvalue_syscall(&self, sem_handle: u32) -> i32 {
         let semtable = &self.sem_table;
-        if let Some(semaphore) = semtable.get_mut(&sem_handle) {
+        if let Some(sementry) = semtable.get_mut(&sem_handle) {
+            let semaphore = sementry.clone();
             return semaphore.get_value();
         }
         return syscall_error(Errno::EINVAL, "sem_getvalue", "sem is not a valid semaphore")
@@ -2551,7 +2554,8 @@ impl Cage {
     pub fn sem_trywait_syscall(&self, sem_handle: u32) -> i32 {
         let semtable = &self.sem_table;
         // Check whether semaphore exists
-        if let Some(semaphore) = semtable.get_mut(&sem_handle) {
+        if let Some(sementry) = semtable.get_mut(&sem_handle) {
+            let semaphore = sementry.clone();
             if !semaphore.trylock() {
                 return syscall_error(Errno::EAGAIN, "sem_trywait", "The operation could not be performed without blocking");
             }
@@ -2571,7 +2575,8 @@ impl Cage {
         }
         let semtable = &self.sem_table;
         // Check whether semaphore exists
-        if let Some(semaphore) = semtable.get_mut(&sem_handle) {
+        if let Some(sementry) = semtable.get_mut(&sem_handle) {
+            let semaphore = sementry.clone();
             if !semaphore.timedlock(time) {
                 return syscall_error(Errno::ETIMEDOUT, "sem_timedwait", "The call timed out before the semaphore could be locked");
             }


### PR DESCRIPTION
## Description

Fixes a deadlock issue in threaded programs with semaphores trying to lock/unlock from the same table. We clone the semaphores to avoid the dashmap deadlock.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran rust test suite and tested python program where deadlock occured.

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
