### PR TITLE
fix concurency of semaphores in fork

### DIFF
--- a/src/safeposix/syscalls/sys_calls.rs
+++ b/src/safeposix/syscalls/sys_calls.rs
@@ -160,7 +160,8 @@ impl Cage {
             let mut shment = shmtable.get_mut(&rev_mapping.1).unwrap();
             shment.shminfo.shm_nattch += 1;
             let refs = shment.attached_cages.get(&self.cageid).unwrap();
-            let childrefs = *refs;
+            let childrefs = refs.clone();
+            drop(refs);
             shment.attached_cages.insert(child_cageid, childrefs);
         }
         drop(shmtable);


### PR DESCRIPTION
## Description
Fixes small concurrency error in fork

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Passed both test suites. Fixed issue in postgres.

## Checklist:

- [x ] My code follows the style guidelines of this project
- [x ] My changes generate no new warnings

