### PR TITLE
Fix benchmarks

### DIFF
--- a/benches/fs_open_close.rs
+++ b/benches/fs_open_close.rs
@@ -43,8 +43,8 @@ pub fn run_benchmark(c: &mut Criterion) {
     group.bench_function("TF01: Lind open+close", |b| {
         b.iter(|| {
             let fd = cage.open_syscall("foo", O_CREAT | O_TRUNC | O_WRONLY, S_IRWXA);
-            assert!(fd>2); // Ensure we didn't get an error or an odd fd
-            assert_eq!(cage.close_syscall(fd),0);  // close the file w/o error
+            assert!(fd > 2); // Ensure we didn't get an error or an odd fd
+            assert_eq!(cage.close_syscall(fd), 0); // close the file w/o error
         })
     });
 
@@ -56,8 +56,8 @@ pub fn run_benchmark(c: &mut Criterion) {
                 O_CREAT | O_TRUNC | O_WRONLY,
                 S_IRWXA,
             );
-            assert!(fd>2); // Ensure we didn't get an error or an odd fd
-            assert_eq!(libc::close(fd),0);  // close the file w/o error
+            assert!(fd > 2); // Ensure we didn't get an error or an odd fd
+            assert_eq!(libc::close(fd), 0); // close the file w/o error
         })
     });
     group.finish();

--- a/benches/fs_open_close.rs
+++ b/benches/fs_open_close.rs
@@ -43,7 +43,8 @@ pub fn run_benchmark(c: &mut Criterion) {
     group.bench_function("TF01: Lind open+close", |b| {
         b.iter(|| {
             let fd = cage.open_syscall("foo", O_CREAT | O_TRUNC | O_WRONLY, S_IRWXA);
-            cage.close_syscall(fd);
+            assert!(fd>2); // Ensure we didn't get an error or an odd fd
+            assert_eq!(cage.close_syscall(fd),0);  // close the file w/o error
         })
     });
 
@@ -55,7 +56,8 @@ pub fn run_benchmark(c: &mut Criterion) {
                 O_CREAT | O_TRUNC | O_WRONLY,
                 S_IRWXA,
             );
-            libc::close(fd);
+            assert!(fd>2); // Ensure we didn't get an error or an odd fd
+            assert_eq!(libc::close(fd),0);  // close the file w/o error
         })
     });
     group.finish();

--- a/benches/fs_read_write.rs
+++ b/benches/fs_read_write.rs
@@ -177,7 +177,6 @@ pub fn run_benchmark(c: &mut Criterion) {
             // reset the file position
             libc::lseek(fd, 0, SEEK_SET);
         }
-        println!("FILE LENGTH: {}", file_length);
 
         // My current position when reading...
         let mut pos = 0;
