### PR TITLE
Bug fix for sync_file_range

### DIFF
--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1947,9 +1947,6 @@ impl Cage {
         if let Some(filedesc_enum) = &mut *unlocked_fd {
             match filedesc_enum {
                 File(ref mut normalfile_filedesc_obj) => {
-                    if is_rdonly(normalfile_filedesc_obj.flags) {
-                        return syscall_error(Errno::EBADF, "sync_file_range", "specified file not open for sync");
-                    }
                     let inodeobj = FS_METADATA.inodetable.get(&normalfile_filedesc_obj.inode).unwrap();
                     match &*inodeobj {
                         Inode::File(_) => {


### PR DESCRIPTION
## Description

We deleted the code that restrict us from calling syncing_file_ranges on read-only files. It is possible to call syncing_file_ranges for read-only files.

### Type of change

<!-- Please delete options that are not relevant. -->

-  Bug fix (non-breaking change which fixes an issue)
-  Breaking change (fix or feature that would cause existing functionality to not work as expected)

