### PR TITLE
Modify a argument of dup2_helper and dup syscalls

### DIFF
--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1107,13 +1107,11 @@ impl Cage {
             None => STARTINGFD,
         };
 
-        if start_fd == fd { return start_fd; } //if the file descriptors are equal (which is not plausible here), return
-
         // get the filedesc_enum
         let checkedfd = self.get_filedescriptor(fd).unwrap();
         let filedesc_enum = checkedfd.write();
         let filedesc_enum = if let Some(f) = &*filedesc_enum {f} else {
-            return syscall_error(Errno::EBADF, "dup2","Invalid old file descriptor.");
+            return syscall_error(Errno::EBADF, "dup","Invalid old file descriptor.");
         };
 
         //checking whether the fd exists in the file table
@@ -1123,7 +1121,7 @@ impl Cage {
     pub fn dup2_syscall(&self, oldfd: i32, newfd: i32) -> i32{
         //checking if the new fd is out of range
         if newfd >= MAXFD || newfd < 0 {
-           return syscall_error(Errno::EBADF, "dup or dup2", "provided file descriptor is out of range");
+           return syscall_error(Errno::EBADF, "dup2", "provided file descriptor is out of range");
        }
 
        if newfd == oldfd { return newfd; } //if the file descriptors are equal, return the new one

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1409,7 +1409,6 @@ impl Cage {
                     0
                 }
                 (F_DUPFD, arg) if arg >= 0 => {
-                    drop(filedesc_enum);
                     self._dup2_helper(&filedesc_enum, arg, false)
                 }
                 //TO DO: implement. this one is saying get the signals

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1107,29 +1107,40 @@ impl Cage {
             None => STARTINGFD,
         };
 
-        //checking whether the fd exists in the file table
-        return Self::_dup2_helper(&self, fd, start_fd, false)
-    }
+        if start_fd == fd { return start_fd; } //if the file descriptors are equal (which is not plausible here), return
 
-    pub fn dup2_syscall(&self, oldfd: i32, newfd: i32) -> i32{
-        //if the old fd exists, execute the helper, else return error
-        return Self::_dup2_helper(&self, oldfd, newfd, true);
-    }
-
-    pub fn _dup2_helper(&self, oldfd: i32, newfd: i32, fromdup2: bool) -> i32 {
-        //checking if the new fd is out of range
-        if newfd >= MAXFD || newfd < 0 {
-            return syscall_error(Errno::EBADF, "dup or dup2", "provided file descriptor is out of range");
-        }
-
-        let checkedfd = self.get_filedescriptor(oldfd).unwrap();
+        // get the filedesc_enum
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
         let filedesc_enum = checkedfd.write();
         let filedesc_enum = if let Some(f) = &*filedesc_enum {f} else {
             return syscall_error(Errno::EBADF, "dup2","Invalid old file descriptor.");
         };
 
+        //checking whether the fd exists in the file table
+        return Self::_dup2_helper(&self, filedesc_enum, start_fd, false)
+    }
+
+    pub fn dup2_syscall(&self, oldfd: i32, newfd: i32) -> i32{
+        //checking if the new fd is out of range
+        if newfd >= MAXFD || newfd < 0 {
+           return syscall_error(Errno::EBADF, "dup or dup2", "provided file descriptor is out of range");
+       }
+
+       if newfd == oldfd { return newfd; } //if the file descriptors are equal, return the new one
+
+       // get the filedesc_enum
+       let checkedfd = self.get_filedescriptor(oldfd).unwrap();
+       let filedesc_enum = checkedfd.write();
+       let filedesc_enum = if let Some(f) = &*filedesc_enum {f} else {
+           return syscall_error(Errno::EBADF, "dup2","Invalid old file descriptor.");
+       };
+
+       //if the old fd exists, execute the helper, else return error
+       return Self::_dup2_helper(&self, filedesc_enum, newfd, true);
+   }
+
+    pub fn _dup2_helper(&self, filedesc_enum: &FileDescriptor, newfd: i32, fromdup2: bool) -> i32 {
         let (dupfd, mut dupfdguard) = if fromdup2 {
-            if newfd == oldfd { return newfd; } //if the file descriptors are equal, return the new one
             let mut fdguard = self.filedescriptortable[newfd as usize].write();
             if fdguard.is_some() {
                 drop(fdguard);
@@ -1399,7 +1410,7 @@ impl Cage {
                 }
                 (F_DUPFD, arg) if arg >= 0 => {
                     drop(filedesc_enum);
-                    self._dup2_helper(fd, arg, false)
+                    self._dup2_helper(&filedesc_enum, arg, false)
                 }
                 //TO DO: implement. this one is saying get the signals
                 (F_GETOWN, ..) => {

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1146,7 +1146,7 @@ impl Cage {
                 drop(fdguard);
                 //close the fd in the way of the new fd. If an error is returned from the helper, return the error, else continue to end
                 let close_result = Self::_close_helper_inner(&self, newfd);
-                // mirror the implementation of linxu, ignore the potential error of the close here
+                // mirror the implementation of linux, ignore the potential error of the close here
             } else { drop(fdguard); }
             fdguard = self.filedescriptortable[newfd as usize].write();
 

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1107,6 +1107,8 @@ impl Cage {
             None => STARTINGFD,
         };
 
+        if start_fd == fd { return start_fd; } //if the file descriptors are equal, return the new one
+
         // get the filedesc_enum
         let checkedfd = self.get_filedescriptor(fd).unwrap();
         let filedesc_enum = checkedfd.write();
@@ -1144,9 +1146,7 @@ impl Cage {
                 drop(fdguard);
                 //close the fd in the way of the new fd. If an error is returned from the helper, return the error, else continue to end
                 let close_result = Self::_close_helper_inner(&self, newfd);
-                if close_result < 0 {
-                    return close_result;
-                }
+                // mirror the implementation of linxu, ignore the potential error of the close here
             } else { drop(fdguard); }
             fdguard = self.filedescriptortable[newfd as usize].write();
 


### PR DESCRIPTION
## Description
the edits are quite simple, I just moved the bound checking, checking if old = new, and the code of getting the filedesc_enum into both dup_syscall and dup2_syscall, so that now dup2_helper just accept the filedesc_enum as a parameter instead of the oldfd

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
