### PR TITLE
clarifing octal and fixing NONBLOCK bug

### DIFF
--- a/src/safeposix/filesystem.rs
+++ b/src/safeposix/filesystem.rs
@@ -171,7 +171,7 @@ pub fn format_fs() {
     let time = interface::timestamp(); //We do a real timestamp now
     let devdirinode = Inode::Dir(DirectoryInode {
         size: 0, uid: DEFAULT_UID, gid: DEFAULT_GID,
-        mode: (S_IFDIR | 0755) as u32,
+        mode: (S_IFDIR | 0o755) as u32,
         linkcount: 3 + 4, //3 for ., .., and the parent dir, 4 is one for each child we will create
         refcount: 0,
         atime: time, ctime: time, mtime: time,
@@ -179,31 +179,31 @@ pub fn format_fs() {
     }); //inode 2
     let nullinode = Inode::CharDev(DeviceInode {
         size: 0, uid: DEFAULT_UID, gid: DEFAULT_UID,
-        mode: (S_IFCHR | 0666) as u32, linkcount: 1, refcount: 0,
+        mode: (S_IFCHR | 0o666) as u32, linkcount: 1, refcount: 0,
         atime: time, ctime: time, mtime: time,
         dev: DevNo {major: 1, minor: 3},
     }); //inode 3
     let zeroinode = Inode::CharDev(DeviceInode {
         size: 0, uid: DEFAULT_UID, gid: DEFAULT_UID,
-        mode: (S_IFCHR | 0666) as u32, linkcount: 1, refcount: 0,
+        mode: (S_IFCHR | 0o666) as u32, linkcount: 1, refcount: 0,
         atime: time, ctime: time, mtime: time,
         dev: DevNo {major: 1, minor: 5},
     }); //inode 4
     let urandominode = Inode::CharDev(DeviceInode {
         size: 0, uid: DEFAULT_UID, gid: DEFAULT_UID,
-        mode: (S_IFCHR | 0666) as u32, linkcount: 1, refcount: 0,
+        mode: (S_IFCHR | 0o666) as u32, linkcount: 1, refcount: 0,
         atime: time, ctime: time, mtime: time,
         dev: DevNo {major: 1, minor: 9},
     }); //inode 5
     let randominode = Inode::CharDev(DeviceInode {
         size: 0, uid: DEFAULT_UID, gid: DEFAULT_UID,
-        mode: (S_IFCHR | 0666) as u32, linkcount: 1, refcount: 0,
+        mode: (S_IFCHR | 0o666) as u32, linkcount: 1, refcount: 0,
         atime: time, ctime: time, mtime: time,
         dev: DevNo {major: 1, minor: 8},
     }); //inode 6
     let tmpdirinode = Inode::Dir(DirectoryInode {
         size: 0, uid: DEFAULT_UID, gid: DEFAULT_GID,
-        mode: (S_IFDIR | 0755) as u32,
+        mode: (S_IFDIR | 0o755) as u32,
         linkcount: 3 + 4, 
         refcount: 0,
         atime: time, ctime: time, mtime: time,

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -182,7 +182,7 @@ impl Cage {
                 } else {
                     return syscall_error(Errno::ENOTDIR, "bind", "unix domain socket path made socket address child of non-directory file");
                 }
-                sockhandle.unix_info = Some(UnixSocketInfo {mode: S_IFSOCK | 0666, sendpipe: None, receivepipe: None, inode: newinodenum});  
+                sockhandle.unix_info = Some(UnixSocketInfo {mode: S_IFSOCK | 0o666, sendpipe: None, receivepipe: None, inode: newinodenum});  
                 NET_METADATA.domsock_paths.insert(truepath);
                 FS_METADATA.inodetable.insert(newinodenum, newinode);
             }

--- a/src/safeposix/syscalls/net_constants.rs
+++ b/src/safeposix/syscalls/net_constants.rs
@@ -18,8 +18,8 @@ pub const SOCK_DGRAM: i32 = 2; //datagram socket
 pub const SOCK_RAW: i32 = 3; //raw protocol interface
 pub const SOCK_RDM: i32 = 4; //reliably delivered message
 pub const SOCK_SEQPACKET: i32 = 5; //sequenced packet stream
-pub const SOCK_CLOEXEC: i32 = 02000000;
-pub const SOCK_NONBLOCK: i32 = 0x4000;
+pub const SOCK_CLOEXEC: i32 =  0o02000000; // Atomically set close-on-exec 
+pub const SOCK_NONBLOCK: i32 = 0o00004000;// Mark as non-blocking
 
 /* Supported address families. */
 pub const AF_UNSPEC: i32 = 0;
@@ -356,12 +356,12 @@ pub const MINSOCKOBJID: i32 = 0;
 pub const MAXSOCKOBJID: i32 = 1024;
 
 //POLL CONSTANTS
-pub const POLLIN: i16 = 01;  // There is data to read.
-pub const POLLPRI: i16 = 02; //There is urgent data to read.
-pub const POLLOUT: i16 = 04; // Writing now will not block.
-pub const POLLERR: i16 = 010; // Error condition.
-pub const POLLHUP: i16 = 020; // Hung up.
-pub const POLLNVAL: i16 = 040; // Invalid polling request.
+pub const POLLIN: i16 = 0o1;  // There is data to read.
+pub const POLLPRI: i16 = 0o2; //There is urgent data to read.
+pub const POLLOUT: i16 = 0o4; // Writing now will not block.
+pub const POLLERR: i16 = 0o10; // Error condition.
+pub const POLLHUP: i16 = 0o20; // Hung up.
+pub const POLLNVAL: i16 = 0o40; // Invalid polling request.
 
 //EPOLL CONSTANTS
 pub const EPOLLIN: i32 = 0x001;


### PR DESCRIPTION
## Description


Fixes incorrect constants due to confusion primarily about how Rust handles Octal values.  This is partially related to [the clippy issue on the main tracker](https://github.com/Lind-Project/lind_project/issues/373#issuecomment-2102774715).

In Rust, an octal must be written as 0oXXXX, instead of C where you can write 0XXXX.  This is the heart of most of this confusion.

While fixing this, I also noticed an error with the SOCK_NONBLOCK flag.  Did I mention we need more testing?  😁 

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I don't have a complete environment running locally so didn't test.  I did double check the constants in both glibc and NaCl to make sure they are correct.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] My changes generate no new warnings
