### PR TITLE
Added tests for mkdir_syscall

### DIFF
--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -50,6 +50,11 @@ pub mod fs_tests {
         ut_lind_fs_sem_trytimed();
         ut_lind_fs_sem_test();
         ut_lind_fs_tmp_file_test();
+        ut_lind_fs_mkdir_empty_directory();
+        ut_lind_fs_mkdir_nonexisting_directory();
+        ut_lind_fs_mkdir_existing_directory();
+        ut_lind_fs_mkdir_invalid_modebits();
+        ut_lind_fs_mkdir_success();
     }
 
     pub fn ut_lind_fs_simple() {
@@ -1237,6 +1242,63 @@ pub mod fs_tests {
         // Check if file is still there (it shouldn't be, assert no)
         assert_eq!(cage.access_syscall(file_path, F_OK), -2);
 
+        lindrustfinalize();
+    }   
+
+    pub fn ut_lind_fs_mkdir_empty_directory() {
+        lindrustinit(0);
+        let cage = interface::cagetable_getref(1);
+        let path = "";
+        // Check for error when directory is empty
+        assert_eq!(cage.mkdir_syscall(path, S_IRWXA), -(Errno::ENOENT as i32));
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    pub fn ut_lind_fs_mkdir_nonexisting_directory() {
+        lindrustinit(0);
+        let cage = interface::cagetable_getref(1);
+        let path = "/parentdir/dir";
+        // Check for error when both parent and child directories don't exist 
+        assert_eq!(cage.mkdir_syscall(path, S_IRWXA), -(Errno::ENOENT as i32));
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    pub fn ut_lind_fs_mkdir_existing_directory() {
+        lindrustinit(0);
+        let cage = interface::cagetable_getref(1);
+        let path = "/parentdir";
+        // Create a parent directory
+        cage.mkdir_syscall(path, S_IRWXA);
+        // Check for error when the same directory is created again
+        assert_eq!(cage.mkdir_syscall(path, S_IRWXA), -(Errno::EEXIST as i32));
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    pub fn ut_lind_fs_mkdir_invalid_modebits() {
+        lindrustinit(0);
+        let cage = interface::cagetable_getref(1);
+        let path = "/parentdir";
+        let invalid_mode = 0o77777; // Invalid mode bits
+        // Create a parent directory
+        cage.mkdir_syscall(path, S_IRWXA);
+        // Check for error when a directory is being created with invalid mode
+        assert_eq!(cage.mkdir_syscall("/parentdir/dir", invalid_mode), -(Errno::EPERM as i32));
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    pub fn ut_lind_fs_mkdir_success() {
+        lindrustinit(0);
+        let cage = interface::cagetable_getref(1);
+        let path = "/parentdir";
+        // Create a parent directory
+        cage.mkdir_syscall(path, S_IRWXA);
+        // Create a child directory inside parent directory with valid mode bits
+        assert_eq!(cage.mkdir_syscall("/parentdir/dir", S_IRWXA), 0);
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
     }
 }

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -1299,8 +1299,25 @@ pub mod fs_tests {
         let path = "/parentdir";
         // Create a parent directory
         cage.mkdir_syscall(path, S_IRWXA);
+
+        // Get the stat data for the parent directory and check for inode link count to be 3 initially
+        let mut statdata = StatData::default();
+        assert_eq!(cage.stat_syscall(path, &mut statdata), 0);
+        assert_eq!(statdata.st_nlink, 3);
+
         // Create a child directory inside parent directory with valid mode bits
         assert_eq!(cage.mkdir_syscall("/parentdir/dir", S_IRWXA), 0);
+        
+        // Get the stat data for the child directory and check for inode link count to be 3 initially
+        let mut statdata2 = StatData::default();
+        assert_eq!(cage.stat_syscall("/parentdir/dir", &mut statdata2), 0);
+        assert_eq!(statdata2.st_nlink, 3);
+
+        // Get the stat data for the parent directory and check for inode link count to be 4 now as a new child directory has been created.
+        let mut statdata3 = StatData::default();
+        assert_eq!(cage.stat_syscall(path, &mut statdata3), 0);
+        assert_eq!(statdata3.st_nlink, 4);
+
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
     }

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -1309,16 +1309,16 @@ pub mod fs_tests {
         lindrustinit(0);
         let cage = interface::cagetable_getref(1);
 
-        // Create a directory which will be referred to as originaldir 
-        let fd = cage.open_syscall("/originaldir", O_CREAT | O_EXCL | O_WRONLY, S_IRWXA);
+        // Create a file which will be referred to as originalFile 
+        let fd = cage.open_syscall("/originalFile", O_CREAT | O_EXCL | O_WRONLY, S_IRWXA);
         assert_eq!(cage.write_syscall(fd, str2cbuf("hi"), 2), 2);
         
-        // Create a link between two directories where the symlinkdir is originally not present
-        // But while linking, symlinkdir will get created
-        assert_eq!(cage.link_syscall("/originaldir", "/symlinkdir"), 0);
+        // Create a link between two files where the symlinkFile is originally not present
+        // But while linking, symlinkFile will get created
+        assert_eq!(cage.link_syscall("/originalFile", "/symlinkFile"), 0);
 
-        // Check for error while creating the symlinkdir again as it would already be created while linking the two directories above.
-        assert_eq!(cage.mkdir_syscall("/symlinkdir", S_IRWXA), -(Errno::EEXIST as i32));
+        // Check for error while creating the symlinkFile again as it would already be created while linking the two files above.
+        assert_eq!(cage.mkdir_syscall("/symlinkFile", S_IRWXA), -(Errno::EEXIST as i32));
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
     }


### PR DESCRIPTION
## Description

Fixes # (issue)
The following changes include the tests for the "mkdir" file system call under RustPosix.
The tests were added to cover all the possible scenarios that might happen when calling the file system_call `mkdir_syscall`. 

### Type of change
- [ ]  This change just contains the tests for an existing file system call.

## How Has This Been Tested?
Inorder to run the tests, we need to run `cargo test --lib` command inside the `safeposix-rust` directory.

All the tests are present under this directory: `lind_project/src/safeposix-rust/src/tests/fs_tests.rs`

- Test A - `ut_lind_fs_mkdir_empty_directory()`
- Test B - `ut_lind_fs_mkdir_nonexisting_directory()`
- Test C - `ut_lind_fs_mkdir_existing_directory()`
- Test D - `ut_lind_fs_mkdir_invalid_modebits()`
- Test E - `ut_lind_fs_mkdir_success()`
- Test F - `ut_lind_fs_mkdir_using_symlink()`

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
