### PR TITLE
Comments and Tests for sys_calls

### DIFF
--- a/src/safeposix/syscalls/sys_calls.rs
+++ b/src/safeposix/syscalls/sys_calls.rs
@@ -38,7 +38,6 @@ impl Cage {
         }
     }
 
-
     pub fn fork_syscall(&self, child_cageid: u64) -> i32 {
         //construct a new mutex in the child cage where each initialized mutex is in the parent cage
         let mutextable = self.mutex_table.read();
@@ -222,7 +221,6 @@ impl Cage {
             new_semtable.insert((*pair.key()).clone(), pair.value().clone());
         }
 
-        // Create a new cage object for the child process 
         let cageobj = Cage {
             cageid: child_cageid,
             cwd: interface::RustLock::new(self.cwd.read().clone()),
@@ -377,7 +375,7 @@ impl Cage {
     ///  
     /// The `getpid_syscall()` system call returns the id of the calling process. The uid is 
     /// guaranteed to be unique and can be used for naming temporary files. 
-    /// The call is always successful.  
+    /// The call is always successful.
     /// 
     /// ### Arguments
     /// 
@@ -411,6 +409,8 @@ impl Cage {
     /// This function returns the real group id of the calling process. The real group id is specified at 
     /// login time. The group id is the group of the user who invoked the program. 
     /// Lind is only run in one group - and hence a default value is expected from this function.  
+    /// Initially we check if the call takes place during the loading stage, and return -1 if yes and set the 
+    /// gid to be the default value.
     /// 
     /// ### Arguments 
     /// 
@@ -421,7 +421,7 @@ impl Cage {
     /// Depending on whether the gid has been initialized or not this function returns either -1 
     /// or the default gid as a 32 bit integer. 
     pub fn getgid_syscall(&self) -> i32 {
-        // This call returns -1 when the gid has not yet been initialized and set the gid to be the default value. 
+        // The call returns -1 to indicate that the call happened during the loading stage
         if self.getgid.load(interface::RustAtomicOrdering::Relaxed) == -1 {
             self.getgid
                 .store(DEFAULT_GID as i32, interface::RustAtomicOrdering::Relaxed);
@@ -434,6 +434,8 @@ impl Cage {
     /// 
     /// The `getegid_syscall` returns the effective group id of the user who invoked the process.
     /// Since Lind is only run in one group a default value (or -1) is returned. 
+    /// Initially we check if the call takes place during the loading stage, and return -1 if yes and set the 
+    /// egid to be the default value.
     /// 
     /// ### Arguments 
     /// 
@@ -441,9 +443,9 @@ impl Cage {
     /// 
     /// ### Returns
     /// 
-    /// Returns a 32 bit integer value which represents the effective group
+    /// Returns a 32 bit integer value (or -1) which represents the effective group
     pub fn getegid_syscall(&self) -> i32 {
-        // If the egid has not been initialized yet - we return -1 and store the default value as the egid 
+        // The call returns -1 to indicate that the call happened during the loading stage
         if self.getegid.load(interface::RustAtomicOrdering::Relaxed) == -1 {
             self.getegid
                 .store(DEFAULT_GID as i32, interface::RustAtomicOrdering::Relaxed);
@@ -458,6 +460,8 @@ impl Cage {
     /// The `getuid_syscall` returns the real user id of the calling process. 
     /// The real user id is the user who invoked the calling process. 
     /// As Lind only allows one user, a default value is returned. 
+    /// Initially we check if the call takes place during the loading stage, and return -1 if yes and set the 
+    /// uid to be the default value.
     /// 
     /// ### Arguments
     ///  
@@ -467,7 +471,7 @@ impl Cage {
     /// 
     /// Returns a 32 bit default integer (or -1) representing the user
     pub fn getuid_syscall(&self) -> i32 {
-        // If the user has not been set yet, we return -1 and then set the user to be the default user. 
+        // The call returns -1 to indicate that the call happened during the loading stage
         if self.getuid.load(interface::RustAtomicOrdering::Relaxed) == -1 {
             self.getuid
                 .store(DEFAULT_UID as i32, interface::RustAtomicOrdering::Relaxed);
@@ -480,16 +484,17 @@ impl Cage {
     /// 
     /// The `geteuid_syscall` returns the effective user id of the calling process. 
     /// As Lind only allows one user, a default value (or -1) is returned. 
+    /// Initially we check if the call takes place during the loading stage, and return -1 if yes and set the 
+    /// euid to be the default value.
     /// 
     /// ### Function Arguments 
     /// The geteuid syscall does not take any arguments
-    /// 
     /// 
     /// ### Returns
     /// 
     /// Returns a 32 bit default integer value (or -1) representing the effective user
     pub fn geteuid_syscall(&self) -> i32 {
-        // If the euid has not been initialized yet, we return -1 and set the default value as the euid. 
+        // The call returns -1 to indicate that the call happened during the loading stage
         if self.geteuid.load(interface::RustAtomicOrdering::Relaxed) == -1 {
             self.geteuid
                 .store(DEFAULT_UID as i32, interface::RustAtomicOrdering::Relaxed);

--- a/src/safeposix/syscalls/sys_calls.rs
+++ b/src/safeposix/syscalls/sys_calls.rs
@@ -38,6 +38,13 @@ impl Cage {
         }
     }
 
+
+    //------------------------------------FORK SYSCALL------------------------------------
+    // Fork causes creation of a new process.  The new process (child process)
+    // is an exact copy of the calling process (parent process)
+    // The child process has a unique process ID 
+    // The parent ID of the child is the ID of the process that calls th fork syscall 
+    // Takes in the id of the child and assigns that to the newly created process. 
     pub fn fork_syscall(&self, child_cageid: u64) -> i32 {
         //construct a new mutex in the child cage where each initialized mutex is in the parent cage
         let mutextable = self.mutex_table.read();
@@ -221,6 +228,7 @@ impl Cage {
             new_semtable.insert((*pair.key()).clone(), pair.value().clone());
         }
 
+        // Create a new cage object for the child process 
         let cageobj = Cage {
             cageid: child_cageid,
             cwd: interface::RustLock::new(self.cwd.read().clone()),
@@ -370,15 +378,30 @@ impl Cage {
         status
     }
 
+
+    //------------------------------------GETPID SYSCALL------------------------------------
+    // Description 
+    // The getpid system call returns the id of the calling process. The uid is 
+    // guaranteed to be unique and can be used for naming temporary files. 
+    // The call is always successful. 
     pub fn getpid_syscall(&self) -> i32 {
-        self.cageid as i32 //not sure if this is quite what we want but it's easy enough to change later
-    }
+        self.cageid as i32 
+    } 
+
+    //------------------------------------GETPPID SYSCALL------------------------------------
+    // Description 
+    // The getppid system call return the id of the parent process of the calling process. 
+    // The uid is guaranteed to be unique, and like the getpid call, this call is also always successful.  
     pub fn getppid_syscall(&self) -> i32 {
         self.parent as i32 // mimicing the call above -- easy to change later if necessary
     }
 
-    /*if its negative 1
-    return -1, but also set the values in the cage struct to the DEFAULTs for future calls*/
+
+    //------------------------------------GETGID SYSCALL------------------------------------ 
+    // Description 
+    // This function returns the real group id of the calling process. The real group id is specified at 
+    // login time. The group id is the group of the user who invoked the program. 
+    // Lind is only run in group - and hence a default value is expected from this function. 
     pub fn getgid_syscall(&self) -> i32 {
         if self.getgid.load(interface::RustAtomicOrdering::Relaxed) == -1 {
             self.getgid
@@ -386,7 +409,12 @@ impl Cage {
             return -1;
         }
         DEFAULT_GID as i32 //Lind is only run in one group so a default value is returned
-    }
+    } 
+
+    //------------------------------------GETEGID SYSCALL------------------------------------ 
+    // Description 
+    // This function returns the effective group id of the calling process. Since Lind is only run in one group
+    // A default value is returned 
     pub fn getegid_syscall(&self) -> i32 {
         if self.getegid.load(interface::RustAtomicOrdering::Relaxed) == -1 {
             self.getegid
@@ -395,7 +423,13 @@ impl Cage {
         }
         DEFAULT_GID as i32 //Lind is only run in one group so a default value is returned
     }
+ 
 
+    //------------------------------------GETUID SYSCALL------------------------------------ 
+    // Descriptiom 
+    // The getuid function returns the real user id of the calling process. 
+    // The real user id is the user who invoked the calling process. 
+    // As Lind only allows one user, a default value is returned. 
     pub fn getuid_syscall(&self) -> i32 {
         if self.getuid.load(interface::RustAtomicOrdering::Relaxed) == -1 {
             self.getuid
@@ -404,6 +438,11 @@ impl Cage {
         }
         DEFAULT_UID as i32 //Lind is only run as one user so a default value is returned
     }
+
+    //------------------------------------GETEUID SYSCALL------------------------------------ 
+    // Description 
+    // The geteuid system call returns the effective user id of the calling process. 
+    // As Lind only allows one user, a default value is returned. 
     pub fn geteuid_syscall(&self) -> i32 {
         if self.geteuid.load(interface::RustAtomicOrdering::Relaxed) == -1 {
             self.geteuid

--- a/src/safeposix/syscalls/sys_calls.rs
+++ b/src/safeposix/syscalls/sys_calls.rs
@@ -39,12 +39,6 @@ impl Cage {
     }
 
 
-    //------------------------------------FORK SYSCALL------------------------------------
-    // Fork causes creation of a new process.  The new process (child process)
-    // is an exact copy of the calling process (parent process)
-    // The child process has a unique process ID 
-    // The parent ID of the child is the ID of the process that calls th fork syscall 
-    // Takes in the id of the child and assigns that to the newly created process. 
     pub fn fork_syscall(&self, child_cageid: u64) -> i32 {
         //construct a new mutex in the child cage where each initialized mutex is in the parent cage
         let mutextable = self.mutex_table.read();
@@ -379,30 +373,55 @@ impl Cage {
     }
 
 
-    //------------------------------------GETPID SYSCALL------------------------------------
-    // Description 
-    // The getpid system call returns the id of the calling process. The uid is 
-    // guaranteed to be unique and can be used for naming temporary files. 
-    // The call is always successful. 
+    /// ### Description
+    ///  
+    /// The `getpid_syscall()` system call returns the id of the calling process. The uid is 
+    /// guaranteed to be unique and can be used for naming temporary files. 
+    /// The call is always successful.  
+    /// 
+    /// ### Arguments
+    /// 
+    /// This system call does not take any arguments.
+    /// 
+    /// ### Returns
+    /// 
+    /// Returns the 32 bit integer uid of the calling Cage object
     pub fn getpid_syscall(&self) -> i32 {
         self.cageid as i32 
     } 
 
-    //------------------------------------GETPPID SYSCALL------------------------------------
-    // Description 
-    // The getppid system call return the id of the parent process of the calling process. 
-    // The uid is guaranteed to be unique, and like the getpid call, this call is also always successful.  
+    /// ### Description 
+    /// 
+    /// The `getppid_syscall()` returns the id of the parent process of the calling process. 
+    /// The uid is guaranteed to be unique, and like the getpid call, this call is also always successful.  
+    /// This call is always successfull
+    /// 
+    /// ### Arguments
+    /// The getppid syscall does not take any arguments
+    /// 
+    /// ### Returns
+    /// Returns a 32 bit integer value that represents the unique id of the parent process. 
     pub fn getppid_syscall(&self) -> i32 {
         self.parent as i32 // mimicing the call above -- easy to change later if necessary
     }
 
 
-    //------------------------------------GETGID SYSCALL------------------------------------ 
-    // Description 
-    // This function returns the real group id of the calling process. The real group id is specified at 
-    // login time. The group id is the group of the user who invoked the program. 
-    // Lind is only run in group - and hence a default value is expected from this function. 
+    /// ### Description 
+    /// 
+    /// This function returns the real group id of the calling process. The real group id is specified at 
+    /// login time. The group id is the group of the user who invoked the program. 
+    /// Lind is only run in one group - and hence a default value is expected from this function.  
+    /// 
+    /// ### Arguments 
+    /// 
+    /// The `getgid_syscall` does not take any argument.
+    ///
+    /// ### Returns
+    /// 
+    /// Depending on whether the gid has been initialized or not this function returns either -1 
+    /// or the default gid as a 32 bit integer. 
     pub fn getgid_syscall(&self) -> i32 {
+        // This call returns -1 when the gid has not yet been initialized and set the gid to be the default value. 
         if self.getgid.load(interface::RustAtomicOrdering::Relaxed) == -1 {
             self.getgid
                 .store(DEFAULT_GID as i32, interface::RustAtomicOrdering::Relaxed);
@@ -411,11 +430,20 @@ impl Cage {
         DEFAULT_GID as i32 //Lind is only run in one group so a default value is returned
     } 
 
-    //------------------------------------GETEGID SYSCALL------------------------------------ 
-    // Description 
-    // This function returns the effective group id of the calling process. Since Lind is only run in one group
-    // A default value is returned 
+    /// ### Description 
+    /// 
+    /// The `getegid_syscall` returns the effective group id of the user who invoked the process.
+    /// Since Lind is only run in one group a default value (or -1) is returned. 
+    /// 
+    /// ### Arguments 
+    /// 
+    /// This syscall does not take any arguments
+    /// 
+    /// ### Returns
+    /// 
+    /// Returns a 32 bit integer value which represents the effective group
     pub fn getegid_syscall(&self) -> i32 {
+        // If the egid has not been initialized yet - we return -1 and store the default value as the egid 
         if self.getegid.load(interface::RustAtomicOrdering::Relaxed) == -1 {
             self.getegid
                 .store(DEFAULT_GID as i32, interface::RustAtomicOrdering::Relaxed);
@@ -425,12 +453,21 @@ impl Cage {
     }
  
 
-    //------------------------------------GETUID SYSCALL------------------------------------ 
-    // Descriptiom 
-    // The getuid function returns the real user id of the calling process. 
-    // The real user id is the user who invoked the calling process. 
-    // As Lind only allows one user, a default value is returned. 
+    /// ### Description
+    /// 
+    /// The `getuid_syscall` returns the real user id of the calling process. 
+    /// The real user id is the user who invoked the calling process. 
+    /// As Lind only allows one user, a default value is returned. 
+    /// 
+    /// ### Arguments
+    ///  
+    /// The `getuid_syscall` does not take any arguments
+    /// 
+    /// ### Returns
+    /// 
+    /// Returns a 32 bit default integer (or -1) representing the user
     pub fn getuid_syscall(&self) -> i32 {
+        // If the user has not been set yet, we return -1 and then set the user to be the default user. 
         if self.getuid.load(interface::RustAtomicOrdering::Relaxed) == -1 {
             self.getuid
                 .store(DEFAULT_UID as i32, interface::RustAtomicOrdering::Relaxed);
@@ -439,11 +476,20 @@ impl Cage {
         DEFAULT_UID as i32 //Lind is only run as one user so a default value is returned
     }
 
-    //------------------------------------GETEUID SYSCALL------------------------------------ 
-    // Description 
-    // The geteuid system call returns the effective user id of the calling process. 
-    // As Lind only allows one user, a default value is returned. 
+    /// ### Description 
+    /// 
+    /// The `geteuid_syscall` returns the effective user id of the calling process. 
+    /// As Lind only allows one user, a default value (or -1) is returned. 
+    /// 
+    /// ### Function Arguments 
+    /// The geteuid syscall does not take any arguments
+    /// 
+    /// 
+    /// ### Returns
+    /// 
+    /// Returns a 32 bit default integer value (or -1) representing the effective user
     pub fn geteuid_syscall(&self) -> i32 {
+        // If the euid has not been initialized yet, we return -1 and set the default value as the euid. 
         if self.geteuid.load(interface::RustAtomicOrdering::Relaxed) == -1 {
             self.geteuid
                 .store(DEFAULT_UID as i32, interface::RustAtomicOrdering::Relaxed);

--- a/src/safeposix/syscalls/sys_calls.rs
+++ b/src/safeposix/syscalls/sys_calls.rs
@@ -421,7 +421,7 @@ impl Cage {
     /// Depending on whether the gid has been initialized or not this function returns either -1 
     /// or the default gid as a 32 bit integer. 
     pub fn getgid_syscall(&self) -> i32 {
-        // The call returns -1 to indicate that the call happened during the loading stage
+        // We return -1 for the first call for compatibility with the dynamic loader. For subsequent calls we return our default value.
         if self.getgid.load(interface::RustAtomicOrdering::Relaxed) == -1 {
             self.getgid
                 .store(DEFAULT_GID as i32, interface::RustAtomicOrdering::Relaxed);
@@ -445,7 +445,7 @@ impl Cage {
     /// 
     /// Returns a 32 bit integer value (or -1) which represents the effective group
     pub fn getegid_syscall(&self) -> i32 {
-        // The call returns -1 to indicate that the call happened during the loading stage
+        // We return -1 for the first call for compatibility with the dynamic loader. For subsequent calls we return our default value.
         if self.getegid.load(interface::RustAtomicOrdering::Relaxed) == -1 {
             self.getegid
                 .store(DEFAULT_GID as i32, interface::RustAtomicOrdering::Relaxed);
@@ -471,7 +471,7 @@ impl Cage {
     /// 
     /// Returns a 32 bit default integer (or -1) representing the user
     pub fn getuid_syscall(&self) -> i32 {
-        // The call returns -1 to indicate that the call happened during the loading stage
+        // We return -1 for the first call for compatibility with the dynamic loader. For subsequent calls we return our default value.
         if self.getuid.load(interface::RustAtomicOrdering::Relaxed) == -1 {
             self.getuid
                 .store(DEFAULT_UID as i32, interface::RustAtomicOrdering::Relaxed);
@@ -494,7 +494,7 @@ impl Cage {
     /// 
     /// Returns a 32 bit default integer value (or -1) representing the effective user
     pub fn geteuid_syscall(&self) -> i32 {
-        // The call returns -1 to indicate that the call happened during the loading stage
+        // We return -1 for the first call for compatibility with the dynamic loader. For subsequent calls we return our default value.
         if self.geteuid.load(interface::RustAtomicOrdering::Relaxed) == -1 {
             self.geteuid
                 .store(DEFAULT_UID as i32, interface::RustAtomicOrdering::Relaxed);

--- a/src/tests/sys_tests.rs
+++ b/src/tests/sys_tests.rs
@@ -29,5 +29,44 @@ pub mod test_sys {
         
     } 
 
+    pub fn ut_lind_getuid() {
+        lindrustinit(0);
+        // The first call to geteuid always returns -1
+        assert_eq!(cage.getuid_syscall(),-1);
+        // Subsequent calls return the default value
+        assert_eq!(cage.getuid_syscall(),DEFAULT_UID);
+        lindrustfinalize()
+    }
+
+    pub fn ut_lind_geteuid() {
+        lindrustinit(0);
+        let cage = interface::cagetable_getref(1);
+        // The first call to geteuid always returns -1
+        assert_eq!(cage.geteuid_syscall(),-1);
+        // Subsequent calls return the default value
+        assert_eq!(cage.geteuid_syscall(),DEFAULT_UID);
+        lindrustfinalize()
+    }
+
+    pub fn ut_lind_getgid() {
+        lindrustinit(0);
+        let cage = interface::cagetable_getref(1);
+        // The first call to geteuid always returns -1
+        assert_eq!(cage.getgid_syscall(),-1);
+        // Subsequent calls return the default value
+        assert_eq!(cage.getgid_syscall(),DEFAULT_GID);
+        lindrustfinalize()
+    } 
+
+    pub fn ut_lind_getegid() {
+        lindrustinit(0);
+        let cage = interface::cagetable_getref(1);
+        // The first call to geteuid always returns -1
+        assert_eq!(cage.getegid_syscall(),-1);
+        // Subsequent calls return the default value
+        assert_eq!(cage.getegid_syscall(),DEFAULT_GID);
+        lindrustfinalize()
+    } 
+
 } 
 

--- a/src/tests/sys_tests.rs
+++ b/src/tests/sys_tests.rs
@@ -6,15 +6,10 @@ pub mod sys_tests {
     use super::super::*;
     use crate::interface;
     use crate::safeposix::syscalls::sys_calls::*;
-    use crate::safeposix::{cage::*, dispatcher::*, filesystem};
-    use libc::c_void;
-    use std::fs::OpenOptions;
-    use std::os::unix::fs::PermissionsExt; 
 
-    pub fn test_fs() {
+    pub fn tests_sys() {
         ut_lind_getpid(); 
         ut_lind_getppid(); 
-        ut_lind_getpid(); 
     } 
 
     pub fn ut_lind_getpid() {

--- a/src/tests/sys_tests.rs
+++ b/src/tests/sys_tests.rs
@@ -2,12 +2,12 @@
 
 #[allow(unused_parens)]
 #[cfg(test)] 
-pub mod sys_tests {
+pub mod test_sys {
     use super::super::*;
     use crate::interface;
     use crate::safeposix::syscalls::sys_calls::*;
 
-    pub fn tests_sys() {
+    pub fn test_sys() {
         ut_lind_getpid(); 
         ut_lind_getppid(); 
     } 

--- a/src/tests/sys_tests.rs
+++ b/src/tests/sys_tests.rs
@@ -1,0 +1,38 @@
+#![allow(dead_code)] //suppress warning for these functions not being used in targets other than the tests
+
+#[allow(unused_parens)]
+#[cfg(test)] 
+pub mod sys_tests {
+    use super::super::*;
+    use crate::interface;
+    use crate::safeposix::syscalls::sys_calls::*;
+    use crate::safeposix::{cage::*, dispatcher::*, filesystem};
+    use libc::c_void;
+    use std::fs::OpenOptions;
+    use std::os::unix::fs::PermissionsExt; 
+
+    pub fn test_fs() {
+        ut_lind_getpid(); 
+        ut_lind_getppid(); 
+        ut_lind_getpid(); 
+    } 
+
+    pub fn ut_lind_getpid() {
+        lindrustinit(0); 
+        let cage =  interface::cagetable_getref(1); 
+        assert_eq!(cage.getpid_syscall(),1); 
+        lindrustfinalize();
+    } 
+
+    pub fn ut_lind_getppid() {
+        lindrustinit(0); 
+        let cage = interface::cagetable_getref(1); 
+        cage.fork_syscall(2);
+        let cage2 = interface::cagetable_getref(2);
+        assert_eq!(cage2.getppid_syscall(),1); 
+        lindrustfinalize(); 
+        
+    } 
+
+} 
+


### PR DESCRIPTION
## Description

Fixes # (issue)
The following changes include the tests and comments in the code for the "get_pid" and "get_ppid" system call under RustPosix.

<!-- Please include a summary of the changes and the related issue. --> 
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] This change adds tests and comments to existing code

## How Has This Been Tested?


<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration --> 

All the tests are inside the ```lind_project/src/safeposix-rust/src/tests/sys_tests/rs``` 

- Test A - `ut_lind_getpid()`
- Test B - `lut_lind_get_ppid()`

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
