### PR TITLE
Hashset to bitmap

### DIFF
--- a/src/interface/types.rs
+++ b/src/interface/types.rs
@@ -397,6 +397,18 @@ pub fn fd_set_to_hashset(union_argument: Arg, nfds: i32) -> Result<interface::Ru
     }
     return Ok(hashset);
 }
+// I don't want everything to assume the size of fd_set is 1024 bits, so this
+// helper function will check up to the byte of the highest fd given by nfds
+pub fn is_fd_set_empty(fdset: *const u8, highest_fd: i32) -> bool {
+    let nbytes = (highest_fd as usize + 7) / 8;
+    for i in 0..nbytes {
+        unsafe {
+            if *fdset.add(i) != 0 {return false;}
+        }
+    }
+    return true;
+}
+
 pub fn copy_out_to_fd_set(union_argument: Arg, nfds: i32, hashset: interface::RustHashSet<i32>) {
     let pointer = unsafe{union_argument.dispatch_mutcbuf};
     if pointer.is_null() {return;} //do nothing if it's null

--- a/src/interface/types.rs
+++ b/src/interface/types.rs
@@ -238,6 +238,7 @@ pub fn get_mutcbuf(union_argument: Arg) -> Result<*mut u8, i32> {
     return Err(syscall_error(Errno::EFAULT, "dispatcher", "input data not valid"));
 }
 
+// for the case where the buffer pointer being Null is normal
 pub fn get_mutcbuf_null(union_argument: Arg) -> Result<*mut u8, i32> {
     return Ok (unsafe{union_argument.dispatch_mutcbuf});
 }

--- a/src/interface/types.rs
+++ b/src/interface/types.rs
@@ -383,7 +383,7 @@ pub fn get_sockpair<'a>(union_argument: Arg) -> Result<&'a mut SockPair, i32> {
     return Err(syscall_error(Errno::EFAULT, "dispatcher", "input data not valid"));
 }
 
-// turn off the fd bit in fd_set
+// turn on the fd bit in fd_set
 pub fn fd_set_set(fd_set: *mut u8, fd: i32) {
     let byte_offset = fd / 8;
     let byte_ptr = fd_set.wrapping_offset(byte_offset as isize);
@@ -391,7 +391,7 @@ pub fn fd_set_set(fd_set: *mut u8, fd: i32) {
     unsafe{*byte_ptr |= 1 << bit_offset;}
 }
 
-// turn on the fd bit in fd_set
+// turn off the fd bit in fd_set
 pub fn fd_set_unset(fd_set: *mut u8, fd: i32) {
     let byte_offset = fd / 8;
     let byte_ptr = fd_set.wrapping_offset(byte_offset as isize);
@@ -404,7 +404,7 @@ pub fn fd_set_check_fd(fd_set: *const u8, fd: i32) -> bool {
     let byte_offset = fd / 8;
     let byte_ptr = fd_set.wrapping_offset(byte_offset as isize);
     let bit_offset = fd & 0b111;
-    return (unsafe{*byte_ptr}) & (1 << bit_offset) == 0;
+    return (unsafe{*byte_ptr}) & (1 << bit_offset) != 0;
 }
 
 // I don't want everything to assume the size of fd_set is 1024 bits, so this

--- a/src/interface/types.rs
+++ b/src/interface/types.rs
@@ -172,7 +172,6 @@ pub union Arg {
 
 
 use std::mem::size_of;
-use std::ptr::null;
 
 // Represents a Dirent struct without the string, as rust has no flexible array member support
 #[repr(C, packed(1))]
@@ -413,7 +412,7 @@ pub fn fd_set_check_fd(fd_set: *const u8, fd: i32) -> bool {
     return (unsafe{*byte_ptr}) & (1 << bit_offset) != 0;
 }
 
-// I don't want everything to assume the size of fd_set is 1024 bits, so this
+// We don't want everything to assume the size of fd_set is 1024 bits, so this
 // helper function will check up to the byte of the highest fd given by nfds
 pub fn fd_set_is_empty(fd_set: *const u8, highest_fd: i32) -> bool {
     let nbytes = (highest_fd as usize + 7) / 8;

--- a/src/safeposix/dispatcher.rs
+++ b/src/safeposix/dispatcher.rs
@@ -352,15 +352,10 @@ pub extern "C" fn dispatcher(cageid: u64, callnum: i32, arg1: Arg, arg2: Arg, ar
             if nfds < 0 { //RLIMIT_NOFILE check as well?
                 return syscall_error(Errno::EINVAL, "select", "The number of fds passed was invalid");
             } else if nfds > 1024 {
-                return syscall_error(Errno::EINVAL, "select", "Number of fds can't exceed 1024");
+                return syscall_error(Errno::EOPNOTSUPP, "select", "Select only support fd number below 1024");
             }
 
-            // we don't use get_mutcbuf here because the pointers might be null
-            let readfds = unsafe{arg2.dispatch_mutcbuf};
-            let writefds = unsafe{arg3.dispatch_mutcbuf};
-            let exceptfds = unsafe{arg4.dispatch_mutcbuf};
-
-            check_and_dispatch!(cage.select_syscall, Ok::<i32, i32>(nfds), Ok::<*mut u8, i32>(readfds), Ok::<*mut u8, i32>(writefds), Ok::<*mut u8, i32>(exceptfds), interface::duration_fromtimeval(arg5))
+            check_and_dispatch!(cage.select_syscall, Ok::<i32, i32>(nfds), interface::get_mutcbuf_null(arg2), interface::get_mutcbuf_null(arg3), interface::get_mutcbuf_null(arg4), interface::duration_fromtimeval(arg5))
         }
         POLL_SYSCALL => {
             let nfds = get_onearg!(interface::get_usize(arg2));

--- a/src/safeposix/dispatcher.rs
+++ b/src/safeposix/dispatcher.rs
@@ -356,9 +356,9 @@ pub extern "C" fn dispatcher(cageid: u64, callnum: i32, arg1: Arg, arg2: Arg, ar
             }
 
             // we don't use get_mutcbuf here because the pointers might be null
-            let mut readfds = unsafe{arg2.dispatch_mutcbuf};
-            let mut writefds = unsafe{arg3.dispatch_mutcbuf};
-            let mut exceptfds = unsafe{arg4.dispatch_mutcbuf};
+            let readfds = unsafe{arg2.dispatch_mutcbuf};
+            let writefds = unsafe{arg3.dispatch_mutcbuf};
+            let exceptfds = unsafe{arg4.dispatch_mutcbuf};
 
             check_and_dispatch!(cage.select_syscall, Ok::<i32, i32>(nfds), Ok::<*mut u8, i32>(readfds), Ok::<*mut u8, i32>(writefds), Ok::<*mut u8, i32>(exceptfds), interface::duration_fromtimeval(arg5))
         }

--- a/src/safeposix/dispatcher.rs
+++ b/src/safeposix/dispatcher.rs
@@ -351,10 +351,7 @@ pub extern "C" fn dispatcher(cageid: u64, callnum: i32, arg1: Arg, arg2: Arg, ar
             let nfds = get_onearg!(interface::get_int(arg1));
             if nfds < 0 { //RLIMIT_NOFILE check as well?
                 return syscall_error(Errno::EINVAL, "select", "The number of fds passed was invalid");
-            } else if nfds > interface::FD_SET_SIZE {
-                return syscall_error(Errno::EOPNOTSUPP, "select", "Select only support fd number below 1024");
-            }
-
+            } 
             check_and_dispatch!(cage.select_syscall, Ok::<i32, i32>(nfds), interface::get_mutcbuf_null(arg2), interface::get_mutcbuf_null(arg3), interface::get_mutcbuf_null(arg4), interface::duration_fromtimeval(arg5))
         }
         POLL_SYSCALL => {

--- a/src/safeposix/dispatcher.rs
+++ b/src/safeposix/dispatcher.rs
@@ -102,7 +102,7 @@ const GETIFADDRS_SYSCALL: i32 = 146;
 
 const FCHDIR_SYSCALL: i32 = 161;
 
-use crate::interface::{self, get_mutcbuf};
+use crate::interface;
 use super::cage::*;
 use super::filesystem::{FS_METADATA, load_fs, incref_root, remove_domain_sock, persist_metadata, LOGMAP, LOGFILENAME, FilesystemMetadata};
 use super::shm::{SHM_METADATA};
@@ -351,7 +351,7 @@ pub extern "C" fn dispatcher(cageid: u64, callnum: i32, arg1: Arg, arg2: Arg, ar
             let nfds = get_onearg!(interface::get_int(arg1));
             if nfds < 0 { //RLIMIT_NOFILE check as well?
                 return syscall_error(Errno::EINVAL, "select", "The number of fds passed was invalid");
-            } else if nfds > 1024 {
+            } else if nfds > interface::FD_SET_SIZE {
                 return syscall_error(Errno::EOPNOTSUPP, "select", "Select only support fd number below 1024");
             }
 

--- a/src/safeposix/dispatcher.rs
+++ b/src/safeposix/dispatcher.rs
@@ -360,7 +360,7 @@ pub extern "C" fn dispatcher(cageid: u64, callnum: i32, arg1: Arg, arg2: Arg, ar
             let mut writefds = unsafe{arg3.dispatch_mutcbuf};
             let mut exceptfds = unsafe{arg4.dispatch_mutcbuf};
 
-            check_and_dispatch!(cage.select_syscall, nfds, readfds, writefds, exceptfds, interface::duration_fromtimeval(arg5))
+            check_and_dispatch!(cage.select_syscall, Ok::<i32, i32>(nfds), Ok::<*mut u8, i32>(readfds), Ok::<*mut u8, i32>(writefds), Ok::<*mut u8, i32>(exceptfds), interface::duration_fromtimeval(arg5))
         }
         POLL_SYSCALL => {
             let nfds = get_onearg!(interface::get_usize(arg2));

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -1272,7 +1272,6 @@ impl Cage {
             if !interface::fd_set_check_fd(readfds, fd) {continue}
             let mut readable = false;
 
-
             let checkedfd = self.get_filedescriptor(fd).unwrap();
             let mut unlocked_fd = checkedfd.write();
             if let Some(filedesc_enum) = &mut *unlocked_fd {
@@ -1717,6 +1716,7 @@ impl Cage {
                 let fd = structpoll.fd;
                 let events = structpoll.events;
 
+                // allocate spaces for fd_set bitmaps
                 let mut reads_chunk: [u8; 128] = [0; 128];
                 let mut writes_chunk: [u8; 128] = [0; 128];
                 let mut errors_chunk: [u8; 128] = [0; 128];

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -1759,8 +1759,8 @@ impl Cage {
                 // NOTE that the nfds argument is highest fd + 1
                 if Self::select_syscall(&self, fd + 1, reads, writes, errors, Some(interface::RustDuration::ZERO)) > 0 {
                     mask += if !interface::is_fd_set_empty(reads, fd) {POLLIN} else {0};
-                    mask += if !interface::is_fd_set_empty(reads, fd) {POLLOUT} else {0};
-                    mask += if !interface::is_fd_set_empty(reads, fd) {POLLERR} else {0};
+                    mask += if !interface::is_fd_set_empty(writes, fd) {POLLOUT} else {0};
+                    mask += if !interface::is_fd_set_empty(errors, fd) {POLLERR} else {0};
                     return_code += 1;
                 }
                 structpoll.revents = mask;

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -1325,7 +1325,7 @@ impl Cage {
                                         } else {
                                             // if it returned an error, then don't insert it into new_readfds
                                             // of course unset the bit explicitly before we continue
-                                            interface::fd_set_unset(readfds, fd);
+                                            interface::fd_set_remove(readfds, fd);
                                             continue;
                                         }
                                     } //if it's already got a pending connection, add it!
@@ -1377,7 +1377,7 @@ impl Cage {
             }
             // if it is readable, leave the bit there, otherwise turn it off
             if !readable {
-                interface::fd_set_unset(readfds, fd)
+                interface::fd_set_remove(readfds, fd)
             }
         }
         return 0;
@@ -1442,7 +1442,7 @@ impl Cage {
             }
             // if fd is writable, leave the bit there, otherwise turn it off
             if !writable {
-                interface::fd_set_unset(writefds, fd)
+                interface::fd_set_remove(writefds, fd)
             }
         }
         return 0;
@@ -1726,11 +1726,11 @@ impl Cage {
                 let errors: *mut u8 = errors_chunk.as_mut_ptr();
 
                 //read
-                if events & POLLIN > 0 {interface::fd_set_set(reads, fd)}
+                if events & POLLIN > 0 {interface::fd_set_insert(reads, fd)}
                 //write
-                if events & POLLOUT > 0 {interface::fd_set_set(writes, fd)}
+                if events & POLLOUT > 0 {interface::fd_set_insert(writes, fd)}
                 //err
-                if events & POLLERR > 0 {interface::fd_set_set(errors, fd)}
+                if events & POLLERR > 0 {interface::fd_set_insert(errors, fd)}
 
                 let mut mask: i16 = 0;
 

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -1333,8 +1333,10 @@ impl Cage {
                                             //save the pending connection for accept to do something with it
                                             vacant.insert(vec!(listeningsocket));
                                         } else {
-                                            //if it returned an error, then don't insert it into new_readfds
-                                        continue;
+                                            // if it returned an error, then don't insert it into new_readfds
+                                            // of course unset the bit explicitly before we continue
+                                            unsafe{*byte_ptr &= !(1 << bit_offset);}
+                                            continue;
                                         }
                                     } //if it's already got a pending connection, add it!
 

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -1218,7 +1218,7 @@ impl Cage {
     }
 
     pub fn select_syscall(&self, nfds: i32, readfds: *mut u8, writefds: *mut u8, exceptfds: *mut u8, timeout: Option<interface::RustDuration>) -> i32 {
-        
+
        if nfds < STARTINGFD || nfds >= MAXFD {
            return syscall_error(Errno::EINVAL, "select", "Number of FDs is wrong");
        }
@@ -1254,7 +1254,7 @@ impl Cage {
                     let byte_ptr = exceptfds.wrapping_offset(byte_offset as isize);
                     let bit_offset = i & 0b111;
                     // find the bit and see if it's on
-                    if (unsafe{*byte_ptr}) & (1 << (i / 8)) == 0 {continue}
+                    if (unsafe{*byte_ptr}) & (1 << bit_offset) == 0 {continue}
                     let fd = i;
                     let checkedfd = self.get_filedescriptor(fd).unwrap();
                     let unlocked_fd = checkedfd.read();

--- a/src/safeposix/syscalls/net_constants.rs
+++ b/src/safeposix/syscalls/net_constants.rs
@@ -383,6 +383,8 @@ pub const EPOLL_CTL_ADD: i32 = 1;
 pub const EPOLL_CTL_DEL: i32 = 2;
 pub const EPOLL_CTL_MOD: i32 = 3;
 
+pub const FD_SET_SIZE :i32 = 1024;
+
 //for internal use
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum ConnState {

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -703,7 +703,7 @@ pub mod net_tests {
         let fds_to_set = [serversockfd, filefd];
         for fd in &fds_to_set {
             let byte_offset = *fd as usize / 8;
-            let bit_offset = (*fd % 8) as u8;
+            let bit_offset = *fd & 0b111;
             let input_byte_ptr = unsafe {inputs.add(byte_offset)};
             unsafe {
                 let input_byte_ptr = inputs.add(byte_offset);
@@ -712,7 +712,7 @@ pub mod net_tests {
         }       
        
         let byte_offset = filefd as usize / 8;
-        let bit_offset = (filefd % 8) as u8;
+        let bit_offset = filefd & 0b111;
         unsafe {
             let output_byte_ptr = outputs.add(byte_offset);
             *output_byte_ptr |= 1 << bit_offset;
@@ -792,7 +792,7 @@ pub mod net_tests {
                         let sockfd = cage.accept_syscall(sock as i32, &mut sockgarbage); //really can only make sure that the fd is valid
                         assert!(sockfd > 0); 
                         let byte_offset = sockfd as usize / 8;
-                        let bit_offset = (sockfd % 8) as u8;
+                        let bit_offset = sockfd & 0b111;
                         let input_byte_ptr = unsafe {inputs.add(byte_offset)};
                         let output_byte_ptr = unsafe {outputs.add(byte_offset)};
                         unsafe {
@@ -804,7 +804,7 @@ pub mod net_tests {
                         assert_eq!(cage.write_syscall(sock as i32, str2cbuf("test"), 4), 4);
                         assert_eq!(cage.lseek_syscall(sock as i32, 0, SEEK_SET), 0);
                         let byte_offset = sock as usize / 8;
-                        let bit_offset = (sock % 8) as u8;
+                        let bit_offset = sock & 0b111;
                         unsafe {
                              let input_byte_ptr = inputs.add(byte_offset);
                             *input_byte_ptr &= !(1 << bit_offset);
@@ -821,7 +821,7 @@ pub mod net_tests {
                         if recvresult == 4 {
                             if cbuf2str(&buf) == "test" {
                                 let byte_offset = sock as usize / 8;
-                                let bit_offset = (sock % 8) as u8;
+                                let bit_offset = sock & 0b111;
                                 let output_byte_ptr = unsafe {outputs.add(byte_offset)};
                                 unsafe {
                                     *output_byte_ptr |= 1 << bit_offset;                   
@@ -833,7 +833,7 @@ pub mod net_tests {
                         }
                         assert_eq!(cage.close_syscall(sock as i32), 0);
                         let byte_offset = sock as usize / 8;
-                        let bit_offset = (sock % 8) as u8;
+                        let bit_offset = sock & 0b111;
                         let input_byte_ptr = unsafe {inputs.add(byte_offset)};
                         unsafe {
                             *input_byte_ptr &= !(1 << bit_offset);
@@ -855,7 +855,7 @@ pub mod net_tests {
                         assert_eq!(cage.read_syscall(sock as i32, buf.as_mut_ptr(), 4), 4);
                         assert_eq!(cbuf2str(&buf), "test");
                         let byte_offset = sock as usize / 8;
-                        let bit_offset = (sock % 8) as u8;
+                        let bit_offset = sock & 0b111;
                         let output_byte_ptr = unsafe {inputs.add(byte_offset)};
                         unsafe {
                             *output_byte_ptr &= !(1 << bit_offset);
@@ -863,7 +863,7 @@ pub mod net_tests {
                     } else { //Data is sent out this socket, it's no longer ready for writing remove this socket from writefd's.
                         assert_eq!(cage.send_syscall(sock as i32, str2cbuf("test"), 4, 0), 4);
                         let byte_offset = sock as usize / 8;
-                        let bit_offset = (sock % 8) as u8;
+                        let bit_offset = sock & 0b111;
                         let output_byte_ptr = unsafe {inputs.add(byte_offset)};
                         unsafe {   
                             *output_byte_ptr &= !(1 << bit_offset);

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 pub mod net_tests {
-    use crate::interface::{self, fd_set_check_fd, fd_set_insert, fd_set_remove};
+    use crate::interface;
     use crate::safeposix::{cage::*, dispatcher::*, filesystem};
     use super::super::*;
     use std::mem::size_of;
@@ -714,7 +714,7 @@ pub mod net_tests {
         assert_eq!(cage.close_syscall(clientsockfd1), 0);
         assert_eq!(cage.close_syscall(clientsockfd2), 0);
 
-        // those barriers ensures that the clients finish the connect before we do the select
+        // these barriers ensures that the clients finish the connect before we do the select
         let barrier = Arc::new(Barrier::new(3));
         let barrier_clone1 = barrier.clone();
         let barrier_clone2 = barrier.clone();
@@ -729,7 +729,7 @@ pub mod net_tests {
             assert_eq!(cage2.send_syscall(clientsockfd1, str2cbuf("test"), 4, 0), 4);
 
             interface::sleep(interface::RustDuration::from_millis(1));
-            
+
             let mut buf = sizecbuf(4);
             assert_eq!(cage2.recv_syscall(clientsockfd1, buf.as_mut_ptr(), 4, 0), 4);
             assert_eq!(cbuf2str(&buf), "test");
@@ -773,7 +773,7 @@ pub mod net_tests {
             //Check for any activity in any of the Input sockets...
             //for sock in binputs {
             for sock in 0..FD_SET_SIZE {
-                if !fd_set_check_fd(inputs, sock) {continue;}
+                if !interface::fd_set_check_fd(inputs, sock) {continue;}
 
                 //If the socket returned was listerner socket, then there's a new conn., so we accept it, and put the client socket in the list of Inputs.
                 if sock == serversockfd {
@@ -880,8 +880,6 @@ pub mod net_tests {
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
     }
-
-
 
     pub fn ut_lind_net_socket() {
         lindrustinit(0);

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -704,6 +704,10 @@ pub mod net_tests {
         interface::fd_set_insert(inputs, filefd);
         interface::fd_set_insert(outputs, filefd);
 
+        assert_eq!(interface::fd_set_check_fd(inputs, serversockfd), true);
+        assert_eq!(interface::fd_set_check_fd(inputs, filefd), true);
+        assert_eq!(interface::fd_set_check_fd(outputs, filefd), true);
+
         assert_eq!(cage.fork_syscall(2), 0);
         assert_eq!(cage.fork_syscall(3), 0);
 
@@ -753,7 +757,7 @@ pub mod net_tests {
             assert_eq!(cage3.close_syscall(clientsockfd2), 0);
             cage3.exit_syscall(EXIT_SUCCESS);
         });
-
+        interface::sleep(interface::RustDuration::from_millis(20));
         //acting as the server and processing the request
         for _counter in 0..600 {
             let select_result = cage.select_syscall(11, inputs, outputs, excepts, Some(interface::RustDuration::ZERO));

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -16,7 +16,7 @@ pub mod net_tests {
        ut_lind_net_listen();
        ut_lind_net_poll();
        ut_lind_net_recvfrom();
-        ut_lind_net_select(); 
+       ut_lind_net_select(); 
        ut_lind_net_shutdown();
        ut_lind_net_socket();
        ut_lind_net_socketoptions();

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -757,7 +757,7 @@ pub mod net_tests {
             assert_eq!(cage3.close_syscall(clientsockfd2), 0);
             cage3.exit_syscall(EXIT_SUCCESS);
         });
-        interface::sleep(interface::RustDuration::from_millis(20));
+        
         //acting as the server and processing the request
         for _counter in 0..600 {
             let select_result = cage.select_syscall(11, inputs, outputs, excepts, Some(interface::RustDuration::ZERO));

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -6,27 +6,27 @@ pub mod net_tests {
     use std::mem::size_of;
     
     pub fn net_tests() {
-        ut_lind_net_bind();
-        ut_lind_net_bind_multiple();
-        ut_lind_net_bind_on_zero();
-        ut_lind_net_connect_basic_udp();
-        ut_lind_net_getpeername();
-        ut_lind_net_getsockname();
-        ut_lind_net_listen();
-        ut_lind_net_poll();
-        ut_lind_net_recvfrom();
+    //    ut_lind_net_bind();
+    //    ut_lind_net_bind_multiple();
+    //    ut_lind_net_bind_on_zero();
+    //    ut_lind_net_connect_basic_udp();
+    //    ut_lind_net_getpeername();
+    //    ut_lind_net_getsockname();
+    //    ut_lind_net_listen();
+    //    ut_lind_net_poll();
+    //    ut_lind_net_recvfrom();
         ut_lind_net_select(); 
-        ut_lind_net_shutdown();
-        ut_lind_net_socket();
-        ut_lind_net_socketoptions();
-        ut_lind_net_socketpair(); 
-        ut_lind_net_udp_bad_bind();
-        ut_lind_net_udp_simple(); 
-        ut_lind_net_udp_connect(); 
-        ut_lind_net_gethostname();
-        ut_lind_net_dns_rootserver_ping();
-        ut_lind_net_domain_socket();
-        ut_lind_net_epoll();
+    //    ut_lind_net_shutdown();
+    //    ut_lind_net_socket();
+    //    ut_lind_net_socketoptions();
+    //    ut_lind_net_socketpair(); 
+    //    ut_lind_net_udp_bad_bind();
+    //    ut_lind_net_udp_simple(); 
+    //    ut_lind_net_udp_connect(); 
+    //    ut_lind_net_gethostname();
+    //    ut_lind_net_dns_rootserver_ping();
+    //    ut_lind_net_domain_socket();
+    //  ut_lind_net_epoll();
     }
 
     pub fn ut_lind_net_bind() {
@@ -780,10 +780,9 @@ pub mod net_tests {
             for ind in 0..128 {
                 let byte_offset = ind / 8;
                 let bit_offset = (ind % 8) as u8;
-                unsafe {
-                    let input_byte_ptr = inputs.add(byte_offset) as *mut u8;
-                    let is_set = ((*input_byte_ptr >> bit_offset) & 1) == 1;
-                }
+                let input_byte_ptr = unsafe {inputs.add(byte_offset) as *mut u8};
+                
+                let is_set = unsafe {((*input_byte_ptr >> bit_offset) & 1) == 1};
                 //If the socket returned was listerner socket, then there's a new conn., so we accept it, and put the client socket in the list of Inputs.
                 if is_set {
                     let sock = ind; 
@@ -846,10 +845,8 @@ pub mod net_tests {
             for ind in 0..128 {
                 let byte_offset = ind / 8;
                 let bit_offset = (ind % 8) as u8;
-                unsafe {
-                    let output_byte_ptr = outputs.add(byte_offset) as *mut u8;
-                    let is_set = ((*output_byte_ptr >> bit_offset) & 1) == 1;
-                }
+                let output_byte_ptr = unsafe{outputs.add(byte_offset) as *mut u8};
+                let is_set = unsafe {((*output_byte_ptr >> bit_offset) & 1) == 1};
                 if is_set {
                     let sock = ind;
                     if sock == filefd as usize {

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -27,7 +27,7 @@ pub mod net_tests {
        ut_lind_net_gethostname();
        ut_lind_net_dns_rootserver_ping();
        ut_lind_net_domain_socket();
-     ut_lind_net_epoll();
+       ut_lind_net_epoll();
     }
 
     pub fn ut_lind_net_bind() {

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -757,7 +757,7 @@ pub mod net_tests {
             assert_eq!(cage3.close_syscall(clientsockfd2), 0);
             cage3.exit_syscall(EXIT_SUCCESS);
         });
-        
+        interface::sleep(interface::RustDuration::from_millis(20));
         //acting as the server and processing the request
         for _counter in 0..600 {
             let select_result = cage.select_syscall(11, inputs, outputs, excepts, Some(interface::RustDuration::ZERO));

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -675,145 +675,161 @@ pub mod net_tests {
         lindrustfinalize();
     }
 
-    // TODO: someone update this test for the new version of select_syscall using bitmaps
     pub fn ut_lind_net_select() {
-        // lindrustinit(0);
-        // let cage = interface::cagetable_getref(1);
+        lindrustinit(0);
+        let cage = interface::cagetable_getref(1);
 
-        // let filefd = cage.open_syscall("/netselecttest.txt", O_CREAT | O_EXCL | O_RDWR, S_IRWXA);
-        // assert!(filefd > 0);
+        let filefd = cage.open_syscall("/netselecttest.txt", O_CREAT | O_EXCL | O_RDWR, S_IRWXA);
+        assert!(filefd > 0);
 
-        // let serversockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
-        // let clientsockfd1 = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
-        // let clientsockfd2 = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
+        let serversockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
+        let clientsockfd1 = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
+        let clientsockfd2 = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
 
-        // let port: u16 = 53008;
-        // let sockaddr = interface::SockaddrV4{ sin_family: AF_INET as u16, sin_port: port.to_be(), sin_addr: interface::V4Addr{ s_addr: u32::from_ne_bytes([127, 0, 0, 1]) }, padding: 0};
-        // let socket = interface::GenSockaddr::V4(sockaddr); //127.0.0.1 from bytes above
-        // assert_eq!(cage.bind_syscall(serversockfd, &socket), 0);
-        // assert_eq!(cage.listen_syscall(serversockfd, 4), 0);
+        let port: u16 = 53008;
+        let sockaddr = interface::SockaddrV4{ sin_family: AF_INET as u16, sin_port: port.to_be(), sin_addr: interface::V4Addr{ s_addr: u32::from_ne_bytes([127, 0, 0, 1]) }, padding: 0};
+        let socket = interface::GenSockaddr::V4(sockaddr); //127.0.0.1 from bytes above
+        assert_eq!(cage.bind_syscall(serversockfd, &socket), 0);
+        assert_eq!(cage.listen_syscall(serversockfd, 4), 0);
 
-        // let inputs = interface::RustHashSet::<i32>::new();
-        // let outputs = interface::RustHashSet::<i32>::new();
-        // let excepts = interface::RustHashSet::<i32>::new();
+        let mut input_chunk: [u8; 128] = [0; 128];
+        let mut output_chunk: [u8; 128] = [0; 128];
+        let mut except_chunk: [u8; 128] = [0; 128];
 
-        // inputs.insert(serversockfd);
-        // inputs.insert(filefd);
-        // outputs.insert(filefd);
+        let inputs: *mut u8 = input_chunk.as_mut_ptr();
+        let outputs: *mut u8 = output_chunk.as_mut_ptr();
+        let excepts: *mut u8 = except_chunk.as_mut_ptr();
+        
+        let fds_to_set = [serversockfd, filefd];
+        for fd in &fds_to_set {
+            let byte_offset = *fd as usize / 8;
+            let bit_offset = (*fd % 8) as u8;
+            let byte_ptr = inputs.wrapping_add(byte_offset) as *mut u8;
+            unsafe {
+                *byte_ptr |= 1 << bit_offset;
+            }
+        }       
+       
+        let byte_offset = filefd as usize / 8;
+        let bit_offset = (filefd % 8) as u8;
+        let output_byte_ptr = outputs.wrapping_add(byte_offset) as *mut u8;
+        unsafe {
+            *output_byte_ptr |= 1 << bit_offset;
+        }
 
-        // assert_eq!(cage.fork_syscall(2), 0);
-        // assert_eq!(cage.fork_syscall(3), 0);
+        assert_eq!(cage.fork_syscall(2), 0);
+        assert_eq!(cage.fork_syscall(3), 0);
 
-        // assert_eq!(cage.close_syscall(clientsockfd1), 0);
-        // assert_eq!(cage.close_syscall(clientsockfd2), 0);
+        assert_eq!(cage.close_syscall(clientsockfd1), 0);
+        assert_eq!(cage.close_syscall(clientsockfd2), 0);
 
-        // //client 1 connects to the server to send and recv data...
-        // let threadclient1 = interface::helper_thread(move || {
-        //     let cage2 = interface::cagetable_getref(2);
-        //     assert_eq!(cage2.close_syscall(serversockfd), 0);
+        //client 1 connects to the server to send and recv data...
+        let threadclient1 = interface::helper_thread(move || {
+            let cage2 = interface::cagetable_getref(2);
+            assert_eq!(cage2.close_syscall(serversockfd), 0);
 
-        //     assert_eq!(cage2.connect_syscall(clientsockfd1, &socket), 0);
-        //     assert_eq!(cage2.send_syscall(clientsockfd1, str2cbuf("test"), 4, 0), 4);
+            assert_eq!(cage2.connect_syscall(clientsockfd1, &socket), 0);
+            assert_eq!(cage2.send_syscall(clientsockfd1, str2cbuf("test"), 4, 0), 4);
 
-        //     interface::sleep(interface::RustDuration::from_millis(1));
+            interface::sleep(interface::RustDuration::from_millis(1));
 
-        //     let mut buf = sizecbuf(4);
-        //     assert_eq!(cage2.recv_syscall(clientsockfd1, buf.as_mut_ptr(), 4, 0), 4);
-        //     assert_eq!(cbuf2str(&buf), "test");
+            let mut buf = sizecbuf(4);
+            assert_eq!(cage2.recv_syscall(clientsockfd1, buf.as_mut_ptr(), 4, 0), 4);
+            assert_eq!(cbuf2str(&buf), "test");
 
-        //     assert_eq!(cage2.close_syscall(clientsockfd1), 0);
-        //     cage2.exit_syscall(EXIT_SUCCESS);
-        // });
+            assert_eq!(cage2.close_syscall(clientsockfd1), 0);
+            cage2.exit_syscall(EXIT_SUCCESS);
+        });
 
-        // //client 2 connects to the server to send and recv data...
-        // let threadclient2 = interface::helper_thread(move || {
-        //     let cage3 = interface::cagetable_getref(3);
+        //client 2 connects to the server to send and recv data...
+        let threadclient2 = interface::helper_thread(move || {
+            let cage3 = interface::cagetable_getref(3);
 
-        //     assert_eq!(cage3.close_syscall(serversockfd), 0);
+            assert_eq!(cage3.close_syscall(serversockfd), 0);
 
-        //     assert_eq!(cage3.connect_syscall(clientsockfd2, &socket), 0);
-        //     assert_eq!(cage3.send_syscall(clientsockfd2, str2cbuf("test"), 4, 0), 4);
+            assert_eq!(cage3.connect_syscall(clientsockfd2, &socket), 0);
+            assert_eq!(cage3.send_syscall(clientsockfd2, str2cbuf("test"), 4, 0), 4);
 
-        //     interface::sleep(interface::RustDuration::from_millis(1));
+            interface::sleep(interface::RustDuration::from_millis(1));
 
-        //     let mut buf = sizecbuf(4);
-        //     let mut result :i32;
-        //     loop {
-        //         result = cage3.recv_syscall(clientsockfd2, buf.as_mut_ptr(), 4, 0);
-        //         if result != -libc::EINTR {
-        //             break; // if the error was EINTR, retry the syscall
-        //         }
-        //     }
-        //     assert_eq!(result, 4);
-        //     assert_eq!(cbuf2str(&buf), "test");
+            let mut buf = sizecbuf(4);
+            let mut result :i32;
+            loop {
+                result = cage3.recv_syscall(clientsockfd2, buf.as_mut_ptr(), 4, 0);
+                if result != -libc::EINTR {
+                    break; // if the error was EINTR, retry the syscall
+                }
+            }
+            assert_eq!(result, 4);
+            assert_eq!(cbuf2str(&buf), "test");
 
-        //     assert_eq!(cage3.close_syscall(clientsockfd2), 0);
-        //     cage3.exit_syscall(EXIT_SUCCESS);
-        // });
+            assert_eq!(cage3.close_syscall(clientsockfd2), 0);
+            cage3.exit_syscall(EXIT_SUCCESS);
+        });
 
-        // //acting as the server and processing the request
-        // for _counter in 0..600 {
-        //     let mut binputs = inputs.clone();
-        //     let mut boutputs = outputs.clone();
-        //     let mut bexcepts = excepts.clone();
-        //     let select_result = cage.select_syscall(11, &mut binputs, &mut boutputs, &mut bexcepts, Some(interface::RustDuration::ZERO));
-        //     assert!(select_result >= 0);
+        //acting as the server and processing the request
+        for _counter in 0..600 {
+            let mut binputs = inputs.clone();
+            let mut boutputs = outputs.clone();
+            let mut bexcepts = excepts.clone();
+            let select_result = cage.select_syscall(11, binputs, boutputs, bexcepts, Some(interface::RustDuration::ZERO));
+            assert!(select_result >= 0);
 
-        //     //Check for any activity in any of the Input sockets...
-        //     for sock in binputs {
-        //         //If the socket returned was listerner socket, then there's a new conn., so we accept it, and put the client socket in the list of Inputs.
-        //         if sock == serversockfd {
-        //             let mut sockgarbage = interface::GenSockaddr::V4(interface::SockaddrV4::default());
-        //             let sockfd = cage.accept_syscall(sock, &mut sockgarbage); //really can only make sure that the fd is valid
-        //             assert!(sockfd > 0);
-        //             inputs.insert(sockfd);
-        //             outputs.insert(sockfd);
-        //         } else if sock == filefd {
-        //             //Write to a file...
-        //             assert_eq!(cage.write_syscall(sock, str2cbuf("test"), 4), 4);
-        //             assert_eq!(cage.lseek_syscall(sock, 0, SEEK_SET), 0);
-        //             inputs.remove(&sock);
-        //         } else { //If the socket is in established conn., then we recv the data. If there's no data, then close the client socket.
-        //             let mut buf = sizecbuf(4);
-        //             let mut recvresult :i32;
-        //             loop {
-        //                 recvresult = cage.recv_syscall(sock, buf.as_mut_ptr(), 4, 0);
-        //                 if recvresult != -libc::EINTR {
-        //                     break; // if the error was EINTR, retry the syscall
-        //                 }
-        //             }
-        //             if recvresult == 4 {
-        //                 if cbuf2str(&buf) == "test" {
-        //                     outputs.insert(sock);
-        //                     continue;
-        //                 }
-        //             } else {
-        //                 assert_eq!(recvresult, 0);
-        //             }
-        //             assert_eq!(cage.close_syscall(sock), 0);
-        //             inputs.remove(&sock);
-        //         }
-        //     }
+            //Check for any activity in any of the Input sockets...
+            for sock in binputs {
+                //If the socket returned was listerner socket, then there's a new conn., so we accept it, and put the client socket in the list of Inputs.
+                if sock == serversockfd {
+                    let mut sockgarbage = interface::GenSockaddr::V4(interface::SockaddrV4::default());
+                    let sockfd = cage.accept_syscall(sock, &mut sockgarbage); //really can only make sure that the fd is valid
+                    assert!(sockfd > 0);
+                    inputs.insert(sockfd);
+                    outputs.insert(sockfd);
+                } else if sock == filefd {
+                    //Write to a file...
+                    assert_eq!(cage.write_syscall(sock, str2cbuf("test"), 4), 4);
+                    assert_eq!(cage.lseek_syscall(sock, 0, SEEK_SET), 0);
+                    inputs.remove(&sock);
+                } else { //If the socket is in established conn., then we recv the data. If there's no data, then close the client socket.
+                    let mut buf = sizecbuf(4);
+                    let mut recvresult :i32;
+                    loop {
+                        recvresult = cage.recv_syscall(sock, buf.as_mut_ptr(), 4, 0);
+                        if recvresult != -libc::EINTR {
+                            break; // if the error was EINTR, retry the syscall
+                        }
+                    }
+                    if recvresult == 4 {
+                        if cbuf2str(&buf) == "test" {
+                            outputs.insert(sock);
+                            continue;
+                        }
+                    } else {
+                        assert_eq!(recvresult, 0);
+                    }
+                    assert_eq!(cage.close_syscall(sock), 0);
+                    inputs.remove(&sock);
+                }
+            }
 
-        //     for sock in boutputs {
-        //         if sock == filefd {
-        //             let mut buf = sizecbuf(4);
-        //             assert_eq!(cage.read_syscall(sock, buf.as_mut_ptr(), 4), 4);
-        //             assert_eq!(cbuf2str(&buf), "test");
-        //             outputs.remove(&sock); //test for file finished, remove from monitoring.
-        //         } else { //Data is sent out this socket, it's no longer ready for writing remove this socket from writefd's.
-        //             assert_eq!(cage.send_syscall(sock, str2cbuf("test"), 4, 0), 4);
-        //             outputs.remove(&sock);
-        //         }
-        //     }
-        // }
-        // assert_eq!(cage.close_syscall(serversockfd), 0);
+            for sock in boutputs {
+                if sock == filefd {
+                    let mut buf = sizecbuf(4);
+                    assert_eq!(cage.read_syscall(sock, buf.as_mut_ptr(), 4), 4);
+                    assert_eq!(cbuf2str(&buf), "test");
+                    outputs.remove(&sock); //test for file finished, remove from monitoring.
+                } else { //Data is sent out this socket, it's no longer ready for writing remove this socket from writefd's.
+                    assert_eq!(cage.send_syscall(sock, str2cbuf("test"), 4, 0), 4);
+                    outputs.remove(&sock);
+                }
+            }
+        }
+        assert_eq!(cage.close_syscall(serversockfd), 0);
 
-        // threadclient1.join().unwrap();
-        // threadclient2.join().unwrap();
+        threadclient1.join().unwrap();
+        threadclient2.join().unwrap();
 
-        // assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
-        // lindrustfinalize();
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
     }
           
     pub fn ut_lind_net_shutdown() {

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -7,27 +7,27 @@ pub mod net_tests {
     use std::sync::{Arc, Barrier};
     
     pub fn net_tests() {
-    //    ut_lind_net_bind();
-    //    ut_lind_net_bind_multiple();
-    //    ut_lind_net_bind_on_zero();
-    //    ut_lind_net_connect_basic_udp();
-    //    ut_lind_net_getpeername();
-    //    ut_lind_net_getsockname();
-    //    ut_lind_net_listen();
-    //    ut_lind_net_poll();
-    //    ut_lind_net_recvfrom();
+       ut_lind_net_bind();
+       ut_lind_net_bind_multiple();
+       ut_lind_net_bind_on_zero();
+       ut_lind_net_connect_basic_udp();
+       ut_lind_net_getpeername();
+       ut_lind_net_getsockname();
+       ut_lind_net_listen();
+       ut_lind_net_poll();
+       ut_lind_net_recvfrom();
         ut_lind_net_select(); 
-    //    ut_lind_net_shutdown();
-    //    ut_lind_net_socket();
-    //    ut_lind_net_socketoptions();
-    //    ut_lind_net_socketpair(); 
-    //    ut_lind_net_udp_bad_bind();
-    //    ut_lind_net_udp_simple(); 
-    //    ut_lind_net_udp_connect(); 
-    //    ut_lind_net_gethostname();
-    //    ut_lind_net_dns_rootserver_ping();
-    //    ut_lind_net_domain_socket();
-    //  ut_lind_net_epoll();
+       ut_lind_net_shutdown();
+       ut_lind_net_socket();
+       ut_lind_net_socketoptions();
+       ut_lind_net_socketpair(); 
+       ut_lind_net_udp_bad_bind();
+       ut_lind_net_udp_simple(); 
+       ut_lind_net_udp_connect(); 
+       ut_lind_net_gethostname();
+       ut_lind_net_dns_rootserver_ping();
+       ut_lind_net_domain_socket();
+     ut_lind_net_epoll();
     }
 
     pub fn ut_lind_net_bind() {
@@ -693,6 +693,7 @@ pub mod net_tests {
         assert_eq!(cage.bind_syscall(serversockfd, &socket), 0);
         assert_eq!(cage.listen_syscall(serversockfd, 4), 0);
 
+        // allocate spaces for fd_set bitmaps
         let mut input_chunk: [u8; 128] = [0; 128];
         let mut output_chunk: [u8; 128] = [0; 128];
         let mut except_chunk: [u8; 128] = [0; 128];

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -675,144 +675,145 @@ pub mod net_tests {
         lindrustfinalize();
     }
 
+    // TODO: someone update this test for the new version of select_syscall using bitmaps
     pub fn ut_lind_net_select() {
-        lindrustinit(0);
-        let cage = interface::cagetable_getref(1);
+        // lindrustinit(0);
+        // let cage = interface::cagetable_getref(1);
 
-        let filefd = cage.open_syscall("/netselecttest.txt", O_CREAT | O_EXCL | O_RDWR, S_IRWXA);
-        assert!(filefd > 0);
+        // let filefd = cage.open_syscall("/netselecttest.txt", O_CREAT | O_EXCL | O_RDWR, S_IRWXA);
+        // assert!(filefd > 0);
 
-        let serversockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
-        let clientsockfd1 = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
-        let clientsockfd2 = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
+        // let serversockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
+        // let clientsockfd1 = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
+        // let clientsockfd2 = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
 
-        let port: u16 = 53008;
-        let sockaddr = interface::SockaddrV4{ sin_family: AF_INET as u16, sin_port: port.to_be(), sin_addr: interface::V4Addr{ s_addr: u32::from_ne_bytes([127, 0, 0, 1]) }, padding: 0};
-        let socket = interface::GenSockaddr::V4(sockaddr); //127.0.0.1 from bytes above
-        assert_eq!(cage.bind_syscall(serversockfd, &socket), 0);
-        assert_eq!(cage.listen_syscall(serversockfd, 4), 0);
+        // let port: u16 = 53008;
+        // let sockaddr = interface::SockaddrV4{ sin_family: AF_INET as u16, sin_port: port.to_be(), sin_addr: interface::V4Addr{ s_addr: u32::from_ne_bytes([127, 0, 0, 1]) }, padding: 0};
+        // let socket = interface::GenSockaddr::V4(sockaddr); //127.0.0.1 from bytes above
+        // assert_eq!(cage.bind_syscall(serversockfd, &socket), 0);
+        // assert_eq!(cage.listen_syscall(serversockfd, 4), 0);
 
-        let inputs = interface::RustHashSet::<i32>::new();
-        let outputs = interface::RustHashSet::<i32>::new();
-        let excepts = interface::RustHashSet::<i32>::new();
+        // let inputs = interface::RustHashSet::<i32>::new();
+        // let outputs = interface::RustHashSet::<i32>::new();
+        // let excepts = interface::RustHashSet::<i32>::new();
 
-        inputs.insert(serversockfd);
-        inputs.insert(filefd);
-        outputs.insert(filefd);
+        // inputs.insert(serversockfd);
+        // inputs.insert(filefd);
+        // outputs.insert(filefd);
 
-        assert_eq!(cage.fork_syscall(2), 0);
-        assert_eq!(cage.fork_syscall(3), 0);
+        // assert_eq!(cage.fork_syscall(2), 0);
+        // assert_eq!(cage.fork_syscall(3), 0);
 
-        assert_eq!(cage.close_syscall(clientsockfd1), 0);
-        assert_eq!(cage.close_syscall(clientsockfd2), 0);
+        // assert_eq!(cage.close_syscall(clientsockfd1), 0);
+        // assert_eq!(cage.close_syscall(clientsockfd2), 0);
 
-        //client 1 connects to the server to send and recv data...
-        let threadclient1 = interface::helper_thread(move || {
-            let cage2 = interface::cagetable_getref(2);
-            assert_eq!(cage2.close_syscall(serversockfd), 0);
+        // //client 1 connects to the server to send and recv data...
+        // let threadclient1 = interface::helper_thread(move || {
+        //     let cage2 = interface::cagetable_getref(2);
+        //     assert_eq!(cage2.close_syscall(serversockfd), 0);
 
-            assert_eq!(cage2.connect_syscall(clientsockfd1, &socket), 0);
-            assert_eq!(cage2.send_syscall(clientsockfd1, str2cbuf("test"), 4, 0), 4);
+        //     assert_eq!(cage2.connect_syscall(clientsockfd1, &socket), 0);
+        //     assert_eq!(cage2.send_syscall(clientsockfd1, str2cbuf("test"), 4, 0), 4);
 
-            interface::sleep(interface::RustDuration::from_millis(1));
+        //     interface::sleep(interface::RustDuration::from_millis(1));
 
-            let mut buf = sizecbuf(4);
-            assert_eq!(cage2.recv_syscall(clientsockfd1, buf.as_mut_ptr(), 4, 0), 4);
-            assert_eq!(cbuf2str(&buf), "test");
+        //     let mut buf = sizecbuf(4);
+        //     assert_eq!(cage2.recv_syscall(clientsockfd1, buf.as_mut_ptr(), 4, 0), 4);
+        //     assert_eq!(cbuf2str(&buf), "test");
 
-            assert_eq!(cage2.close_syscall(clientsockfd1), 0);
-            cage2.exit_syscall(EXIT_SUCCESS);
-        });
+        //     assert_eq!(cage2.close_syscall(clientsockfd1), 0);
+        //     cage2.exit_syscall(EXIT_SUCCESS);
+        // });
 
-        //client 2 connects to the server to send and recv data...
-        let threadclient2 = interface::helper_thread(move || {
-            let cage3 = interface::cagetable_getref(3);
+        // //client 2 connects to the server to send and recv data...
+        // let threadclient2 = interface::helper_thread(move || {
+        //     let cage3 = interface::cagetable_getref(3);
 
-            assert_eq!(cage3.close_syscall(serversockfd), 0);
+        //     assert_eq!(cage3.close_syscall(serversockfd), 0);
 
-            assert_eq!(cage3.connect_syscall(clientsockfd2, &socket), 0);
-            assert_eq!(cage3.send_syscall(clientsockfd2, str2cbuf("test"), 4, 0), 4);
+        //     assert_eq!(cage3.connect_syscall(clientsockfd2, &socket), 0);
+        //     assert_eq!(cage3.send_syscall(clientsockfd2, str2cbuf("test"), 4, 0), 4);
 
-            interface::sleep(interface::RustDuration::from_millis(1));
+        //     interface::sleep(interface::RustDuration::from_millis(1));
 
-            let mut buf = sizecbuf(4);
-            let mut result :i32;
-            loop {
-                result = cage3.recv_syscall(clientsockfd2, buf.as_mut_ptr(), 4, 0);
-                if result != -libc::EINTR {
-                    break; // if the error was EINTR, retry the syscall
-                }
-            }
-            assert_eq!(result, 4);
-            assert_eq!(cbuf2str(&buf), "test");
+        //     let mut buf = sizecbuf(4);
+        //     let mut result :i32;
+        //     loop {
+        //         result = cage3.recv_syscall(clientsockfd2, buf.as_mut_ptr(), 4, 0);
+        //         if result != -libc::EINTR {
+        //             break; // if the error was EINTR, retry the syscall
+        //         }
+        //     }
+        //     assert_eq!(result, 4);
+        //     assert_eq!(cbuf2str(&buf), "test");
 
-            assert_eq!(cage3.close_syscall(clientsockfd2), 0);
-            cage3.exit_syscall(EXIT_SUCCESS);
-        });
+        //     assert_eq!(cage3.close_syscall(clientsockfd2), 0);
+        //     cage3.exit_syscall(EXIT_SUCCESS);
+        // });
 
-        //acting as the server and processing the request
-        for _counter in 0..600 {
-            let mut binputs = inputs.clone();
-            let mut boutputs = outputs.clone();
-            let mut bexcepts = excepts.clone();
-            let select_result = cage.select_syscall(11, &mut binputs, &mut boutputs, &mut bexcepts, Some(interface::RustDuration::ZERO));
-            assert!(select_result >= 0);
+        // //acting as the server and processing the request
+        // for _counter in 0..600 {
+        //     let mut binputs = inputs.clone();
+        //     let mut boutputs = outputs.clone();
+        //     let mut bexcepts = excepts.clone();
+        //     let select_result = cage.select_syscall(11, &mut binputs, &mut boutputs, &mut bexcepts, Some(interface::RustDuration::ZERO));
+        //     assert!(select_result >= 0);
 
-            //Check for any activity in any of the Input sockets...
-            for sock in binputs {
-                //If the socket returned was listerner socket, then there's a new conn., so we accept it, and put the client socket in the list of Inputs.
-                if sock == serversockfd {
-                    let mut sockgarbage = interface::GenSockaddr::V4(interface::SockaddrV4::default());
-                    let sockfd = cage.accept_syscall(sock, &mut sockgarbage); //really can only make sure that the fd is valid
-                    assert!(sockfd > 0);
-                    inputs.insert(sockfd);
-                    outputs.insert(sockfd);
-                } else if sock == filefd {
-                    //Write to a file...
-                    assert_eq!(cage.write_syscall(sock, str2cbuf("test"), 4), 4);
-                    assert_eq!(cage.lseek_syscall(sock, 0, SEEK_SET), 0);
-                    inputs.remove(&sock);
-                } else { //If the socket is in established conn., then we recv the data. If there's no data, then close the client socket.
-                    let mut buf = sizecbuf(4);
-                    let mut recvresult :i32;
-                    loop {
-                        recvresult = cage.recv_syscall(sock, buf.as_mut_ptr(), 4, 0);
-                        if recvresult != -libc::EINTR {
-                            break; // if the error was EINTR, retry the syscall
-                        }
-                    }
-                    if recvresult == 4 {
-                        if cbuf2str(&buf) == "test" {
-                            outputs.insert(sock);
-                            continue;
-                        }
-                    } else {
-                        assert_eq!(recvresult, 0);
-                    }
-                    assert_eq!(cage.close_syscall(sock), 0);
-                    inputs.remove(&sock);
-                }
-            }
+        //     //Check for any activity in any of the Input sockets...
+        //     for sock in binputs {
+        //         //If the socket returned was listerner socket, then there's a new conn., so we accept it, and put the client socket in the list of Inputs.
+        //         if sock == serversockfd {
+        //             let mut sockgarbage = interface::GenSockaddr::V4(interface::SockaddrV4::default());
+        //             let sockfd = cage.accept_syscall(sock, &mut sockgarbage); //really can only make sure that the fd is valid
+        //             assert!(sockfd > 0);
+        //             inputs.insert(sockfd);
+        //             outputs.insert(sockfd);
+        //         } else if sock == filefd {
+        //             //Write to a file...
+        //             assert_eq!(cage.write_syscall(sock, str2cbuf("test"), 4), 4);
+        //             assert_eq!(cage.lseek_syscall(sock, 0, SEEK_SET), 0);
+        //             inputs.remove(&sock);
+        //         } else { //If the socket is in established conn., then we recv the data. If there's no data, then close the client socket.
+        //             let mut buf = sizecbuf(4);
+        //             let mut recvresult :i32;
+        //             loop {
+        //                 recvresult = cage.recv_syscall(sock, buf.as_mut_ptr(), 4, 0);
+        //                 if recvresult != -libc::EINTR {
+        //                     break; // if the error was EINTR, retry the syscall
+        //                 }
+        //             }
+        //             if recvresult == 4 {
+        //                 if cbuf2str(&buf) == "test" {
+        //                     outputs.insert(sock);
+        //                     continue;
+        //                 }
+        //             } else {
+        //                 assert_eq!(recvresult, 0);
+        //             }
+        //             assert_eq!(cage.close_syscall(sock), 0);
+        //             inputs.remove(&sock);
+        //         }
+        //     }
 
-            for sock in boutputs {
-                if sock == filefd {
-                    let mut buf = sizecbuf(4);
-                    assert_eq!(cage.read_syscall(sock, buf.as_mut_ptr(), 4), 4);
-                    assert_eq!(cbuf2str(&buf), "test");
-                    outputs.remove(&sock); //test for file finished, remove from monitoring.
-                } else { //Data is sent out this socket, it's no longer ready for writing remove this socket from writefd's.
-                    assert_eq!(cage.send_syscall(sock, str2cbuf("test"), 4, 0), 4);
-                    outputs.remove(&sock);
-                }
-            }
-        }
-        assert_eq!(cage.close_syscall(serversockfd), 0);
+        //     for sock in boutputs {
+        //         if sock == filefd {
+        //             let mut buf = sizecbuf(4);
+        //             assert_eq!(cage.read_syscall(sock, buf.as_mut_ptr(), 4), 4);
+        //             assert_eq!(cbuf2str(&buf), "test");
+        //             outputs.remove(&sock); //test for file finished, remove from monitoring.
+        //         } else { //Data is sent out this socket, it's no longer ready for writing remove this socket from writefd's.
+        //             assert_eq!(cage.send_syscall(sock, str2cbuf("test"), 4, 0), 4);
+        //             outputs.remove(&sock);
+        //         }
+        //     }
+        // }
+        // assert_eq!(cage.close_syscall(serversockfd), 0);
 
-        threadclient1.join().unwrap();
-        threadclient2.join().unwrap();
+        // threadclient1.join().unwrap();
+        // threadclient2.join().unwrap();
 
-        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
-        lindrustfinalize();
+        // assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        // lindrustfinalize();
     }
           
     pub fn ut_lind_net_shutdown() {


### PR DESCRIPTION
## Description

Fixes issue #337 in Lind_project

Previously the dispatcher will convert fd_set into hashsets before calling `select_syscall`, which leads to severe overheads, and the adhoc hashsets are very short-living. So I made select and epoll to use bitmaps. As a fd_set is just a bitmap in itself, we don't need to convert anything now. The dispatcher treat original fd_set as a pointer to a `mutcbuf` and pass it into `select_syscall`. The helper functions to check and edit the bitmaps are implemented in types.rs

The unit tests were updted for the new select syscall. Notably, having a faster `select` reveals a concurrency issue of the tester, where the server doesn't wait for client threads to connect. This is also fixed with std barriers.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
