### PR TITLE
fixes for running lind install

### DIFF
--- a/gen_netdevs.sh
+++ b/gen_netdevs.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 WORKDIR=$(pwd)  # Set working directory to the output of pwd
 FILE="$WORKDIR/gen_netdevs"  # Use the full path for the file
+PARENTPATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P ) # needs the source location when being used in lind-build.
+
 if [ -f "$FILE" ]; then
     echo "$FILE exists."
 else 
     echo "$FILE does not exist. Compiling."
-    gcc "$WORKDIR/gen_netdevs.c" -o "$WORKDIR/gen_netdevs"
+    gcc "$PARENTPATH/gen_netdevs.c" -o "$WORKDIR/gen_netdevs"
     if [ $? -ne 0 ]; then  # Check if gcc succeeded
         echo "Compilation failed."
         exit 1


### PR DESCRIPTION
## Description

Using WORKDIR=$(pwd) in gen_netdevs.sh was causing lind build to fail, since make was executing this script from lindenv inside of LIND_HOME/lind. as this location didnt contain the gen_netdevs.c . 

Fixes # (issue)

<!-- Please include a summary of the changes and the related issue. --> 
using the BASH_SOURCE  to get the location of the script and creating the absolute path for gen_netdevs.c on the fly.
added a new PARENTPATH - absolute path of safeposix-rust.
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

### Type of change

<!-- Please delete options that are not relevant. -->

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

- Test A - `lind_project/tests/test_cases/test_a.c`
- Test B - `lind_project/tests/test_cases/test_b.c`

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [ x ] My code follows the style guidelines of this project
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
