### PR TITLE
Tests, Comments, and minor code changes for mknod syscall

### DIFF
--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -391,65 +391,97 @@ impl Cage {
 
     /// ## ------------------MKNOD SYSCALL------------------
     /// ### Description
-    /// The `mknod_syscall()` creates a filesystem node (file, device special file or pipe) named by a path as the input parameter.
-    /// The file type and the permissions of the new file are initialized from the "mode" provided as the input parameter.
-    /// There are 5 different file types: S_IFREG, S_IFCHR, S_IFBLK, S_IFIFO, or S_IFSOCK representing a regular file, character special file, block special file, FIFO (named pipe), or UNIX domain socket, respectively.
+    ///
+    /// The `mknod_syscall()` creates a filesystem node (file, device special file
+    /// or pipe) named by a path as the input parameter.
+    /// The file type and the permissions of the new file are initialized from the
+    /// "mode" provided as the input parameter.
+    /// There are 5 different file types: S_IFREG, S_IFCHR, S_IFBLK, S_IFIFO, or
+    /// S_IFSOCK representing a regular file, character special file, block special
+    /// file, FIFO (named pipe), or UNIX domain socket, respectively.
     /// The newly created file is empty with size 0.
-    /// On successful completion, the timestamps for both the newly created file and its parent are updated along with their linkcounts.
+    /// On successful completion, the timestamps for both the newly created file
+    /// and its parent are updated along with their linkcounts.
     /// 
     /// ### Function Arguments
+    ///
     /// The `mknod_syscall()` receives three arguments:
     /// * `path` - This argument points to a pathname naming the file.
-    //             For example: "/parentdir/file" represents the new file name as "file", which will be created at this path (/parentdir/file).
-    /// * `mode` - The mode argument specifies both the permissions to use and the type of node to be created. It is a combination (using bitwise OR) of one of the file types and the permissions for the new node.
-    ///            FileType - In LIND, we have only implemented the file type of "Character Device" represented by S_IFCHR flag.
-    ///            FilePermission - The general permission mode used is "S_IRWXA": which represents the read, write, and search permissions on the new file.
-    ///            The final file mode is represented by the bitwise-OR of FileType and FilePermission Flags.
-    /// * `dev` -  It is a configuration-dependent specification of a character or block I/O device. If mode does not indicate a block special or character special device, dev is ignored.
-    ///            Since "CharDev" is the only supported type, 'dev' is represented using makedev() function; that returns a formatted device number   
-    ///            For example: "makedev(&DevNo { major: majorId, minor: minorId })" accepts a Device Number that consists of: 
-    ///            MajorID, identifying the class of the device, and a minor ID, identifying a specific instance of a device in that class.
+    /// For example: "/parentdir/file" represents the new file name as "file",
+    /// which will be created at this path (/parentdir/file).
+    ///
+    /// * `mode` - The mode argument specifies both the permissions to use and the
+    /// type of node to be created. It is a combination (using bitwise OR) of one
+    /// of the file types and the permissions for the new node.
+    /// FileType - In LIND, we have only implemented the file type of "Character
+    /// Device" represented by S_IFCHR flag.
+    /// FilePermission - The general permission mode used is "S_IRWXA": which
+    /// represents the read, write, and search permissions on the new file.
+    /// The final file mode is represented by the bitwise-OR of FileType and
+    /// FilePermission Flags.
+    ///
+    /// * `dev` - It is a configuration-dependent specification of a character or
+    /// block I/O device. If mode does not indicate a block special or character
+    /// special device, dev is ignored.
+    /// Since "CharDev" is the only supported type, 'dev' is represented using
+    /// makedev() function; that returns a formatted device number   
+    /// For example: "makedev(&DevNo { major: majorId, minor: minorId })" accepts a
+    /// Device Number that consists of a MajorID, identifying the class of the device, 
+    /// and a minor ID, identifying a specific instance of a device in that class.
     ///
     /// ### Returns
+    ///
     /// Upon successful creation of the file, 0 is returned.
     /// Otherwise, errors or panics are returned for different scenarios.
     ///
     /// ### Errors
-    /// * `ENOENT` - occurs when a directory component in the absolute path does not exist
+    ///
+    /// * `ENOENT` - occurs when a directory component in the absolute path does
+    /// not exist
     /// * `EPERM` - the mode bits for the new file are not sane
-    /// * `EINVAL` - when any other file type (regular, socket, block, fifo) instead of character file type is passed
+    /// * `EINVAL` - when any other file type (regular, socket, block, fifo) instead
+    /// of character file type is passed
     /// * `EEXIST` - when the file to be created already exists
     /// 
-    /// for more detailed description of all the commands and return values, see 
+    /// For more detailed description of all the commands and return values, see 
     /// [mknod(2)](https://man7.org/linux/man-pages/man2/mknod.2.html)
     ///
     pub fn mknod_syscall(&self, path: &str, mode: u32, dev: u64) -> i32 {
-        // Check that the given input path is empty
+        // Return an error if the provided path is empty
         if path.len() == 0 {
             return syscall_error(Errno::ENOENT, "mknod", "given path was null");
         }
-        // Retrieve the absolute path from the root directory. The absolute path is then used to validate directory paths
-        // while navigating through subdirectories and establishing new directory at the given location.
+        // Retrieve the absolute path from the root directory. The absolute path is
+        // then used to validate directory paths while navigating through
+        // subdirectories and establishing new directory at the given location.
         let truepath = normpath(convpath(path), self);
 
-        // Store the FileMetadata into a helper variable which is used for fetching the metadata of a given inode from the Inode Table. 
+        // Store the FileMetadata into a helper variable which is used for fetching
+        // the metadata of a given inode from the Inode Table. 
         let metadata = &FS_METADATA;
 
-        // Walk through the absolute path which returns a tuple consisting of inode number of file (if it exists), and inode number of parent (if it exists)
+        // Walk through the absolute path which returns a tuple consisting of inode
+        // number of file (if it exists), and inode number of parent (if it exists)
         match metawalkandparent(truepath.as_path()) {
-            // Case 1: When the file doesn't exist but the parent directory exists
+            // Case: When the file doesn't exist but the parent directory exists
             (None, Some(pardirinode)) => {
-                let filename = truepath.file_name().unwrap().to_str().unwrap().to_string(); //for now we assume this is sane, but maybe this should be checked later
+                // for now we assume this is sane, but maybe this should be checked later
+                let filename = truepath.file_name().unwrap().to_str().unwrap().to_string(); 
 
-                // S_FILETYPEFLAGS represents a bitmask that can be used to extract the file type information from a file's mode.
+                // S_FILETYPEFLAGS represents a bitmask that can be used to extract
+                // the file type information from a file's mode.
                 // This code is referenced from Lind-Repy codebase.
-                // Here, we are checking whether the mode bits are sane by ensuring that only valid file permission bits (S_IRWXA) and file type bits (S_FILETYPEFLAGS) are set. Else, we return the error.
+                // Here, we are checking whether the mode bits are sane by ensuring
+                // that only valid file permission bits (S_IRWXA) and file type bits
+                // (S_FILETYPEFLAGS) are set. Else, we return the error.
                 if mode & (S_IRWXA | S_FILETYPEFLAGS as u32) != mode {
                     return syscall_error(Errno::EPERM, "mknod", "Mode bits were not sane");
                 }
 
-                // As of now, the only file type in LIND supported by mknod syscall is "Char Device"
-                // Inorder to check for Char file type, a bitwise-AND operation is performed with the "mode".
+                // As of now, the only file type in LIND supported by mknod syscall
+                // is "Char Device".
+                // In order to check for Char file type, a bitwise-AND operation is
+                // performed with the "mode".
                 if mode as i32 & S_IFCHR == 0 {
                     return syscall_error(
                         Errno::EINVAL,
@@ -458,7 +490,7 @@ impl Cage {
                     );
                 }
                 // New Inode of type CharDev is created with file size 0
-                let time = interface::timestamp(); //We do a real timestamp now
+                let time = interface::timestamp(); // We do a real timestamp now
                 let newinode = Inode::CharDev(DeviceInode {
                     size: 0,
                     uid: DEFAULT_UID,
@@ -472,42 +504,49 @@ impl Cage {
                     dev: devtuple(dev),
                 });
 
+                // fetch_add returns the previous value, which is the inode number we want
                 let newinodenum = FS_METADATA
                     .nextinode
-                    .fetch_add(1, interface::RustAtomicOrdering::Relaxed); //fetch_add returns the previous value, which is the inode number we want
-                
-                // Insert a reference to the file in the parent directory and update the inode attributes
-                // Fetch the inode of the parent directory and only proceed when its type is directory.
-                if let Inode::Dir(ref mut parentdir) = *(FS_METADATA.inodetable.get_mut(&pardirinode).unwrap())
+                    .fetch_add(1, interface::RustAtomicOrdering::Relaxed); 
+
+                // Insert a reference to the file in the parent directory and update
+                // the inode attributes.
+                // Fetch the inode of the parent directory and only proceed when its
+                // type is directory.
+                if let Inode::Dir(ref mut parentdir) =
+                    *(FS_METADATA.inodetable.get_mut(&pardirinode).unwrap())
                 {
                     parentdir
                         .filename_to_inode_dict
                         .insert(filename, newinodenum);
                     parentdir.linkcount += 1;
-                    parentdir.ctime = time; // Here, update the ctime and mtime for the parent directory as well
+                    // Update the ctime and mtime for the parent directory as well
+                    // since the new file is linked with it.
+                    parentdir.ctime = time; 
                     parentdir.mtime = time;
                 }
 
-                // Update the inode table by inserting the newly formed inode mapped with its inode number.
+                // Update the inode table by inserting the newly formed inode mapped
+                // with its inode number.
                 metadata.inodetable.insert(newinodenum, newinode);
                 log_metadata(metadata, pardirinode);
                 log_metadata(metadata, newinodenum);
-                0 //mknod has succeeded
+                0 // mknod has succeeded
             }
 
-            // Case 2: When the file directory name already exists, then return the error.
+            // Case: When the file directory name already exists, then return the error.
             (Some(_), ..) => syscall_error(
                 Errno::EEXIST,
                 "mknod",
                 "pathname already exists, cannot create device file",
             ),
 
-            // Case 3: When neither the file directory nor the parent directory exists
+            // Case: When neither the file directory nor the parent directory exists
             (None, None) => syscall_error(
                 Errno::ENOENT,
                 "mknod",
                 "a directory component in pathname does not exist or is a dangling symbolic link",
-            )
+            ),
         }
     }
 

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -31,7 +31,15 @@ pub mod fs_tests {
         ut_lind_fs_fstat_complex();
         ut_lind_fs_getuid();
         ut_lind_fs_load_fs();
-        ut_lind_fs_mknod();
+
+        // mknod_syscall_tests
+        ut_lind_fs_mknod_empty_path();
+        ut_lind_fs_mknod_nonexisting_parent_directory();
+        ut_lind_fs_mknod_existing_file();
+        ut_lind_fs_mknod_invalid_modebits();
+        ut_lind_fs_mknod_invalid_filetypes();
+        ut_lind_fs_mknod_success();
+
         ut_lind_fs_multiple_open();
         ut_lind_fs_rename();
         ut_lind_fs_rmdir();
@@ -777,7 +785,78 @@ pub mod fs_tests {
         lindrustfinalize();
     }
 
-    pub fn ut_lind_fs_mknod() {
+    pub fn ut_lind_fs_mknod_empty_path() {
+        lindrustinit(0);
+        let cage = interface::cagetable_getref(1);
+        let dev = makedev(&DevNo { major: 1, minor: 3 });
+        let path = "";
+        // Check for error when directory is empty
+        assert_eq!(cage.mknod_syscall(path, S_IRWXA | S_IFCHR as u32, dev), -(Errno::ENOENT as i32));
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    pub fn ut_lind_fs_mknod_nonexisting_parent_directory() {
+        lindrustinit(0);
+        let cage = interface::cagetable_getref(1);
+        let dev = makedev(&DevNo { major: 1, minor: 3 });
+        let path = "/parentdir/file";
+        // Check for error when both parent and file don't exist 
+        assert_eq!(cage.mknod_syscall(path, S_IRWXA | S_IFCHR as u32, dev), -(Errno::ENOENT as i32));
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    pub fn ut_lind_fs_mknod_existing_file() {
+        lindrustinit(0);
+        let cage = interface::cagetable_getref(1);
+        let dev = makedev(&DevNo { major: 1, minor: 3 });
+        let path = "/charfile";
+        // Create a special character file for the first time
+        assert_eq!(cage.mknod_syscall(path, S_IRWXA | S_IFCHR as u32, dev), 0);
+
+        // Check for error when the same file is created again
+        assert_eq!(cage.mknod_syscall(path, S_IRWXA | S_IFCHR as u32, dev), -(Errno::EEXIST as i32));
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    pub fn ut_lind_fs_mknod_invalid_modebits() {
+        lindrustinit(0);
+        let cage = interface::cagetable_getref(1);
+        let dev = makedev(&DevNo { major: 1, minor: 3 });
+        let path = "/testfile";
+        let invalid_mode = 0o77777; // Invalid mode bits for testing
+        // Check for error when the file is being created with invalid mode
+        assert_eq!(cage.mknod_syscall(path, invalid_mode, dev), -(Errno::EPERM as i32));
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    pub fn ut_lind_fs_mknod_invalid_filetypes() {
+        // Check for error when file types other than S_IFCHR are passed in the input
+        lindrustinit(0);
+        let cage = interface::cagetable_getref(1);
+        let dev = makedev(&DevNo { major: 1, minor: 3 });
+        let path = "/invalidfile";
+
+        // When file type is S_IFDIR (Directory), error is expected
+        assert_eq!(cage.mknod_syscall(path, S_IRWXA | S_IFDIR as u32, dev), -(Errno::EINVAL as i32));
+
+        // When file type is S_IFIFO (FIFO), error is expected
+        assert_eq!(cage.mknod_syscall(path, S_IRWXA | S_IFIFO as u32, dev), -(Errno::EINVAL as i32));
+        
+        // When file type is S_IFREG (Regular File), error is expected
+        assert_eq!(cage.mknod_syscall(path, S_IRWXA | S_IFREG as u32, dev), -(Errno::EINVAL as i32));
+        
+        // When file type is S_IFSOCK (Socket), error is expected
+        assert_eq!(cage.mknod_syscall(path, S_IRWXA | S_IFSOCK as u32, dev), -(Errno::EINVAL as i32));
+        
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    pub fn ut_lind_fs_mknod_success() {
         // let's create /dev/null
         lindrustinit(0);
         let cage = interface::cagetable_getref(1);
@@ -786,7 +865,7 @@ pub mod fs_tests {
 
         //now we are going to mknod /dev/null with create, read and write flags and permissions
         //and then makr sure that it exists
-        assert_eq!(cage.mknod_syscall(path, S_IFCHR as u32, dev), 0);
+        assert_eq!(cage.mknod_syscall(path, S_IRWXA | S_IFCHR as u32, dev), 0);
         let fd = cage.open_syscall(path, O_RDWR, S_IRWXA);
 
         //checking the metadata of the file:
@@ -809,7 +888,7 @@ pub mod fs_tests {
         let path2 = "/random";
 
         //making the node and then making sure that it exists
-        assert_eq!(cage.mknod_syscall(path2, S_IFCHR as u32, dev2), 0);
+        assert_eq!(cage.mknod_syscall(path2, S_IRWXA | S_IFCHR as u32, dev2), 0);
         let fd2 = cage.open_syscall(path2, O_RDWR, S_IRWXA);
 
         let mut buf2 = sizecbuf(4);

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -791,7 +791,10 @@ pub mod fs_tests {
         let dev = makedev(&DevNo { major: 1, minor: 3 });
         let path = "";
         // Check for error when directory is empty
-        assert_eq!(cage.mknod_syscall(path, S_IRWXA | S_IFCHR as u32, dev), -(Errno::ENOENT as i32));
+        assert_eq!(
+            cage.mknod_syscall(path, S_IRWXA | S_IFCHR as u32, dev),
+            -(Errno::ENOENT as i32)
+        );
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
     }
@@ -801,8 +804,11 @@ pub mod fs_tests {
         let cage = interface::cagetable_getref(1);
         let dev = makedev(&DevNo { major: 1, minor: 3 });
         let path = "/parentdir/file";
-        // Check for error when both parent and file don't exist 
-        assert_eq!(cage.mknod_syscall(path, S_IRWXA | S_IFCHR as u32, dev), -(Errno::ENOENT as i32));
+        // Check for error when both parent and file don't exist
+        assert_eq!(
+            cage.mknod_syscall(path, S_IRWXA | S_IFCHR as u32, dev),
+            -(Errno::ENOENT as i32)
+        );
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
     }
@@ -816,7 +822,10 @@ pub mod fs_tests {
         assert_eq!(cage.mknod_syscall(path, S_IRWXA | S_IFCHR as u32, dev), 0);
 
         // Check for error when the same file is created again
-        assert_eq!(cage.mknod_syscall(path, S_IRWXA | S_IFCHR as u32, dev), -(Errno::EEXIST as i32));
+        assert_eq!(
+            cage.mknod_syscall(path, S_IRWXA | S_IFCHR as u32, dev),
+            -(Errno::EEXIST as i32)
+        );
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
     }
@@ -827,8 +836,11 @@ pub mod fs_tests {
         let dev = makedev(&DevNo { major: 1, minor: 3 });
         let path = "/testfile";
         let invalid_mode = 0o77777; // Invalid mode bits for testing
-        // Check for error when the file is being created with invalid mode
-        assert_eq!(cage.mknod_syscall(path, invalid_mode, dev), -(Errno::EPERM as i32));
+                                    // Check for error when the file is being created with invalid mode
+        assert_eq!(
+            cage.mknod_syscall(path, invalid_mode, dev),
+            -(Errno::EPERM as i32)
+        );
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
     }
@@ -841,17 +853,29 @@ pub mod fs_tests {
         let path = "/invalidfile";
 
         // When file type is S_IFDIR (Directory), error is expected
-        assert_eq!(cage.mknod_syscall(path, S_IRWXA | S_IFDIR as u32, dev), -(Errno::EINVAL as i32));
+        assert_eq!(
+            cage.mknod_syscall(path, S_IRWXA | S_IFDIR as u32, dev),
+            -(Errno::EINVAL as i32)
+        );
 
         // When file type is S_IFIFO (FIFO), error is expected
-        assert_eq!(cage.mknod_syscall(path, S_IRWXA | S_IFIFO as u32, dev), -(Errno::EINVAL as i32));
-        
+        assert_eq!(
+            cage.mknod_syscall(path, S_IRWXA | S_IFIFO as u32, dev),
+            -(Errno::EINVAL as i32)
+        );
+
         // When file type is S_IFREG (Regular File), error is expected
-        assert_eq!(cage.mknod_syscall(path, S_IRWXA | S_IFREG as u32, dev), -(Errno::EINVAL as i32));
-        
+        assert_eq!(
+            cage.mknod_syscall(path, S_IRWXA | S_IFREG as u32, dev),
+            -(Errno::EINVAL as i32)
+        );
+
         // When file type is S_IFSOCK (Socket), error is expected
-        assert_eq!(cage.mknod_syscall(path, S_IRWXA | S_IFSOCK as u32, dev), -(Errno::EINVAL as i32));
-        
+        assert_eq!(
+            cage.mknod_syscall(path, S_IRWXA | S_IFSOCK as u32, dev),
+            -(Errno::EINVAL as i32)
+        );
+
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
     }

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -885,10 +885,19 @@ pub mod fs_tests {
         lindrustinit(0);
         let cage = interface::cagetable_getref(1);
         let dev = makedev(&DevNo { major: 1, minor: 3 });
-        let path = "/null";
 
-        //now we are going to mknod /dev/null with create, read and write flags and permissions
-        //and then makr sure that it exists
+        //making the node with read only permission (S_IRUSR) and check if it gets created successfully
+        assert_eq!(cage.mknod_syscall("/readOnlyFile", S_IRUSR | S_IFCHR as u32, dev), 0);
+
+        //making the node with write only permission (S_IWUSR) and check if it gets created successfully
+        assert_eq!(cage.mknod_syscall("/writeOnlyFile", S_IWUSR | S_IFCHR as u32, dev), 0);
+
+        //making the node with execute only permission (S_IXUSR) and check if it gets created successfully
+        assert_eq!(cage.mknod_syscall("/executeOnlyFile", S_IXUSR | S_IFCHR as u32, dev), 0);
+
+        //now we are going to mknod /dev/null with read, write, and execute flags and permissions
+        //and then make sure that it exists
+        let path = "/null";
         assert_eq!(cage.mknod_syscall(path, S_IRWXA | S_IFCHR as u32, dev), 0);
         let fd = cage.open_syscall(path, O_RDWR, S_IRWXA);
 


### PR DESCRIPTION
## Description

Fixes # (issue)
The following changes include the tests and comments in the code for the "mknod_syscall" file system call under RustPosix.
The tests were added to cover all the possible scenarios that might happen when calling the file system_call `mknod_syscall`. 

### Type of change
- [ ]  This change just contains the tests for an existing file system call.
- [ ]  This change contains the minor code changes and comments for mknod syscall.

## How Has This Been Tested?
Inorder to run the tests, we need to run `cargo test --lib` command inside the `safeposix-rust` directory.

All the tests are present under this directory: `lind_project/src/safeposix-rust/src/tests/fs_tests.rs`

- Test A - `ut_lind_fs_mknod_empty_path()`
- Test B - `ut_lind_fs_mknod_nonexisting_parent_directory()`
- Test C - `ut_lind_fs_mknod_existing_file()`
- Test D - `ut_lind_fs_mknod_invalid_modebits()`
- Test E -  `ut_lind_fs_mknod_invalid_filetypes()`
- Test F - `ut_lind_fs_mknod_success()`

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
