### PR TITLE
Fix Open TOCCTOU and Log Inode Tracking

### DIFF
--- a/src/safeposix/filesystem.rs
+++ b/src/safeposix/filesystem.rs
@@ -2,7 +2,6 @@
 #![allow(dead_code)]
 
 use crate::interface;
-use std::cmp::max;
 use super::syscalls::fs_constants::*;
 use super::syscalls::sys_constants::*;
 use super::net::NET_METADATA;
@@ -248,12 +247,12 @@ pub fn load_fs() {
             // drain the vector and deserialize into pairs of inodenum + inodes,
             // if the inode exists, add it, if not, remove it
             // keep track of the largest inodenum we see so we can update the nextinode counter
-            let mut max_inodenum = 0;
+            let mut max_inodenum = FS_METADATA.nextinode.load(interface::RustAtomicOrdering::Relaxed);
             for serialpair in logvec.drain(..) {
                 let (inodenum, inode) = serialpair;
                 match inode {
                     Some(inode) => {
-                        max_inodenum = max(max_inodenum, inodenum);
+                        max_inodenum = interface::rust_max(max_inodenum, inodenum);
                         FS_METADATA.inodetable.insert(inodenum, inode);
                     }
                     None => {FS_METADATA.inodetable.remove(&inodenum);}

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -111,12 +111,13 @@ impl Cage {
     
                             let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
                             interface::removefile(sysfilename.clone()).unwrap();
-    
-                            if let interface::RustHashEntry::Vacant(vac) = FILEOBJECTTABLE.entry(inodenum){
-                                let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
-                                vac.insert(interface::openfile(sysfilename, true).unwrap());
-                            }
                         }
+                        
+                        if let interface::RustHashEntry::Vacant(vac) = FILEOBJECTTABLE.entry(inodenum){
+                            let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
+                            vac.insert(interface::openfile(sysfilename, true).unwrap());
+                        }
+                        
                         size = f.size;
                         f.refcount += 1;
                     }

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -76,13 +76,11 @@ impl Cage {
                 log_metadata(&FS_METADATA, pardirinode);
                 log_metadata(&FS_METADATA, newinodenum);
 
-                if is_reg(mode) {
-                    if let interface::RustHashEntry::Vacant(vac) = FILEOBJECTTABLE.entry(newinodenum){
-                        let sysfilename = format!("{}{}", FILEDATAPREFIX, newinodenum);
-                        vac.insert(interface::openfile(sysfilename, true).unwrap());
-                    }
+                if let interface::RustHashEntry::Vacant(vac) = FILEOBJECTTABLE.entry(newinodenum){
+                    let sysfilename = format!("{}{}", FILEDATAPREFIX, newinodenum);
+                    vac.insert(interface::openfile(sysfilename, true).unwrap());
                 }
-
+                
                 let _insertval = fdoption.insert(new_file_initializer(newinodenum, flags, 0));
             }
 

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -17,7 +17,7 @@ impl Cage {
         //insert file descriptor into self.filedescriptortableable of the cage
         let position = if 0 != flags & O_APPEND {size} else {0};
         let allowmask = O_RDWRFLAGS | O_CLOEXEC;
-        File(FileDesc {position: position, inode: inodenum, flags: flags & allowmask, advlock: interface::RustRfc::new(interface::AdvisoryLock::new())})
+        FileDesc {position: position, inode: inodenum, flags: flags & allowmask, advlock: interface::RustRfc::new(interface::AdvisoryLock::new())}
     }
 
     pub fn open_syscall(&self, path: &str, flags: i32, mode: u32) -> i32 {
@@ -81,7 +81,7 @@ impl Cage {
                     vac.insert(interface::openfile(sysfilename, true).unwrap());
                 }
                 
-                let _insertval = fdoption.insert(File(_file_initializer(newinodenum, flags, 0)));
+                let _insertval = fdoption.insert(File(self._file_initializer(newinodenum, flags, 0)));
             }
 
             //If the file exists (we don't need to look at parent here)
@@ -125,7 +125,7 @@ impl Cage {
                     Inode::Socket(_) => { return syscall_error(Errno::ENXIO, "open", "file is a UNIX domain socket"); }
                 }
 
-                let _insertval = fdoption.insert(File(_file_initializer(inodenum, flags, size)));
+                let _insertval = fdoption.insert(File(self._file_initializer(inodenum, flags, size)));
             }
         }
 

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -13,7 +13,7 @@ impl Cage {
 
     //------------------------------------OPEN SYSCALL------------------------------------
 
-    fn _file_initializer(&self, inodenum: usize, flags: i32, size: i32) -> FileDesc{
+    fn _file_initializer(&self, inodenum: usize, flags: i32, size: usize) -> FileDesc{
         //insert file descriptor into self.filedescriptortableable of the cage
         let position = if 0 != flags & O_APPEND {size} else {0};
         let allowmask = O_RDWRFLAGS | O_CLOEXEC;

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -13,6 +13,13 @@ impl Cage {
 
     //------------------------------------OPEN SYSCALL------------------------------------
 
+    fn _file_initializer(inodenum: usize, flags: i32, size: i32) -> FileDesc{
+        //insert file descriptor into self.filedescriptortableable of the cage
+        let position = if 0 != flags & O_APPEND {size} else {0};
+        let allowmask = O_RDWRFLAGS | O_CLOEXEC;
+        File(FileDesc {position: position, inode: inodenum, flags: flags & allowmask, advlock: interface::RustRfc::new(interface::AdvisoryLock::new())})
+    }
+
     pub fn open_syscall(&self, path: &str, flags: i32, mode: u32) -> i32 {
         //Check that path is not empty
         if path.len() == 0 {return syscall_error(Errno::ENOENT, "open", "given path was null");}
@@ -53,7 +60,7 @@ impl Cage {
                 let time = interface::timestamp(); //We do a real timestamp now
                 let newinode = Inode::File(GenericInode {
                     size: 0, uid: DEFAULT_UID, gid: DEFAULT_GID,
-                    mode: effective_mode, linkcount: 1, refcount: 0,
+                    mode: effective_mode, linkcount: 1, refcount: 1,
                     atime: time, ctime: time, mtime: time,
                 });
 
@@ -68,6 +75,15 @@ impl Cage {
                 FS_METADATA.inodetable.insert(newinodenum, newinode);
                 log_metadata(&FS_METADATA, pardirinode);
                 log_metadata(&FS_METADATA, newinodenum);
+
+                if is_reg(mode) {
+                    if let interface::RustHashEntry::Vacant(vac) = FILEOBJECTTABLE.entry(newinodenum){
+                        let sysfilename = format!("{}{}", FILEDATAPREFIX, newinodenum);
+                        vac.insert(interface::openfile(sysfilename, true).unwrap());
+                    }
+                }
+
+                let _insertval = fdoption.insert(new_file_initializer(newinodenum, flags, 0));
             }
 
             //If the file exists (we don't need to look at parent here)
@@ -75,58 +91,45 @@ impl Cage {
                 if (O_CREAT | O_EXCL) == (flags & (O_CREAT | O_EXCL)) {
                     return syscall_error(Errno::EEXIST, "open", "file already exists and O_CREAT and O_EXCL were used");
                 }
+                let size;
 
-                if O_TRUNC == (flags & O_TRUNC) {
-                    // We only do this to regular files, otherwiese O_TRUNC is undefined
-                    if let Inode::File(ref mut g) = *(FS_METADATA.inodetable.get_mut(&inodenum).unwrap()) {
-                        //close the file object if another cage has it open
-                        let entry = FILEOBJECTTABLE.entry(inodenum);
-                        if let interface::RustHashEntry::Occupied(occ) = &entry {
-                            occ.get().close().unwrap();
+                let mut inodeobj = FS_METADATA.inodetable.get_mut(&inodenum).unwrap();
+                match *inodeobj {
+                    Inode::File(ref mut f) => {
+                        if O_TRUNC == (flags & O_TRUNC) {
+                        // We only do this to regular files, otherwise O_TRUNC is undefined
+                            //close the file object if another cage has it open
+                            let entry = FILEOBJECTTABLE.entry(inodenum);
+                            if let interface::RustHashEntry::Occupied(occ) = &entry {
+                                occ.get().close().unwrap();
+                            }
+                            // resize it to 0
+                            f.size = 0;
+    
+                            //remove the previous file and add a new one of 0 length
+                            if let interface::RustHashEntry::Occupied(occ) = entry {
+                                occ.remove_entry();
+                            }
+    
+                            let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
+                            interface::removefile(sysfilename.clone()).unwrap();
+    
+                            if let interface::RustHashEntry::Vacant(vac) = FILEOBJECTTABLE.entry(inodenum){
+                                let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
+                                vac.insert(interface::openfile(sysfilename, true).unwrap());
+                            }
                         }
-                        // resize it to 0
-                        g.size = 0;
-
-                        //remove the previous file and add a new one of 0 length
-                        if let interface::RustHashEntry::Occupied(occ) = entry {
-                            occ.remove_entry();
-                        }
-
-                        let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
-                        interface::removefile(sysfilename.clone()).unwrap();
-                    }   
+                        size = f.size;
+                        f.refcount += 1;
+                    }
+                    Inode::Dir(ref mut f) => {size = f.size; f.refcount += 1;}
+                    Inode::CharDev(ref mut f) => {size = f.size; f.refcount += 1;}
+                    Inode::Socket(_) => { return syscall_error(Errno::ENXIO, "open", "file is a UNIX domain socket"); }
                 }
+
+                let _insertval = fdoption.insert(new_file_initializer(inodenum, flags, size));
             }
         }
-
-        //We redo our metawalk in case of O_CREAT, but this is somewhat inefficient
-        if let Some(inodenum) = metawalk(truepath.as_path()) {
-            let mut inodeobj = FS_METADATA.inodetable.get_mut(&inodenum).unwrap();
-            let mode;
-            let size;
-
-            //increment number of open handles to the file, retrieve other data from inode
-            match *inodeobj {
-                Inode::File(ref mut f) => {size = f.size; mode = f.mode; f.refcount += 1;}
-                Inode::Dir(ref mut f) => {size = f.size; mode = f.mode; f.refcount += 1;}
-                Inode::CharDev(ref mut f) => {size = f.size; mode = f.mode; f.refcount += 1;}
-                Inode::Socket(_) => { return syscall_error(Errno::ENXIO, "open", "file is a UNIX domain socket"); }
-            }
-
-            //If the file is a regular file, open the file object
-            if is_reg(mode) {
-                if let interface::RustHashEntry::Vacant(vac) = FILEOBJECTTABLE.entry(inodenum){
-                    let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
-                    vac.insert(interface::openfile(sysfilename, true).unwrap());
-                }
-            }
-
-            //insert file descriptor into self.filedescriptortableable of the cage
-            let position = if 0 != flags & O_APPEND {size} else {0};
-            let allowmask = O_RDWRFLAGS | O_CLOEXEC;
-            let newfd = File(FileDesc {position: position, inode: inodenum, flags: flags & allowmask, advlock: interface::RustRfc::new(interface::AdvisoryLock::new())});
-            let _insertval = fdoption.insert(newfd);
-        } else {panic!("Inode not created for some reason");}
 
         fd //open returns the opened file descriptor
     }

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -81,7 +81,7 @@ impl Cage {
                     vac.insert(interface::openfile(sysfilename, true).unwrap());
                 }
                 
-                let _insertval = fdoption.insert(new_file_initializer(newinodenum, flags, 0));
+                let _insertval = fdoption.insert(File(_file_initializer(newinodenum, flags, 0)));
             }
 
             //If the file exists (we don't need to look at parent here)
@@ -125,7 +125,7 @@ impl Cage {
                     Inode::Socket(_) => { return syscall_error(Errno::ENXIO, "open", "file is a UNIX domain socket"); }
                 }
 
-                let _insertval = fdoption.insert(new_file_initializer(inodenum, flags, size));
+                let _insertval = fdoption.insert(File(_file_initializer(inodenum, flags, size)));
             }
         }
 

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -13,7 +13,7 @@ impl Cage {
 
     //------------------------------------OPEN SYSCALL------------------------------------
 
-    fn _file_initializer(inodenum: usize, flags: i32, size: i32) -> FileDesc{
+    fn _file_initializer(&self, inodenum: usize, flags: i32, size: i32) -> FileDesc{
         //insert file descriptor into self.filedescriptortableable of the cage
         let position = if 0 != flags & O_APPEND {size} else {0};
         let allowmask = O_RDWRFLAGS | O_CLOEXEC;


### PR DESCRIPTION
## Description

This bug fixes some problems we were seeing in postgres where:

1. Open would panic due to a TOCCTOU 
2. Inode numbers would be accidentally reused due to the nextinode field not being updated when syncing the log based file system

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
All rust tests, lind test suite, postgres tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
