### PR TITLE
Add UDS/Pipe to writev()/Fix UDS EPIPE on send

### DIFF
--- a/src/interface/file.rs
+++ b/src/interface/file.rs
@@ -18,8 +18,8 @@ use crate::interface::errnos::{syscall_error, Errno};
 use libc::{mmap, mremap, munmap, off64_t, MAP_SHARED, MREMAP_MAYMOVE, PROT_READ, PROT_WRITE};
 use std::convert::TryInto;
 use std::ffi::c_void;
+use std::os::unix::fs::FileExt;
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::os::unix::fs::{FileExt};
 
 pub fn removefile(filename: String) -> std::io::Result<()> {
     let path: RustPathBuf = [".".to_string(), filename].iter().collect();
@@ -514,7 +514,9 @@ mod tests {
         let emulated_file = EmulatedFile::new(file_path.clone(), file_content.len()).unwrap();
 
         let mut buffer = vec![0; file_content.len()];
-        let bytes_read = emulated_file.readat(buffer.as_mut_ptr(), buffer.len(), 0).unwrap();
+        let bytes_read = emulated_file
+            .readat(buffer.as_mut_ptr(), buffer.len(), 0)
+            .unwrap();
 
         assert_eq!(bytes_read, file_content.len());
         assert_eq!(buffer, file_content);
@@ -529,13 +531,17 @@ mod tests {
         let mut emulated_file = EmulatedFile::new(file_path.clone(), file_content.len()).unwrap();
 
         let new_content = b"test_writeat_emulated_file, world!";
-        let bytes_written = emulated_file.writeat(new_content.as_ptr(), new_content.len(), 0).unwrap();
+        let bytes_written = emulated_file
+            .writeat(new_content.as_ptr(), new_content.len(), 0)
+            .unwrap();
 
         assert_eq!(bytes_written, new_content.len());
         assert_eq!(emulated_file.filesize, new_content.len());
 
         let mut buffer = vec![0; new_content.len()];
-        emulated_file.readat(buffer.as_mut_ptr(), buffer.len(), 0).unwrap();
+        emulated_file
+            .readat(buffer.as_mut_ptr(), buffer.len(), 0)
+            .unwrap();
         assert_eq!(buffer, new_content);
     }
 }

--- a/src/interface/pipe.rs
+++ b/src/interface/pipe.rs
@@ -152,16 +152,19 @@ impl EmulatedPipe {
         let mut buf = Vec::new();
         let mut length = 0;
 
+        // we're going to loop through the iovec array and combine the buffers into one slice, recording the length
+        // this is hacky but is the best way to do this for now
         for _iov in 0..iovcnt {
             unsafe {
-                let iovec = *ptr;
                 assert!(!ptr.is_null());
+                let iovec = *ptr;
                 let iovbuf = slice::from_raw_parts(iovec.iov_base as *const u8, iovec.iov_len);
                 buf.extend_from_slice(iovbuf);
                 length = length + iovec.iov_len
             };
         }
 
+        // now that we have a single buffer we can use the usual write to pipe function
         self.write_to_pipe(buf.as_ptr(), length, nonblocking)
     }
 

--- a/src/interface/pipe.rs
+++ b/src/interface/pipe.rs
@@ -143,8 +143,12 @@ impl EmulatedPipe {
     }
 
     // Write length bytes from pointer into pipe
-    pub fn write_vectored_to_pipe(&self, ptr: *const interface::IovecStruct, iovcnt: i32, nonblocking: bool) -> i32 {
-
+    pub fn write_vectored_to_pipe(
+        &self,
+        ptr: *const interface::IovecStruct,
+        iovcnt: i32,
+        nonblocking: bool,
+    ) -> i32 {
         let mut buf = Vec::new();
         let mut length = 0;
 

--- a/src/interface/pipe.rs
+++ b/src/interface/pipe.rs
@@ -142,6 +142,66 @@ impl EmulatedPipe {
         bytes_written as i32
     }
 
+    // Write length bytes from pointer into pipe
+    pub fn write_vectored_to_pipe(&self, ptr: *const interface::IovecStruct, iovcnt: i32, nonblocking: bool) -> i32 {
+        let mut total_bytes_written = 0;
+
+        let mut iovecs = Vec::new();
+
+        for _iov in 0..iovcnt {
+            unsafe {
+                let iovec = *ptr;
+                assert!(!ptr.is_null());
+                let buf = slice::from_raw_parts(iovec.iov_base as *const u8, iovec.iov_len);
+                iovecs.push((buf, iovec.iov_len));
+            };
+        }
+
+        let mut write_end = self.write_end.lock();
+
+        let pipe_space = write_end.remaining();
+        if nonblocking && (pipe_space == 0) {
+            return syscall_error(
+                Errno::EAGAIN,
+                "write",
+                "there is no data available right now, try again later",
+            );
+        }
+
+        for iovec in iovecs {
+            let mut bytes_written = 0;
+
+            let buf = iovec.0;
+            let length = iovec.1;
+
+            while bytes_written < length {
+                if self.get_read_ref() == 0 {
+                    return syscall_error(Errno::EPIPE, "write", "broken pipe");
+                } // EPIPE, all read ends are closed
+
+                let remaining = write_end.remaining();
+
+                if remaining == 0 {
+                    interface::lind_yield(); //yield on a full pipe
+                    continue;
+                }
+                // we write if the pipe is empty, otherwise we try to limit writes to 4096 bytes (unless whats leftover of this write is < 4096)
+                if remaining != self.size
+                    && (length - bytes_written) > PAGE_SIZE
+                    && remaining < PAGE_SIZE
+                {
+                    continue;
+                };
+                let bytes_to_write = min(length, bytes_written as usize + remaining);
+                write_end.push_slice(&buf[bytes_written..bytes_to_write]);
+                bytes_written = bytes_to_write;
+            }
+            total_bytes_written = total_bytes_written + bytes_written;
+        }
+
+        total_bytes_written as i32
+    }
+
     // Read length bytes from the pipe into pointer
     // Will wait for bytes unless pipe is empty and eof is set.
     pub fn read_from_pipe(&self, ptr: *mut u8, length: usize, nonblocking: bool) -> i32 {

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1263,10 +1263,12 @@ impl Cage {
                                         nonblocking = true;
                                     }
                                     let retval = match sockinfo.sendpipe.as_ref() {
-                                        Some(sendpipe) => {
-                                            sendpipe.write_vectored_to_pipe(iovec, iovcnt, nonblocking)
-                                                as i32
-                                        }
+                                        Some(sendpipe) => sendpipe.write_vectored_to_pipe(
+                                            iovec,
+                                            iovcnt,
+                                            nonblocking,
+                                        )
+                                            as i32,
                                         None => {
                                             return syscall_error(Errno::EAGAIN, "writev", "there is no data available right now, try again later");
                                         }
@@ -1284,7 +1286,7 @@ impl Cage {
                                     );
                                 }
                             }
-                        },
+                        }
                         _ => {
                             return syscall_error(
                                 Errno::EOPNOTSUPP,
@@ -1293,7 +1295,7 @@ impl Cage {
                             );
                         }
                     }
-                },
+                }
                 Pipe(pipe_filedesc_obj) => {
                     if is_rdonly(pipe_filedesc_obj.flags) {
                         return syscall_error(
@@ -1308,15 +1310,16 @@ impl Cage {
                         nonblocking = true;
                     }
 
-                    let retval = pipe_filedesc_obj
-                        .pipe
-                        .write_vectored_to_pipe(iovec, iovcnt, nonblocking)
-                        as i32;
+                    let retval =
+                        pipe_filedesc_obj
+                            .pipe
+                            .write_vectored_to_pipe(iovec, iovcnt, nonblocking)
+                            as i32;
                     if retval == -(Errno::EPIPE as i32) {
                         interface::lind_kill_from_id(self.cageid, SIGPIPE);
                     } // Trigger SIGPIPE
                     retval
-                },
+                }
                 _ => {
                     // we currently don't support writev for files/streams
                     return syscall_error(

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -842,8 +842,8 @@ impl Cage {
                         AF_UNIX => {
                             match sockhandle.protocol {
                                 IPPROTO_TCP => {
-                                    // to be able to send here we either need to be fully connected, or connected for write only
-                                    if (sockhandle.state != ConnState::CONNECTED)
+                                        // to be able to send here we either need to be fully connected, or connected for write only
+                                        if (sockhandle.state != ConnState::CONNECTED)
                                         && (sockhandle.state != ConnState::CONNWRONLY)
                                     {
                                         return syscall_error(
@@ -855,12 +855,12 @@ impl Cage {
                                     // get the socket pipe, write to it, and return bytes written
                                     let sockinfo = &sockhandle.unix_info.as_ref().unwrap();
                                     let mut nonblocking = false;
-                                    if socket_filedesc_obj.flags & O_NONBLOCK != 0 {
+                                    if sockfdobj.flags & O_NONBLOCK != 0 {
                                         nonblocking = true;
                                     }
                                     let retval = match sockinfo.sendpipe.as_ref() {
                                         Some(sendpipe) => {
-                                            sendpipe.write_vectored_to_pipe(iovec, iovcnt, nonblocking)
+                                            sendpipe.write_to_pipe(buf, buflen, nonblocking)
                                                 as i32
                                         }
                                         None => {

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -842,8 +842,8 @@ impl Cage {
                         AF_UNIX => {
                             match sockhandle.protocol {
                                 IPPROTO_TCP => {
-                                        // to be able to send here we either need to be fully connected, or connected for write only
-                                        if (sockhandle.state != ConnState::CONNECTED)
+                                    // to be able to send here we either need to be fully connected, or connected for write only
+                                    if (sockhandle.state != ConnState::CONNECTED)
                                         && (sockhandle.state != ConnState::CONNWRONLY)
                                     {
                                         return syscall_error(
@@ -860,8 +860,7 @@ impl Cage {
                                     }
                                     let retval = match sockinfo.sendpipe.as_ref() {
                                         Some(sendpipe) => {
-                                            sendpipe.write_to_pipe(buf, buflen, nonblocking)
-                                                as i32
+                                            sendpipe.write_to_pipe(buf, buflen, nonblocking) as i32
                                         }
                                         None => {
                                             return syscall_error(Errno::EAGAIN, "writev", "there is no data available right now, try again later");

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -842,41 +842,35 @@ impl Cage {
                         AF_UNIX => {
                             match sockhandle.protocol {
                                 IPPROTO_TCP => {
-                                    if sockhandle.state != ConnState::CONNECTED {
+                                    // to be able to send here we either need to be fully connected, or connected for write only
+                                    if (sockhandle.state != ConnState::CONNECTED)
+                                        && (sockhandle.state != ConnState::CONNWRONLY)
+                                    {
                                         return syscall_error(
                                             Errno::ENOTCONN,
-                                            "send",
+                                            "writev",
                                             "The descriptor is not connected",
                                         );
                                     }
-
                                     // get the socket pipe, write to it, and return bytes written
-                                    if let Some(sockinfo) = &sockhandle.unix_info {
-                                        let mut nonblocking = false;
-                                        if sockfdobj.flags & O_NONBLOCK != 0 {
-                                            nonblocking = true;
-                                        }
-                                        let retval = match sockinfo.sendpipe.as_ref() {
-                                            Some(sendpipe) => {
-                                                sendpipe.write_to_pipe(buf, buflen, nonblocking)
-                                                    as i32
-                                            }
-                                            None => {
-                                                return syscall_error(Errno::EAGAIN, "write", "there is no data available right now, try again later");
-                                            }
-                                        };
-                                        if retval < 0 {
-                                            return syscall_error(Errno::EAGAIN, "write", "there is no data available right now, try again later");
-                                        } else {
-                                            return retval;
-                                        }
+                                    let sockinfo = &sockhandle.unix_info.as_ref().unwrap();
+                                    let mut nonblocking = false;
+                                    if socket_filedesc_obj.flags & O_NONBLOCK != 0 {
+                                        nonblocking = true;
                                     }
-
-                                    return syscall_error(
-                                        Errno::EINPROGRESS,
-                                        "connect",
-                                        "The libc call to connect failed!",
-                                    );
+                                    let retval = match sockinfo.sendpipe.as_ref() {
+                                        Some(sendpipe) => {
+                                            sendpipe.write_vectored_to_pipe(iovec, iovcnt, nonblocking)
+                                                as i32
+                                        }
+                                        None => {
+                                            return syscall_error(Errno::EAGAIN, "writev", "there is no data available right now, try again later");
+                                        }
+                                    };
+                                    if retval == -(Errno::EPIPE as i32) {
+                                        interface::lind_kill_from_id(self.cageid, SIGPIPE);
+                                    } // Trigger SIGPIPE
+                                    retval
                                 }
                                 _ => {
                                     return syscall_error(

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -5,9 +5,9 @@ pub mod fs_tests {
     use crate::interface;
     use crate::safeposix::syscalls::fs_calls::*;
     use crate::safeposix::{cage::*, dispatcher::*, filesystem};
+    use libc::c_void;
     use std::fs::OpenOptions;
     use std::os::unix::fs::PermissionsExt;
-    use libc::c_void;
 
     pub fn test_fs() {
         ut_lind_fs_simple(); // has to go first, else the data files created screw with link count test

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -7,6 +7,7 @@ pub mod fs_tests {
     use crate::safeposix::{cage::*, dispatcher::*, filesystem};
     use std::fs::OpenOptions;
     use std::os::unix::fs::PermissionsExt;
+    use libc::c_void;
 
     pub fn test_fs() {
         ut_lind_fs_simple(); // has to go first, else the data files created screw with link count test
@@ -1023,7 +1024,6 @@ pub mod fs_tests {
         lindrustfinalize();
     }
 
-    use libc::c_void;
     pub fn ut_lind_fs_shm() {
         lindrustinit(0);
         let cage = interface::cagetable_getref(1);

--- a/src/tests/ipc_tests.rs
+++ b/src/tests/ipc_tests.rs
@@ -6,6 +6,7 @@ pub mod ipc_tests {
     use std::fs::OpenOptions;
     use std::os::unix::fs::PermissionsExt;
     use std::time::Instant;
+    use libc::c_void;
 
     //#[test]
     pub fn test_ipc() {
@@ -331,6 +332,64 @@ pub mod ipc_tests {
         cage.recv_syscall(socketpair.sock1, buf2.as_mut_ptr(), 15, 0);
         assert_eq!(cbuf2str(&buf2), "Socketpair Test");
 
+        thread.join().unwrap();
+
+        assert_eq!(cage.close_syscall(socketpair.sock1), 0);
+        assert_eq!(cage.close_syscall(socketpair.sock2), 0);
+
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    pub fn ut_lind_ipc_writev() {
+        lindrustinit(0);
+        let cage = interface::cagetable_getref(1);
+        let mut socketpair = interface::SockPair::default();
+        assert_eq!(
+            Cage::socketpair_syscall(cage.clone(), AF_UNIX, SOCK_STREAM, 0, &mut socketpair),
+            0
+        );
+        let cage2 = cage.clone();
+
+        let thread = interface::helper_thread(move || {
+            let mut buf = sizecbuf(10);
+            cage2.recv_syscall(socketpair.sock2, buf.as_mut_ptr(), 10, 0);
+            assert_eq!(cbuf2str(&buf), "test\0\0\0\0\0\0");
+
+            interface::sleep(interface::RustDuration::from_millis(30));
+            
+            let iovec: [interface::IovecStruct; 3] = [
+                interface::IovecStruct {
+                    iov_base: str2cbuf(&"A".repeat(100)) as *mut c_void,
+                    iov_len: 100,
+                },
+                interface::IovecStruct {
+                    iov_base: str2cbuf(&"B".repeat(100)) as *mut c_void,
+                    iov_len: 100,
+                },
+                interface::IovecStruct {
+                    iov_base: str2cbuf(&"C".repeat(100)) as *mut c_void,
+                    iov_len: 100,
+                },
+            ];
+    
+            assert_eq!(cage2.writev_syscall(socketpair.sock2, iovec.as_ptr(), 3), 300);
+        });
+
+        let iovec2: [interface::IovecStruct; 1] = [
+            interface::IovecStruct {
+                iov_base: str2cbuf("test") as *mut c_void,
+                iov_len: 4,
+            }
+        ];
+        assert_eq!(cage.writev_syscall(socketpair.sock1, iovec2.as_ptr(), 1), 4);
+
+
+        let mut buf2 = sizecbuf(300);
+        assert_eq!(
+            cage.recv_syscall(socketpair.sock1, buf2.as_mut_ptr(), 300, 0),
+            300
+        );
         thread.join().unwrap();
 
         assert_eq!(cage.close_syscall(socketpair.sock1), 0);

--- a/src/tests/ipc_tests.rs
+++ b/src/tests/ipc_tests.rs
@@ -3,10 +3,10 @@ pub mod ipc_tests {
     use super::super::*;
     use crate::interface;
     use crate::safeposix::{cage::*, dispatcher::*, filesystem};
+    use libc::c_void;
     use std::fs::OpenOptions;
     use std::os::unix::fs::PermissionsExt;
     use std::time::Instant;
-    use libc::c_void;
 
     //#[test]
     pub fn test_ipc() {
@@ -357,7 +357,7 @@ pub mod ipc_tests {
             assert_eq!(cbuf2str(&buf), "test\0\0\0\0\0\0");
 
             interface::sleep(interface::RustDuration::from_millis(30));
-            
+
             let iovec: [interface::IovecStruct; 3] = [
                 interface::IovecStruct {
                     iov_base: str2cbuf(&"A".repeat(100)) as *mut c_void,
@@ -372,18 +372,18 @@ pub mod ipc_tests {
                     iov_len: 100,
                 },
             ];
-    
-            assert_eq!(cage2.writev_syscall(socketpair.sock2, iovec.as_ptr(), 3), 300);
+
+            assert_eq!(
+                cage2.writev_syscall(socketpair.sock2, iovec.as_ptr(), 3),
+                300
+            );
         });
 
-        let iovec2: [interface::IovecStruct; 1] = [
-            interface::IovecStruct {
-                iov_base: str2cbuf("test") as *mut c_void,
-                iov_len: 4,
-            }
-        ];
+        let iovec2: [interface::IovecStruct; 1] = [interface::IovecStruct {
+            iov_base: str2cbuf("test") as *mut c_void,
+            iov_len: 4,
+        }];
         assert_eq!(cage.writev_syscall(socketpair.sock1, iovec2.as_ptr(), 1), 4);
-
 
         let mut buf2 = sizecbuf(300);
         assert_eq!(

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -3,9 +3,9 @@ pub mod net_tests {
     use super::super::*;
     use crate::interface;
     use crate::safeposix::{cage::*, dispatcher::*, filesystem};
+    use libc::c_void;
     use std::mem::size_of;
     use std::sync::{Arc, Barrier};
-    use libc::c_void;
 
     pub fn net_tests() {
         ut_lind_net_bind();

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -3,9 +3,9 @@ pub mod net_tests {
     use super::super::*;
     use crate::interface;
     use crate::safeposix::{cage::*, dispatcher::*, filesystem};
-    use libc::c_void;
     use std::mem::size_of;
     use std::sync::{Arc, Barrier};
+    use libc::c_void;
 
     pub fn net_tests() {
         ut_lind_net_bind();


### PR DESCRIPTION
## Description

Fixes # (issue)

- implements pipes and unix sockets for send()
- adds sending EPIPE for unix domain sockets on send/writev

### Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Added unix domain writev test
Lamp tests
Test suite

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
