### PR TITLE
chmod_syscall() updates

### DIFF
--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2263,34 +2263,29 @@ impl Cage {
 
     /// ### Description
     ///
-    /// The `chmod_syscall()` changes a file's mode bits that consist of read, write, and execute file permission bits.
-    /// Changing set-user-ID, set-group-ID, and sticky bits is currently not supported.
+    /// The `_chmod_helper()` is a helper function used by both `chmod_syscall()` and `fchmod_syscall()` 
+    /// to change mode bits that consist of read, write, and execute file permission bits of a file
+    /// specified by an inode obtained from the corresponding caller syscall.
     ///
     /// ### Arguments
     ///
-    /// The `chmod_syscall()` accepts two arguments:
-    /// * `path` - pathname of the file whose mode bits we are willing to change (symbolic links are currently 
-    /// not supported). If the pathname is relative, then it is interpreted relative to the current working directory 
-    /// of the calling process.
+    /// The `_chmod_helper()` accepts two arguments:
+    /// * `inodenum` - an inode of a file whose mode bits we are willing to change obtained from the caller syscall.
     /// * `mode` - the new file mode, which is a bit mask created by bitwise-or'ing zero or more valid mode bits.
     /// Some of the examples of such bits are `S_IRUSR` (read by owner), `S_IWUSR` (write by owner), etc.
     ///
     /// ### Returns
     /// 
     /// Upon successful completion, zero is returned.
-    /// In case of a failure, -1 is returned, and `errno` is set depending on the error, e.g. EACCES, ENOENT, etc.
+    /// In case of a failure, an error is returned, and `errno` is set depending on the error, e.g. EACCES, ENOENT, etc.
     ///
     /// ### Errors and Panics
     ///
-    /// Currently, only two errors are supposrted:
-    /// * `EINVAL` - the value of the mode argument is invalid 
-    /// * `ENOENT` - a component of path does not name an existing file
+    /// Currently, only one error is supported:
+    /// * `EINVAL` - the value of the mode argument is invalid.
     /// Other errors, like `EFAULT  , `ENOTDIR`, etc. are not supported.
     ///
-    /// There are no cases where this syscall panics.
-    ///
-    /// To learn more about the syscall, valid mode bits, and error values, see
-    /// [chmod(2)](https://man7.org/linux/man-pages/man2/chmod.2.html)
+    /// There are no cases where this helper function panics.
 
     pub fn _chmod_helper(inodenum: usize, mode: u32) -> i32 {
         //S_IRWXA is a result of bitwise-or'ing read, write, and execute or search permissions for the file owner, group owners, 
@@ -2337,6 +2332,37 @@ impl Cage {
         }
     }
 
+    /// ### Description
+    ///
+    /// The `chmod_syscall()` changes a file's mode bits that consist of read, write, and execute file permission bits.
+    /// Changing set-user-ID, set-group-ID, and sticky bits is currently not supported.
+    ///
+    /// ### Arguments
+    ///
+    /// The `chmod_syscall()` accepts two arguments:
+    /// * `path` - pathname of the file whose mode bits we are willing to change (symbolic links are currently 
+    /// not supported). If the pathname is relative, then it is interpreted relative to the current working directory 
+    /// of the calling process.
+    /// * `mode` - the new file mode, which is a bit mask created by bitwise-or'ing zero or more valid mode bits.
+    /// Some of the examples of such bits are `S_IRUSR` (read by owner), `S_IWUSR` (write by owner), etc.
+    ///
+    /// ### Returns
+    /// 
+    /// Upon successful completion, zero is returned.
+    /// In case of a failure, an error is returned, and `errno` is set depending on the error, e.g. EACCES, ENOENT, etc.
+    ///
+    /// ### Errors and Panics
+    ///
+    /// Currently, only two errors are supposrted:
+    /// * `EINVAL` - the value of the mode argument is invalid 
+    /// * `ENOENT` - a component of path does not name an existing file
+    /// Other errors, like `EFAULT  , `ENOTDIR`, etc. are not supported.
+    ///
+    /// There are no cases where this syscall panics.
+    ///
+    /// To learn more about the syscall, valid mode bits, and error values, see
+    /// [chmod(2)](https://man7.org/linux/man-pages/man2/chmod.2.html)
+
     pub fn chmod_syscall(&self, path: &str, mode: u32) -> i32 {
         //Convert the provided pathname into an absolute path without `.` or `..` components.
         let truepath = normpath(convpath(path), self);
@@ -2372,7 +2398,7 @@ impl Cage {
     /// ### Returns
     /// 
     /// Upon successful completion, zero is returned.
-    /// In case of a failure, -1 is returned, and `errno` is set depending on the error, e.g. EACCES, ENOENT, etc.
+    /// In case of a failure, an error is returned, and `errno` is set depending on the error, e.g. EACCES, ENOENT, etc.
     ///
     /// ### Errors and Panics
     ///

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2273,8 +2273,7 @@ impl Cage {
     /// not supported). If the pathname is relative, then it is interpreted relative to the current working directory 
     /// of the calling process.
     /// * `mode` - the new file mode, which is a bit mask created by bitwise-or'ing zero or more valid mode bits.
-    /// Some of the examples of such bits are `S_IRUSR` (read by owner), `S_IWUSR` (write by owner), 
-    /// `S_ISUID` (set-user-ID), etc.
+    /// Some of the examples of such bits are `S_IRUSR` (read by owner), `S_IWUSR` (write by owner), etc.
     ///
     /// ### Returns
     /// 
@@ -2308,19 +2307,19 @@ impl Cage {
             //the intact mode bits with the changed mode bits.
             match *thisinode {
                 Inode::File(ref mut general_inode) => {
-                    general_inode.mode = (general_inode.mode & !S_IRWXA) | mode
+                    general_inode.mode = (general_inode.mode & !S_IRWXA) | (mode & S_IRWXA);
                 }
                 Inode::CharDev(ref mut dev_inode) => {
-                    dev_inode.mode = (dev_inode.mode & !S_IRWXA) | mode;
+                    dev_inode.mode = (dev_inode.mode & !S_IRWXA) | (mode & S_IRWXA);
                 }
                 Inode::Socket(ref mut sock_inode) => {
-                    sock_inode.mode = (sock_inode.mode & !S_IRWXA) | mode;
+                    sock_inode.mode = (sock_inode.mode & !S_IRWXA) | (mode & S_IRWXA);
                     //Sockets only exist as long as the cages using them are running. After these cages are closed, no changes
                     //to sockets' inodes need to be persisted, thus using log is unnecessary.
                     log = false;
                 }
                 Inode::Dir(ref mut dir_inode) => {
-                    dir_inode.mode = (dir_inode.mode & !S_IRWXA) | mode;
+                    dir_inode.mode = (dir_inode.mode & !S_IRWXA) | (mode & S_IRWXA);
                 }
             }
             drop(thisinode);

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2263,43 +2263,53 @@ impl Cage {
 
     /// ### Description
     ///
-    /// The `_chmod_helper()` is a helper function used by both `chmod_syscall()` and `fchmod_syscall()` 
-    /// to change mode bits that consist of read, write, and execute file permission bits of a file
-    /// specified by an inode obtained from the corresponding caller syscall.
+    /// The `_chmod_helper()` is a helper function used by both `chmod_syscall()` 
+    /// and `fchmod_syscall()` to change mode bits that consist of read, write, 
+    /// and execute file permission bits of a file specified by an inode 
+    /// obtained from the corresponding caller syscall.
     ///
     /// ### Arguments
     ///
     /// The `_chmod_helper()` accepts two arguments:
-    /// * `inodenum` - an inode of a file whose mode bits we are willing to change obtained from the caller syscall.
-    /// * `mode` - the new file mode, which is a bit mask created by bitwise-or'ing zero or more valid mode bits.
-    /// Some of the examples of such bits are `S_IRUSR` (read by owner), `S_IWUSR` (write by owner), etc.
+    /// * `inodenum` - an inode of a file whose mode bits we are willing to 
+    /// change obtained from the caller syscall.
+    /// * `mode` - the new file mode, which is a bit mask created by 
+    /// bitwise-or'ing zero or more valid mode bits. Some of the examples of 
+    /// such bits are `S_IRUSR` (read by owner), `S_IWUSR` (write by owner), etc.
     ///
     /// ### Returns
     /// 
     /// Upon successful completion, zero is returned.
-    /// In case of a failure, an error is returned, and `errno` is set depending on the error, e.g. EACCES, ENOENT, etc.
+    /// In case of a failure, an error is returned, and `errno` is set depending
+    /// on the error, e.g. EACCES, ENOENT, etc.
     ///
     /// ### Errors and Panics
     ///
     /// Currently, only one error is supported:
     /// * `EINVAL` - the value of the mode argument is invalid.
-    /// Other errors, like `EFAULT  , `ENOTDIR`, etc. are not supported.
+    /// Other errors, like `EFAULT`, `ENOTDIR`, etc. are not supported.
     ///
     /// There are no cases where this helper function panics.
 
     pub fn _chmod_helper(inodenum: usize, mode: u32) -> i32 {
-        //S_IRWXA is a result of bitwise-or'ing read, write, and execute or search permissions for the file owner, group owners, 
-        //and other users. It encompasses all the mode bits that can be changed via `chmod_syscall()` and is used as a bitmask
-        //to make sure that no other invalid bit change is being made. 
+        //S_IRWXA is a result of bitwise-or'ing read, write, and execute or search 
+        //permissions for the file owner, group owners, 
+        //and other users. It encompasses all the mode bits that can be changed 
+        //via `chmod_syscall()` and is used as a bitmask to make sure that no 
+        //other invalid bit change is being made. 
         if (mode & S_IRWXA) == mode {
-            //getting a mutable reference to an inode struct that corresponds to the file whose mode bits we want to change
+            //getting a mutable reference to an inode struct that corresponds to 
+            //the file whose mode bits we want to change
             let mut thisinode = FS_METADATA.inodetable.get_mut(&inodenum).unwrap();
-            //log is used to store all the changes made to the filesystem. After the cage is closed, all the collected
-            //changes are serialized and the state of the underlying filsystem is persisted. This allows us to avoid
-            //serializing and persisting filesystem state after every `chmod_syscall()`.
+            //log is used to store all the changes made to the filesystem. After 
+            //the cage is closed, all the collected changes are serialized and 
+            //the state of the underlying filsystem is persisted. This allows us
+            //to avoid serializing and persisting filesystem state after every 
+            //`chmod_syscall()`.
             let mut log = true;
-            //We obtain the mode bits that should remain intact by bitwise-and'ing the inode's mode bits with 
-            //the set of bits that can be changed via `chmod_syscall`. The changes are applied by bitwise-or'ing 
+            //We obtain the mode bits that should remain intact by bitwise-and'ing 
+            //the inode's mode bits with the set of bits that can be changed via 
+            //`chmod_syscall`. The changes are applied by bitwise-or'ing 
             //the intact mode bits with the changed mode bits.
             match *thisinode {
                 Inode::File(ref mut general_inode) => {
@@ -2310,20 +2320,23 @@ impl Cage {
                 }
                 Inode::Socket(ref mut sock_inode) => {
                     sock_inode.mode = (sock_inode.mode & !S_IRWXA) | mode;
-                    //Sockets only exist as long as the cages using them are running. After these cages are closed, no changes
-                    //to sockets' inodes need to be persisted, thus using log is unnecessary.
+                    //Sockets only exist as long as the cages using them are running.
+                    //After these cages are closed, no changes to sockets' inodes 
+                    //need to be persisted, thus using log is unnecessary.
                     log = false;
                 }
                 Inode::Dir(ref mut dir_inode) => {
                     dir_inode.mode = (dir_inode.mode & !S_IRWXA) | mode;
                 }
             }
-            //the mutable reference to the inode has to be dropped because log_metadata will need to acquire an immutable 
-            //reference to the same inode
+            //the mutable reference to the inode has to be dropped because 
+            //`log_metadata` will need to acquire an immutable reference to 
+            //the same inode
             drop(thisinode);
-            //changes to an inode are saved into the log for all file types except for Sockets
+            //changes to an inode are saved into the log for all file types 
+            //except for Sockets
             if log {
-                log_metadata(&FS_METADATA, inodenum)
+                log_metadata(&FS_METADATA, inodenum);
             };
             //return 0 on success
             0
@@ -2334,29 +2347,34 @@ impl Cage {
 
     /// ### Description
     ///
-    /// The `chmod_syscall()` changes a file's mode bits that consist of read, write, and execute file permission bits.
-    /// Changing set-user-ID, set-group-ID, and sticky bits is currently not supported.
+    /// The `chmod_syscall()` changes a file's mode bits that consist of read, 
+    /// write, and execute file permission bits.
+    /// Changing `set-user-ID`, `set-group-ID`, and sticky bits is currently 
+    /// not supported.
     ///
     /// ### Arguments
     ///
     /// The `chmod_syscall()` accepts two arguments:
-    /// * `path` - pathname of the file whose mode bits we are willing to change (symbolic links are currently 
-    /// not supported). If the pathname is relative, then it is interpreted relative to the current working directory 
-    /// of the calling process.
-    /// * `mode` - the new file mode, which is a bit mask created by bitwise-or'ing zero or more valid mode bits.
-    /// Some of the examples of such bits are `S_IRUSR` (read by owner), `S_IWUSR` (write by owner), etc.
+    /// * `path` - pathname of the file whose mode bits we are willing to 
+    /// change (symbolic links are currently not supported). If the 
+    /// pathname is relative, then it is interpreted relative to the 
+    /// current working directory of the calling process.
+    /// * `mode` - the new file mode, which is a bit mask created by 
+    /// bitwise-or'ing zero or more valid mode bits. Some of the examples 
+    /// of such bits are `S_IRUSR` (read by owner), `S_IWUSR` (write by owner), etc.
     ///
     /// ### Returns
     /// 
     /// Upon successful completion, zero is returned.
-    /// In case of a failure, an error is returned, and `errno` is set depending on the error, e.g. EACCES, ENOENT, etc.
+    /// In case of a failure, an error is returned, and `errno` is set depending
+    /// on the error, e.g. `EACCES`, `ENOENT`, etc.
     ///
     /// ### Errors and Panics
     ///
     /// Currently, only two errors are supposrted:
     /// * `EINVAL` - the value of the mode argument is invalid 
     /// * `ENOENT` - a component of path does not name an existing file
-    /// Other errors, like `EFAULT  , `ENOTDIR`, etc. are not supported.
+    /// Other errors, like `EFAULT`, `ENOTDIR`, etc. are not supported.
     ///
     /// There are no cases where this syscall panics.
     ///
@@ -2364,13 +2382,15 @@ impl Cage {
     /// [chmod(2)](https://man7.org/linux/man-pages/man2/chmod.2.html)
 
     pub fn chmod_syscall(&self, path: &str, mode: u32) -> i32 {
-        //Convert the provided pathname into an absolute path without `.` or `..` components.
+        //Convert the provided pathname into an absolute path without `.` or `..` 
+        //components.
         let truepath = normpath(convpath(path), self);
-        //Perfrom a walk down the file tree starting from the root directory to obtain an inode number 
-        //of the file whose pathname was specified.
-        //`None` is returned if one of the following occurs while moving down the tree: accessing a child 
-        //of a non-directory inode, accessing a child of a nonexistent parent directory, accessing 
-        //a nonexistent child, accessing an unexpected component, like `.` or `..` directory reference. 
+        //Perfrom a walk down the file tree starting from the root directory to 
+        //obtain an inode number of the file whose pathname was specified.
+        //`None` is returned if one of the following occurs while moving down
+        //the tree: accessing a child of a non-directory inode, accessing a 
+        //child of a nonexistent parent directory, accessing a nonexistent child,
+        //accessing an unexpected component, like `.` or `..` directory reference. 
         //In this case, `The file does not exist` error is returned.
         //Otherwise, a `Some()` option containing the inode number is returned.
         if let Some(inodenum) = metawalk(truepath.as_path()) {
@@ -2382,29 +2402,33 @@ impl Cage {
 
     /// ### Description
     ///
-    /// The `fchmod_syscall()` is equivalent to chmod() in that it is used to change a file's mode bits 
-    /// that consist of read, write, and execute file permission bits except that the file
-    /// is specified by the file descriptor.
-    /// Changing set-user-ID, set-group-ID, and sticky bits is currently not supported.
+    /// The `fchmod_syscall()` is equivalent to `chmod_syscall()` in that
+    /// it is used to change a file's mode bits that consist of read, 
+    /// write, and execute file permission bits except that the file
+    /// is specified by the file descriptor. Changing `set-user-ID`, 
+    /// `set-group-ID`, and sticky bits is currently not supported.
     ///
     /// ### Arguments
     ///
     /// The `fchmod_syscall()` accepts two arguments:
     /// * `fd` - an open file descriptor.
-    /// * `mode` - the new file mode, which is a bit mask created by bitwise-or'ing zero or more valid mode bits.
-    /// Some of the examples of such bits are `S_IRUSR` (read by owner), `S_IWUSR` (write by owner), 
-    /// `S_ISUID` (set-user-ID), etc.
+    /// * `mode` - the new file mode, which is a bit mask created by 
+    /// bitwise-or'ing zero or more valid mode bits. Some of the examples 
+    /// of such bits are `S_IRUSR` (read by owner), `S_IWUSR` 
+    /// (write by owner), etc.
     ///
     /// ### Returns
     /// 
     /// Upon successful completion, zero is returned.
-    /// In case of a failure, an error is returned, and `errno` is set depending on the error, e.g. EACCES, ENOENT, etc.
+    /// In case of a failure, an error is returned, and `errno` is set 
+    /// depending on the error, e.g. `EACCES`, `ENOENT`, etc.
     ///
     /// ### Errors and Panics
     ///
-    /// * `EBADF` - the file descriptor fd is not valid. 
-    /// * `EINVAL` - the value of the `mode` argument is invalid or mode bits cannot be changed on this file type
-    /// Other errors, like `EFAULT  , `ENOTDIR`, etc. are not supported.
+    /// * `EBADF` - the file descriptor `fd` is not valid. 
+    /// * `EINVAL` - the value of the `mode` argument is invalid or 
+    /// mode bits cannot be changed on this file type
+    /// Other errors, like `EFAULT`, `ENOTDIR`, etc. are not supported.
     ///
     /// A panic occurs when a provided file descriptor is out of bounds
     ///
@@ -2413,9 +2437,9 @@ impl Cage {
 
     pub fn fchmod_syscall(&self, fd: i32, mode: u32) -> i32 {
         //BUG
-        //if the provided file descriptor is out of bounds, 'get_filedescriptor' returns Err(),
-        //unwrapping on which  produces a 'panic!'
-        //otherwise, file descriptor table entry is stored in 'checkedfd'
+        //if the provided file descriptor is out of bounds, 'get_filedescriptor'
+        //returns `Err()`, unwrapping on which  produces a `panic!`
+        //otherwise, file descriptor table entry is stored in `checkedfd`
         let checkedfd = self.get_filedescriptor(fd).unwrap();
         let unlocked_fd = checkedfd.read();
         //if a table descriptor entry is non-empty, a valid request is performed

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2283,11 +2283,13 @@ impl Cage {
     /// In case of a failure, an error is returned, and `errno` is set depending
     /// on the error, e.g. EACCES, ENOENT, etc.
     ///
-    /// ### Errors and Panics
+    /// ### Errors
     ///
     /// Currently, only one error is supported:
     /// * `EINVAL` - the value of the mode argument is invalid.
     /// Other errors, like `EFAULT`, `ENOTDIR`, etc. are not supported.
+    ///
+    /// ### Panics
     ///
     /// There are no cases where this helper function panics.
 
@@ -2369,12 +2371,14 @@ impl Cage {
     /// In case of a failure, an error is returned, and `errno` is set depending
     /// on the error, e.g. `EACCES`, `ENOENT`, etc.
     ///
-    /// ### Errors and Panics
+    /// ### Errors
     ///
     /// Currently, only two errors are supposrted:
     /// * `EINVAL` - the value of the mode argument is invalid 
     /// * `ENOENT` - a component of path does not name an existing file
     /// Other errors, like `EFAULT`, `ENOTDIR`, etc. are not supported.
+    ///
+    /// ### Panics
     ///
     /// There are no cases where this syscall panics.
     ///
@@ -2423,12 +2427,14 @@ impl Cage {
     /// In case of a failure, an error is returned, and `errno` is set 
     /// depending on the error, e.g. `EACCES`, `ENOENT`, etc.
     ///
-    /// ### Errors and Panics
+    /// ### Errors
     ///
     /// * `EBADF` - the file descriptor `fd` is not valid. 
     /// * `EINVAL` - the value of the `mode` argument is invalid or 
     /// mode bits cannot be changed on this file type
     /// Other errors, like `EFAULT`, `ENOTDIR`, etc. are not supported.
+    ///
+    /// ### Panics
     ///
     /// A panic occurs when a provided file descriptor is out of bounds
     ///

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2396,21 +2396,7 @@ impl Cage {
             match filedesc_enum {
                 File(normalfile_filedesc_obj) => {
                     let inodenum = normalfile_filedesc_obj.inode;
-                    //S_IRWXA is a result of bitwise-or'ing read, write, and execute or search permissions 
-                    //for the file owner, group owners, and other users. It encompasses all the mode bits 
-                    //that can be changed via `chmod_syscall()` and is used as a bitmask to make sure that 
-                    //no other invalid bit change is being made. 
-                    //S_FILETYPEFLAGS is a result of bitwise-or'ing S_IFREG, S_IFSOCK, S_IFDIR, S_IFCHR, 
-                    //and S_IFIFO, which correspond to the flags designating regular file, socket, directory,
-                    //character device, and named pipe file types. It is used as a sanity check to make
-                    //sure that chmod_syscall() is only called on the supported file types.
-                    //BUG: S_IFIFO is included in S_FILETYPEFLAGS implying that calling chmod_syscall() on 
-                    //named papes is supported even though named pipes are currently not supported. 
-                    if mode & (S_IRWXA | (S_FILETYPEFLAGS as u32)) == mode {
-                        Self::_chmod_helper(inodenum, mode);
-                    } else {
-                        return syscall_error(Errno::EINVAL, "chmod", "The value of the mode argument is invalid");
-                    }
+                    Self::_chmod_helper(inodenum, mode)                    
                 }
                 Socket(_) => {
                     return syscall_error(
@@ -2444,7 +2430,6 @@ impl Cage {
         } else {
             return syscall_error(Errno::EBADF, "ioctl", "Invalid file descriptor");
         }
-        0 //success!
     }
 
     //------------------------------------MMAP SYSCALL------------------------------------

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2345,7 +2345,7 @@ impl Cage {
         //In this case, `The file does not exist` error is returned.
         //Otherwise, a `Some()` option containing the inode number is returned.
         if let Some(inodenum) = metawalk(truepath.as_path()) {
-            //S_IRWXA is a result of bitwise-or'ing read, write, and execute or search permissions for the file owner, group owner, 
+            //S_IRWXA is a result of bitwise-or'ing read, write, and execute or search permissions for the file owner, group owners, 
             //and other users. It encompasses all the mode bits that can be changed via `chmod_syscall()` and is used as a bitmask
             //to make sure that no other invalid bit change is being made. 
             //S_FILETYPEFLAGS is a result of bitwise-or'ing S_IFREG, S_IFSOCK, S_IFDIR, S_IFCHR, and S_IFIFO, which correspond to the flags

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2384,6 +2384,15 @@ impl Cage {
     /// In case of a failure, -1 is returned, and `errno` is set depending on the error, e.g. EACCES, ENOENT, etc.
     ///
     /// ### Errors and Panics
+    ///
+    /// * `EBADF` - the file descriptor fd is not valid. 
+    /// * `EINVAL` - the value of the `mode` argument is invalid or mode bits cannot be changed on this file type
+    /// Other errors, like `EFAULT  , `ENOTDIR`, etc. are not supported.
+    ///
+    /// A panic occurs when a provided file descriptor is out of bounds
+    ///
+    /// To learn more about the syscall, valid mode bits, and error values, see
+    /// [fchmod(2)](https://linux.die.net/man/2/fchmod)
 
     pub fn fchmod_syscall(&self, fd: i32, mode: u32) -> i32 {
         //BUG
@@ -2416,30 +2425,30 @@ impl Cage {
                 }
                 Socket(_) => {
                     return syscall_error(
-                        Errno::EACCES,
+                        Errno::EINVAL,
                         "fchmod",
-                        "cannot change mode on this file descriptor",
+                        "Mode bits cannot be changed on this file type",
                     );
                 }
                 Stream(_) => {
                     return syscall_error(
-                        Errno::EACCES,
+                        Errno::EINVAL,
                         "fchmod",
-                        "cannot change mode on this file descriptor",
+                        "Mode bits cannot be changed on this file type",
                     );
                 }
                 Pipe(_) => {
                     return syscall_error(
-                        Errno::EACCES,
+                        Errno::EINVAL,
                         "fchmod",
-                        "cannot change mode on this file descriptor",
+                        "Mode bits cannot be changed on this file type",
                     );
                 }
                 Epoll(_) => {
                     return syscall_error(
-                        Errno::EACCES,
+                        Errno::EINVAL,
                         "fchmod",
-                        "cannot change mode on this file descriptor",
+                        "Mode bits cannot be changed on this file type",
                     );
                 }
             }

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2323,6 +2323,8 @@ impl Cage {
                     dir_inode.mode = (dir_inode.mode & !S_IRWXA) | mode;
                 }
             }
+            //the mutable reference to the inode has to be dropped because log_metadata will need to acquire an immutable 
+            //reference to the same inode
             drop(thisinode);
             //changes to an inode are saved into the log for all file types except for Sockets
             if log {

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -301,8 +301,7 @@ pub mod fs_tests {
         let fd = cage.open_syscall(filepath, flags, S_IRWXA);
         assert_eq!(cage.stat_syscall(filepath, &mut statdata), 0);
         assert_eq!(statdata.st_mode, S_IRWXA | S_IFREG as u32);
-        //0o7777 is an arbitrary value that does not correspond to any combination of valid mode 
-        //bits or supported file types
+        //0o7777 is an arbitrary value that does not correspond to any combination of valid mode bits
         assert_eq!(cage.chmod_syscall(filepath, 0o7777 as u32), -(Errno::EINVAL as i32));
 
         assert_eq!(cage.close_syscall(fd), 0);

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -13,7 +13,8 @@ pub mod fs_tests {
         ut_lind_fs_simple(); // has to go first, else the data files created screw with link count test
 
         ut_lind_fs_broken_close();
-        ut_lind_fs_chmod();
+        ut_lind_fs_chmod_valid_args();
+        ut_lind_fs_chmod_invalid_args();
         ut_lind_fs_fchmod();
         ut_lind_fs_dir_chdir();
         ut_lind_fs_dir_mode();
@@ -221,26 +222,88 @@ pub mod fs_tests {
         lindrustfinalize();
     }
 
-    pub fn ut_lind_fs_chmod() {
+    pub fn ut_lind_fs_chmod_valid_args() {
         lindrustinit(0);
         let cage = interface::cagetable_getref(1);
 
         let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
-        let filepath = "/chmodTestFile";
+        //checking if `chmod_syscall()` works with a relative path that includes only normal components, 
+        //e.g. without `.` or `..` references
+        let filepath = "/chmodTestFile1";
 
         let mut statdata = StatData::default();
 
-        let fd = cage.open_syscall(filepath, flags, S_IRWXA);
+        //checking if the file was successfully created with the specified initial flags
+        //set all mode bits to 0 to change them later
+        let fd = cage.open_syscall(filepath, flags, 0);
         assert_eq!(cage.stat_syscall(filepath, &mut statdata), 0);
-        assert_eq!(statdata.st_mode, S_IRWXA | S_IFREG as u32);
+        assert_eq!(statdata.st_mode, S_IFREG as u32);
 
-        assert_eq!(cage.chmod_syscall(filepath, S_IRUSR | S_IRGRP), 0);
+        //checking if owner read, write, and execute or search mode bits are correctly set
+        assert_eq!(cage.chmod_syscall(filepath, S_IRUSR | S_IWUSR | S_IXUSR), 0);
         assert_eq!(cage.stat_syscall(filepath, &mut statdata), 0);
-        assert_eq!(statdata.st_mode, S_IRUSR | S_IRGRP | S_IFREG as u32);
+        assert_eq!(statdata.st_mode, S_IRUSR | S_IWUSR | S_IXUSR | S_IFREG as u32);
 
+        //resetting access mode bits 
+        assert_eq!(cage.chmod_syscall(filepath, 0), 0);
+
+        //checking if group owners read, write, and execute or search mode bits are correctly set
+        assert_eq!(cage.chmod_syscall(filepath, S_IRGRP | S_IWGRP | S_IXGRP), 0);
+        assert_eq!(cage.stat_syscall(filepath, &mut statdata), 0);
+        assert_eq!(statdata.st_mode, S_IRGRP | S_IWGRP | S_IXGRP | S_IFREG as u32);
+
+        //resetting access mode bits 
+        assert_eq!(cage.chmod_syscall(filepath, 0), 0);
+
+        //checking if other users read, write, and execute or search mode bits are correctly set
+        assert_eq!(cage.chmod_syscall(filepath, S_IROTH | S_IWOTH | S_IXOTH), 0);
+        assert_eq!(cage.stat_syscall(filepath, &mut statdata), 0);
+        assert_eq!(statdata.st_mode, S_IROTH | S_IWOTH | S_IXOTH | S_IFREG as u32);
+
+        assert_eq!(cage.close_syscall(fd), 0);
+
+        //checking if `chmod_syscall()` works with relative path that include parent directory reference
+        let newdir = "../testFolder";
+        assert_eq!(cage.mkdir_syscall(newdir, S_IRWXA), 0);
+        let filepath = "../testFolder/chmodTestFile";
+
+        //checking if the file was successfully created with the specified initial flags
+        //set all mode bits to 0 to set them later
+        let fd = cage.open_syscall(filepath, flags, 0);
+        assert_eq!(cage.stat_syscall(filepath, &mut statdata), 0);
+        assert_eq!(statdata.st_mode, S_IFREG as u32);
+
+        //checking if owner, group owners, and other users read, write, and execute or search
+        //mode bits are correctly set
         assert_eq!(cage.chmod_syscall(filepath, S_IRWXA), 0);
         assert_eq!(cage.stat_syscall(filepath, &mut statdata), 0);
         assert_eq!(statdata.st_mode, S_IRWXA | S_IFREG as u32);
+
+        assert_eq!(cage.close_syscall(fd), 0);
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    pub fn ut_lind_fs_chmod_invalid_args() {
+        lindrustinit(0);
+        let cage = interface::cagetable_getref(1);
+
+        //checking if passing a nonexistent pathname to `chmod_syscall()` 
+        //correctly results in `A component of path does not name an existing file` error
+        let invalidpath = "/someInvalidPath/testFile";
+        assert_eq!(cage.chmod_syscall(invalidpath, S_IRUSR | S_IWUSR | S_IXUSR), -(Errno::ENOENT as i32));
+
+        //checking if passing an invalid set of mod bits to `chmod_syscall()`
+        //correctly results in `The value of the mode argument is invalid` error
+        let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
+        let filepath = "/chmodTestFile2";
+        let mut statdata = StatData::default();
+        let fd = cage.open_syscall(filepath, flags, S_IRWXA);
+        assert_eq!(cage.stat_syscall(filepath, &mut statdata), 0);
+        assert_eq!(statdata.st_mode, S_IRWXA | S_IFREG as u32);
+        //0o7777 is an arbitrary value that does not correspond to any combination of valid mode 
+        //bits or supported file types
+        assert_eq!(cage.chmod_syscall(filepath, 0o7777 as u32), -(Errno::EINVAL as i32));
 
         assert_eq!(cage.close_syscall(fd), 0);
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);


### PR DESCRIPTION
## Description

Fixes # (issue)

The following changes include more elaborate comments and new unit tests for `chmod_syscall` and `fchmod_syscall`.

### Type of change

- [ ] More detailed comments for `chmod_syscall` and `fchmod_syscall`
- [ ] Shifted checking the validity of mode bits from `chmod_syscall()` to the `_chmod_helper()` helper function since it used by both `chmod_syscall()` and `fchmod_syscall()`
- [ ] Removed the unnecessary check for file type flags that allowed the file type to be changed
- [ ] New unit tests for `chmod_syscall` and `fchmod_syscall`

## How Has This Been Tested?

To run the tests, we need to run cargo test --lib command inside the safeposix-rust directory.

All the tests are present under this directory: lind_project/src/safeposix-rust/src/tests/fs_tests.rs

- Test A - `lut_lind_fs_chmod_valid_args()`
- Test B - `ut_lind_fs_chmod_invalid_args()`
- Test C - `ut_lind_fs_fchmod()`

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