@@ -197,7 +196,6 @@ pub fn run_benchmark(c: &mut Criterion) {
                     if file_length <= pos {
                         libc::lseek(fd, 0, SEEK_SET);
                         pos = 0;
-                        print!(".");
                     }
                     assert_eq!(
                         libc::read(fd, read_buffer.as_mut_ptr() as *mut c_void, *buflen),

--- a/benches/fs_read_write.rs
+++ b/benches/fs_read_write.rs
@@ -54,7 +54,7 @@ pub fn run_benchmark(c: &mut Criterion) {
             &String::from_utf8(vec![b'X'; *buflen]).expect("error building string"),
         );
 
-        let fd = cage.open_syscall("foo", O_CREAT | O_TRUNC | O_WRONLY, S_IRWXA);
+        let fd = cage.open_syscall("foo", O_CREAT | O_TRUNC | O_RDWR, S_IRWXA);
         // Let's see how fast various file system calls are
         group.bench_with_input(
             BenchmarkId::new("TF02:Lind write", buflen),
@@ -94,7 +94,7 @@ pub fn run_benchmark(c: &mut Criterion) {
         let path = c_str.into_raw() as *const u8;
 
         unsafe {
-            fd = libc::open(path, O_CREAT | O_TRUNC | O_WRONLY, S_IRWXA);
+            fd = libc::open(path, O_CREAT | O_TRUNC | O_RDWR, S_IRWXA);
         }
 
         let deststring = tests::str2cbuf(

--- a/benches/fs_read_write_seek.rs
+++ b/benches/fs_read_write_seek.rs
@@ -53,6 +53,12 @@ pub fn run_benchmark(c: &mut Criterion) {
             &String::from_utf8(vec![b'X'; *buflen]).expect("error building string"),
         );
 
+        // The size of the buffer and the amount we expect to read and write.
+        // I need to type convert this because it's a usize by default.
+        // I'm lazily converting with as here because it's not feasible to
+        // test values where usize would overflow this.
+        let expected_retval = *buflen as i32;
+
         let read_buffer = tests::sizecbuf(*buflen).as_mut_ptr();
         // Let's see how fast various file system calls are
         group.bench_with_input(
@@ -60,10 +66,10 @@ pub fn run_benchmark(c: &mut Criterion) {
             buflen,
             |b, buflen| {
                 b.iter(|| {
-                    let _ = cage.write_syscall(fd, deststring, *buflen);
-                    cage.lseek_syscall(fd, 0, SEEK_SET);
-                    cage.read_syscall(fd, read_buffer, *buflen);
-                    cage.lseek_syscall(fd, 0, SEEK_SET);
+                    assert_eq!(cage.write_syscall(fd, deststring, *buflen),expected_retval);
+                    assert_eq!(cage.lseek_syscall(fd, 0, SEEK_SET),0);
+                    assert_eq!(cage.read_syscall(fd, read_buffer, *buflen),expected_retval);
+                    assert_eq!(cage.lseek_syscall(fd, 0, SEEK_SET),0);
                 })
             },
         );
@@ -92,16 +98,24 @@ pub fn run_benchmark(c: &mut Criterion) {
 
         let read_buffer = tests::sizecbuf(*buflen).as_mut_ptr();
 
+        // The size of the buffer and the amount we expect to read and write.
+        // I need to type convert this because it's a usize by default.
+        // I'm lazily converting with as here because it's not feasible to
+        // test values where usize would overflow this.
+        // NOTE: This has a different type than Lind, which is i32.  I think
+        // this is likely okay.
+        let expected_retval = *buflen as isize;
+
         // For comparison let's time the native OS...
         group.bench_with_input(
             BenchmarkId::new("TF03:Native write+read+lseek", buflen),
             buflen,
             |b, buflen| {
                 b.iter(|| unsafe {
-                    let _ = libc::write(fd, deststring as *const c_void, *buflen);
-                    libc::lseek(fd, 0, SEEK_SET);
-                    libc::read(fd, read_buffer as *mut c_void, *buflen);
-                    libc::lseek(fd, 0, SEEK_SET);
+                    assert_eq!(libc::write(fd, deststring as *const c_void, *buflen),expected_retval);
+                    assert_eq!(libc::lseek(fd, 0, SEEK_SET),0);
+                    assert_eq!(libc::read(fd, read_buffer as *mut c_void, *buflen),expected_retval);
+                    assert_eq!(libc::lseek(fd, 0, SEEK_SET),0);
                 })
             },
         );
@@ -118,7 +132,7 @@ pub fn run_benchmark(c: &mut Criterion) {
     rustposix::safeposix::dispatcher::lindrustfinalize();
 }
 
-criterion_group!(name=benches; 
+criterion_group!(name=benches;
                  // Add the global settings here so we don't type it everywhere
                  config=global_criterion_settings::get_criterion(); 
                  targets=run_benchmark);

--- a/benches/fs_read_write_seek.rs
+++ b/benches/fs_read_write_seek.rs
@@ -66,10 +66,10 @@ pub fn run_benchmark(c: &mut Criterion) {
             buflen,
             |b, buflen| {
                 b.iter(|| {
-                    assert_eq!(cage.write_syscall(fd, deststring, *buflen),expected_retval);
-                    assert_eq!(cage.lseek_syscall(fd, 0, SEEK_SET),0);
-                    assert_eq!(cage.read_syscall(fd, read_buffer, *buflen),expected_retval);
-                    assert_eq!(cage.lseek_syscall(fd, 0, SEEK_SET),0);
+                    assert_eq!(cage.write_syscall(fd, deststring, *buflen), expected_retval);
+                    assert_eq!(cage.lseek_syscall(fd, 0, SEEK_SET), 0);
+                    assert_eq!(cage.read_syscall(fd, read_buffer, *buflen), expected_retval);
+                    assert_eq!(cage.lseek_syscall(fd, 0, SEEK_SET), 0);
                 })
             },
         );
@@ -112,10 +112,16 @@ pub fn run_benchmark(c: &mut Criterion) {
             buflen,
             |b, buflen| {
                 b.iter(|| unsafe {
-                    assert_eq!(libc::write(fd, deststring as *const c_void, *buflen),expected_retval);
-                    assert_eq!(libc::lseek(fd, 0, SEEK_SET),0);
-                    assert_eq!(libc::read(fd, read_buffer as *mut c_void, *buflen),expected_retval);
-                    assert_eq!(libc::lseek(fd, 0, SEEK_SET),0);
+                    assert_eq!(
+                        libc::write(fd, deststring as *const c_void, *buflen),
+                        expected_retval
+                    );
+                    assert_eq!(libc::lseek(fd, 0, SEEK_SET), 0);
+                    assert_eq!(
+                        libc::read(fd, read_buffer as *mut c_void, *buflen),
+                        expected_retval
+                    );
+                    assert_eq!(libc::lseek(fd, 0, SEEK_SET), 0);
                 })
             },
         );

--- a/benches/fs_read_write_seek.rs
+++ b/benches/fs_read_write_seek.rs
@@ -47,7 +47,7 @@ pub fn run_benchmark(c: &mut Criterion) {
 
     // Iterate for different buffer sizes...
     for buflen in [1, 64, 1024, 65536].iter() {
-        let fd = cage.open_syscall("foo", O_CREAT | O_TRUNC | O_WRONLY, S_IRWXA);
+        let fd = cage.open_syscall("foo", O_CREAT | O_TRUNC | O_RDWR, S_IRWXA);
 
         let deststring = tests::str2cbuf(
             &String::from_utf8(vec![b'X'; *buflen]).expect("error building string"),
@@ -83,7 +83,7 @@ pub fn run_benchmark(c: &mut Criterion) {
         let path = c_str.into_raw() as *const u8;
 
         unsafe {
-            fd = libc::open(path, O_CREAT | O_TRUNC | O_WRONLY, S_IRWXA);
+            fd = libc::open(path, O_CREAT | O_TRUNC | O_RDWR, S_IRWXA);
         }
 
         let deststring = tests::str2cbuf(


### PR DESCRIPTION
## Description

Partial fix for #242 

This fixes the two example problems listed in #242.  However, #241 is not addressed here (which is noted in the code along with instructions about how to change the code after fixing this bug).

Furthermore, a bug still exists leading to some memory corruption issues.  (Notice the XXXXXXX in the output below is indicative that a string with the test name was overwritten by the [construction of deststring](https://github.com/Lind-Project/safeposix-rust/blob/fix_benchmarks/benches/fs_read_write.rs#L53-L55).)

I would appreciate help to track down the memory corruption issue.


`Compare fs:write+read+lseek/TF03:Lind write+read+lseek/1                        
                        time:   [1.0006 µs 1.0080 µs 1.0200 µs]
                        change: [+2.9263% +3.7612% +4.6903%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) high mild
  7 (7.00%) high severe
Benchmarking Compare fs:write+read+lseek/TF03:Lind write+read+lseek/64: Warming                                                                                 Benchmarking XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX: Collecti                                                                                Benchmarking XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX: Analyzin                                                                                XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
                        time:   [1.0222 µs 1.0229 µs 1.0236 µs]
                        change: [+3.1119% +4.1536% +5.9263%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe
Benchmarking Compare fs:write+read+lseek/TF03:Lind write+read+lseek/1024: Warmin                                                                                Benchmarking Compare fs:write+read+lseek/TF03:Lind write+read+lseek/1024: Collec                                                                                Benchmarking Compare fs:write+read+lseek/TF03:Lind write+read+lseek/1024: Analyz                                                                                Compare fs:write+read+lseek/TF03:Lind write+read+lseek/1024
                        time:   [1.0780 µs 1.0958 µs 1.1209 µs]
                        change: [+6.9239% +21.318% +44.944%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 21 outliers among 100 measurements (21.00%)
  4 (4.00%) high mild
  17 (17.00%) high severe
Benchmarking Compare fs:write+read+lseek/TF03:Lind write+read+lseek/65536: Warmi                                                                                Benchmarking Compare fs:write+read+lseek/TF03:Lind write+read+lseek/65536: Colle                                                                                Benchmarking Compare fs:write+read+lseek/TF03:Lind write+read+lseek/65536: Analy                                                                                Compare fs:write+read+lseek/TF03:Lind write+read+lseek/65536
                        time:   [5.4057 µs 5.4267 µs 5.4614 µs]
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  8 (8.00%) high severe
error: bench failed, to rerun pass '--bench fs_read_write_seek'

Caused by:
  process didn't exit successfully: '/home/test/safeposix-rust/target/release/deps/fs_read_write_seek-adecf1c62a8ef04d --bench' (signal: 11, SIGSEGV: invalid memory reference)
`

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Run on docker on my mac using cargo bench

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
