### PR TITLE
Open/Close Performance/Style Fixes

### DIFF
--- a/src/interface/file.rs
+++ b/src/interface/file.rs
@@ -31,8 +31,12 @@ pub fn removefile(filename: String) -> std::io::Result<()> {
     Ok(())
 }
 
-pub fn openfile(filename: String) -> std::io::Result<EmulatedFile> {
-    EmulatedFile::new(filename)
+pub fn openfile(filename: String, filesize: usize) -> std::io::Result<EmulatedFile> {
+    EmulatedFile::new(filename, filesize)
+}
+
+pub fn openmetadata(filename: String) -> std::io::Result<EmulatedFile> {
+    EmulatedFile::new_metadata(filename)
 }
 
 #[derive(Debug)]
@@ -49,7 +53,13 @@ pub fn pathexists(filename: String) -> bool {
 
 impl EmulatedFile {
 
-    fn new(filename: String) -> std::io::Result<EmulatedFile> {
+    fn new(filename: String, filesize: usize) -> std::io::Result<EmulatedFile> {
+
+        let f = OpenOptions::new().read(true).write(true).create(true).open(filename.clone()).unwrap();
+        Ok(EmulatedFile {filename: filename, fobj: Some(Arc::new(Mutex::new(f))), filesize: filesize})
+    }
+
+    fn new_metadata(filename: String) -> std::io::Result<EmulatedFile> {
 
         let f = OpenOptions::new().read(true).write(true).create(true).open(filename.clone()).unwrap();
 
@@ -57,6 +67,7 @@ impl EmulatedFile {
 
         Ok(EmulatedFile {filename: filename, fobj: Some(Arc::new(Mutex::new(f))), filesize: filesize as usize})
     }
+
 
     pub fn close(&self) -> std::io::Result<()> {
         Ok(())

--- a/src/interface/file.rs
+++ b/src/interface/file.rs
@@ -53,8 +53,8 @@ pub fn removefile(filename: String) -> std::io::Result<()> {
     Ok(())
 }
 
-pub fn openfile(filename: String, create: bool) -> std::io::Result<EmulatedFile> {
-    EmulatedFile::new(filename, create)
+pub fn openfile(filename: String) -> std::io::Result<EmulatedFile> {
+    EmulatedFile::new(filename)
 }
 
 #[derive(Debug)]
@@ -71,22 +71,12 @@ pub fn pathexists(filename: String) -> bool {
 
 impl EmulatedFile {
 
-    fn new(filename: String, create: bool) -> std::io::Result<EmulatedFile> {
+    fn new(filename: String) -> std::io::Result<EmulatedFile> {
         if OPEN_FILES.contains(&filename) {
             panic!("FileInUse");
         }
 
-        let path: RustPathBuf = [".".to_string(), filename.clone()].iter().collect();
-
-        let f = if !path.exists() {
-            if !create {
-              panic!("Cannot open non-existent file {}", filename);
-            }
-
-            OpenOptions::new().read(true).write(true).create(true).open(filename.clone())
-        } else {
-            OpenOptions::new().read(true).write(true).open(filename.clone())
-        }?;
+        let f = OpenOptions::new().read(true).write(true).create(true).open(filename.clone()).unwrap();
 
         OPEN_FILES.insert(filename.clone());
         let filesize = f.metadata()?.len();

--- a/src/safeposix/filesystem.rs
+++ b/src/safeposix/filesystem.rs
@@ -127,7 +127,7 @@ impl FilesystemMetadata {
     pub fn init_fs_metadata() -> FilesystemMetadata {
         // Read CBOR from file
         if interface::pathexists(METADATAFILENAME.to_string()) {
-            let metadata_fileobj = interface::openfile(METADATAFILENAME.to_string(), false).unwrap();
+            let metadata_fileobj = interface::openfile(METADATAFILENAME.to_string()).unwrap();
             let metadatabytes = metadata_fileobj.readfile_to_new_bytes().unwrap();
             metadata_fileobj.close().unwrap();
     
@@ -226,13 +226,13 @@ pub fn load_fs() {
     // If the metadata file exists, just close the file for later restore
     // If it doesn't, lets create a new one, load special files, and persist it.
     if interface::pathexists(METADATAFILENAME.to_string()) {
-        let metadata_fileobj = interface::openfile(METADATAFILENAME.to_string(), true).unwrap();
+        let metadata_fileobj = interface::openfile(METADATAFILENAME.to_string()).unwrap();
         metadata_fileobj.close().unwrap();
 
         // if we have a log file at this point, we need to sync it with the existing metadata
         if interface::pathexists(LOGFILENAME.to_string()) {
 
-            let log_fileobj = interface::openfile(LOGFILENAME.to_string(), false).unwrap();
+            let log_fileobj = interface::openfile(LOGFILENAME.to_string()).unwrap();
             // read log file and parse count
             let mut logread = log_fileobj.readfile_to_new_bytes().unwrap();
             let logsize = interface::convert_bytes_to_size(&logread[0..interface::COUNTMAPSIZE]);
@@ -333,7 +333,7 @@ pub fn persist_metadata(metadata: &FilesystemMetadata) {
     let _ = interface::removefile(METADATAFILENAME.to_string());
 
     // write to file
-    let mut metadata_fileobj = interface::openfile(METADATAFILENAME.to_string(), true).unwrap();
+    let mut metadata_fileobj = interface::openfile(METADATAFILENAME.to_string()).unwrap();
     metadata_fileobj.writefile_from_bytes(&metadatabytes).unwrap();
     metadata_fileobj.close().unwrap();
 }

--- a/src/safeposix/filesystem.rs
+++ b/src/safeposix/filesystem.rs
@@ -127,7 +127,7 @@ impl FilesystemMetadata {
     pub fn init_fs_metadata() -> FilesystemMetadata {
         // Read CBOR from file
         if interface::pathexists(METADATAFILENAME.to_string()) {
-            let metadata_fileobj = interface::openfile(METADATAFILENAME.to_string()).unwrap();
+            let metadata_fileobj = interface::openmetadata(METADATAFILENAME.to_string()).unwrap();
             let metadatabytes = metadata_fileobj.readfile_to_new_bytes().unwrap();
             metadata_fileobj.close().unwrap();
     
@@ -226,13 +226,13 @@ pub fn load_fs() {
     // If the metadata file exists, just close the file for later restore
     // If it doesn't, lets create a new one, load special files, and persist it.
     if interface::pathexists(METADATAFILENAME.to_string()) {
-        let metadata_fileobj = interface::openfile(METADATAFILENAME.to_string()).unwrap();
+        let metadata_fileobj = interface::openmetadata(METADATAFILENAME.to_string()).unwrap();
         metadata_fileobj.close().unwrap();
 
         // if we have a log file at this point, we need to sync it with the existing metadata
         if interface::pathexists(LOGFILENAME.to_string()) {
 
-            let log_fileobj = interface::openfile(LOGFILENAME.to_string()).unwrap();
+            let log_fileobj = interface::openmetadata(LOGFILENAME.to_string()).unwrap();
             // read log file and parse count
             let mut logread = log_fileobj.readfile_to_new_bytes().unwrap();
             let logsize = interface::convert_bytes_to_size(&logread[0..interface::COUNTMAPSIZE]);
@@ -333,7 +333,7 @@ pub fn persist_metadata(metadata: &FilesystemMetadata) {
     let _ = interface::removefile(METADATAFILENAME.to_string());
 
     // write to file
-    let mut metadata_fileobj = interface::openfile(METADATAFILENAME.to_string()).unwrap();
+    let mut metadata_fileobj = interface::openmetadata(METADATAFILENAME.to_string()).unwrap();
     metadata_fileobj.writefile_from_bytes(&metadatabytes).unwrap();
     metadata_fileobj.close().unwrap();
 }

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1828,7 +1828,7 @@ impl Cage {
                     panic!("Somehow a normal file with an fd was truncated but there was no file object in rustposix?");
                 } else {
                     let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
-                    tempbind = interface::openfile(sysfilename, filesize).unwrap(); // create new file
+                    tempbind = interface::openfile(sysfilename, filesize).unwrap(); // open file with size given from inode
                     close_on_exit = true;
                     &mut tempbind
                 };

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1314,10 +1314,10 @@ impl Cage {
                                     FS_METADATA.inodetable.remove(&inodenum);
                                     let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
                                     interface::removefile(sysfilename).unwrap();
+                                    log_metadata(&FS_METADATA, inodenum);
                                 } else {
                                     drop(inodeobj);
                                 }
-                                log_metadata(&FS_METADATA, inodenum);
                             }
                         },
                         Inode::Dir(ref mut dir_inode_obj) => {

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -79,7 +79,7 @@ impl Cage {
 
                 if let interface::RustHashEntry::Vacant(vac) = FILEOBJECTTABLE.entry(newinodenum){
                     let sysfilename = format!("{}{}", FILEDATAPREFIX, newinodenum);
-                    vac.insert(interface::openfile(sysfilename).unwrap());
+                    vac.insert(interface::openfile(sysfilename, 0).unwrap()); // new file of size 0
                 }
                 
                 let _insertval = fdoption.insert(File(self._file_initializer(newinodenum, flags, 0)));
@@ -116,7 +116,7 @@ impl Cage {
                         
                         if let interface::RustHashEntry::Vacant(vac) = FILEOBJECTTABLE.entry(inodenum){
                             let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
-                            vac.insert(interface::openfile(sysfilename).unwrap());
+                            vac.insert(interface::openfile(sysfilename, f.size).unwrap()); // use existing file size
                         }
                         
                         size = f.size;
@@ -1828,7 +1828,7 @@ impl Cage {
                     panic!("Somehow a normal file with an fd was truncated but there was no file object in rustposix?");
                 } else {
                     let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
-                    tempbind = interface::openfile(sysfilename).unwrap();
+                    tempbind = interface::openfile(sysfilename, 0).unwrap(); // create new file
                     close_on_exit = true;
                     &mut tempbind
                 };

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1828,7 +1828,7 @@ impl Cage {
                     panic!("Somehow a normal file with an fd was truncated but there was no file object in rustposix?");
                 } else {
                     let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
-                    tempbind = interface::openfile(sysfilename, 0).unwrap(); // create new file
+                    tempbind = interface::openfile(sysfilename, filesize).unwrap(); // create new file
                     close_on_exit = true;
                     &mut tempbind
                 };

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -79,7 +79,7 @@ impl Cage {
 
                 if let interface::RustHashEntry::Vacant(vac) = FILEOBJECTTABLE.entry(newinodenum){
                     let sysfilename = format!("{}{}", FILEDATAPREFIX, newinodenum);
-                    vac.insert(interface::openfile(sysfilename, true).unwrap());
+                    vac.insert(interface::openfile(sysfilename).unwrap());
                 }
                 
                 let _insertval = fdoption.insert(File(self._file_initializer(newinodenum, flags, 0)));
@@ -116,7 +116,7 @@ impl Cage {
                         
                         if let interface::RustHashEntry::Vacant(vac) = FILEOBJECTTABLE.entry(inodenum){
                             let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
-                            vac.insert(interface::openfile(sysfilename, true).unwrap());
+                            vac.insert(interface::openfile(sysfilename).unwrap());
                         }
                         
                         size = f.size;
@@ -1828,7 +1828,7 @@ impl Cage {
                     panic!("Somehow a normal file with an fd was truncated but there was no file object in rustposix?");
                 } else {
                     let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
-                    tempbind = interface::openfile(sysfilename, true).unwrap();
+                    tempbind = interface::openfile(sysfilename).unwrap();
                     close_on_exit = true;
                     &mut tempbind
                 };


### PR DESCRIPTION
## Description

Fixes # (issue)
This removes a lot of cruft in the interface open that was leftover from the RePy transition and was unesccesary as well as decreasing the performance of open. It also fixes a minor bug in logging in close that was also making some performance losses.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
- RustPOSIX test suite
- Main Lind test suite
- All LAMP/IPC tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings

