### PR TITLE
Connect sys call comments and tests

### DIFF
--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -641,12 +641,21 @@ impl Cage {
             syscall_error(Errno::EBADF, "bind", "invalid file descriptor")
         }
     }
-
+    
+    // ** Why is this its own function? it seems incredibly similar to assign_new_addr ** //
     fn assign_new_addr_unix(sockhandle: &SocketHandle) -> interface::GenSockaddr {
+        //If the socket handle has a local address set, return a clone of the addr. 
+        //This is because we do not want to assign a new address to a socket that is already assigned one
         if let Some(addr) = sockhandle.localaddr.clone() {
             addr
         } else {
+            //path will be in the format of /sockID, where ID is of type
+            //usize before being converted toa string type
+            //The UD_ID_COUNTER begins counting at 0
             let path = interface::gen_ud_path();
+            //Unix domains paths can't exceed 108 bytes. If this happens, process will panic
+            //Set the newremote address based on the Unix domain and the path
+            //Note, Unix domain socket addresses expect a null-terminated string or zero-padded path
             let newremote = interface::GenSockaddr::Unix(interface::new_sockaddr_unix(
                 AF_UNIX as u16,
                 path.as_bytes(),
@@ -655,29 +664,50 @@ impl Cage {
         }
     }
 
+    //Return a new address based on the domain of the socket handle
+    //If a socket handle contains a local address, return a clone of the local address
+
+    //** I've seen checks previously that make sure the input domain matches the domain
+    // of the sockhandle. Possibly consider adding it in the function at the beginning? **/
     fn assign_new_addr(
         sockhandle: &SocketHandle,
         domain: i32,
         rebindability: bool,
     ) -> Result<interface::GenSockaddr, i32> {
+        //If the socket handle has a local address set, return a Result
+        //type containing a clone of the addr. This is because we do not 
+        //want to assign a new address to a socket that already contains one
         if let Some(addr) = &sockhandle.localaddr {
             Ok(addr.clone())
         } else {
             let mut newremote: interface::GenSockaddr;
             //This is the specified behavior for the berkeley sockets API
+            //** Let's try to get a link to the berkeley sockets API ??? ** //
             match domain {
                 AF_UNIX => {
+                    //path will be in the format of /sockID, where ID is of type
+                    //usize before being converted toa string type
+                    //The UD_ID_COUNTER begins counting at 0
                     let path = interface::gen_ud_path();
+                    //Unix domains paths can't exceed 108 bytes. If this happens, process will panic
+                    //Set the newremote address based on the Unix domain and the path
+                    //Note, Unix domain socket addresses expect a null-terminated string or zero-padded path
                     newremote = interface::GenSockaddr::Unix(interface::new_sockaddr_unix(
                         AF_UNIX as u16,
                         path.as_bytes(),
                     ));
                 }
                 AF_INET => {
+                    //Initialize and assign values to the remote address for a connection
                     newremote = interface::GenSockaddr::V4(interface::SockaddrV4::default());
                     let addr = interface::GenIpaddr::V4(interface::V4Addr::default());
                     newremote.set_addr(addr);
                     newremote.set_family(AF_INET as u16);
+                    //Arguments being passed in ...
+                    // ** Why are we setting an addr to default and then cloning it ?? ** //
+                    //port is set to 0 to use any available port
+                    //Possible protocols are IPPROTO_UDP and IPPROTO_TCP
+                    //Will panic for unknown protocols 
                     newremote.set_port(
                         match NET_METADATA._reserve_localport(
                             addr.clone(),
@@ -692,10 +722,16 @@ impl Cage {
                     );
                 }
                 AF_INET6 => {
+                    //Initialize and assign values to the remote address for a connection
                     newremote = interface::GenSockaddr::V6(interface::SockaddrV6::default());
                     let addr = interface::GenIpaddr::V6(interface::V6Addr::default());
                     newremote.set_addr(addr);
                     newremote.set_family(AF_INET6 as u16);
+                    //Arguments being passed in ...
+                    // ** Why are we setting an addr to default and then cloning it ?? ** //
+                    //port is set to 0 to use any available port
+                    //Possible protocols are IPPROTO_UDP and IPPROTO_TCP
+                    //Will panic for unknown protocols 
                     newremote.set_port(
                         match NET_METADATA._reserve_localport(
                             addr.clone(),
@@ -721,16 +757,86 @@ impl Cage {
         }
     }
 
-    //The connect() system call connects the socket referred to by the
-    //file descriptor fd to the address specified by remoteaddr.
+    /// ### Description
+    /// 
+    /// `connect_syscall` connects the socket referred to by the
+    /// file descriptor fd to the address specified by remoteaddr. 
+    /// 
+    /// ### Arguments
+    /// 
+    /// it accepts two parameters: 
+    /// * `fd` - an open file descriptor
+    /// * `remoteaddr` - the address to request a connection to
+    /// 
+    /// ### Returns
+    /// 
+    /// for a successful call, zero is returned. On
+    /// error, -errno is returned, and errno is set to indicate the error.
+    /// 
+    /// ### Errors
+    /// 
+    /// * EADDRNOTAVAIL - The specified address is not available from the local machine.
+    /// * EAFNOSUPPORT - The specified address is not a valid address for the address family of the specified socket.
+    /// * EALREADY - A connection request is already in progress for the specified socket.
+    /// * EBADF - The socket argument is not a valid file descriptor.
+    /// * ECONNREFUSED - The target address was not listening for connections or refused the connection request.
+    /// * EINPROGRESS - O_NONBLOCK is set for the file descriptor for the socket and the connection cannot be immediately established; the connection shall be established asynchronously.
+    /// * EINTR - The attempt to establish a connection was interrupted by delivery of a signal that was caught; the connection shall be established asynchronously.
+    /// * EISCONN - The specified socket is connection-mode and is already connected.
+    /// * ENETUNREACH - No route to the network is present.
+    /// * ENOTSOCK - The socket argument does not refer to a socket.
+    /// * EPROTOTYPE - The specified address has a different type than the socket bound to the specified peer address.
+    /// * ETIMEDOUT - The attempt to connect timed out before a connection was made.
+    /// 
+    /// If the address family of the socket is AF_UNIX, then connect() shall fail if:
+    ///
+    /// * EIO - An I/O error occurred while reading from or writing to the file system.
+    /// * ELOOP - A loop exists in symbolic links encountered during resolution of the pathname in address.
+    /// * ENAMETOOLONG - A component of a pathname exceeded {NAME_MAX} characters, or an entire pathname exceeded {PATH_MAX} characters.
+    /// * ENOENT - A component of the pathname does not name an existing file or the pathname is an empty string.
+    /// * ENOTDIR - A component of the path prefix of the pathname in address is not a directory.
+    ///
+    /// The connect() function may fail if:
+    /// 
+    /// * EACCES - Search permission is denied for a component of the path prefix; or write access to the named socket is denied.
+    /// * EADDRINUSE - Attempt to establish a connection that uses addresses that are already in use.
+    /// * ECONNRESET - Remote host reset the connection request.
+    /// * EHOSTUNREACH - The destination host cannot be reached (probably because the host is down or a remote router cannot reach it).
+    /// * EINVAL - The address_len argument is not a valid length for the address family; or invalid address family in the sockaddr structure.
+    /// * ELOOP - More than {SYMLOOP_MAX} symbolic links were encountered during resolution of the pathname in address.
+    /// * ENAMETOOLONG - Pathname resolution of a symbolic link produced an intermediate result whose length exceeds {PATH_MAX}.
+    /// * ENETDOWN - The local network interface used to reach the destination is down.
+    /// * ENOBUFS- No buffer space is available.
+    /// * EOPNOTSUPP - The socket is listening and cannot be connected.
+    /// 
+    /// ### Panics
+    /// 
+    /// * Unknown errno value from bind libc call, will cause panic
+    /// * Unknown errno value from connect libc call, will cause panic.
+    /// 
+    /// for more detailed description of all the commands and return values, see 
+    /// [connect(3)](https://linux.die.net/man/3/connect)
+
+    // ** I think we are missing some implementation details mentioned on the man page
+    // under the Description section ** //
     pub fn connect_syscall(&self, fd: i32, remoteaddr: &interface::GenSockaddr) -> i32 {
+        //If fd is out of range of [0,MAXFD], process will panic
+        //Otherwise, we obtain a write gaurd to the Option<FileDescriptor> object
         let checkedfd = self.get_filedescriptor(fd).unwrap();
         let mut unlocked_fd = checkedfd.write();
+        //Pattern match such that FileDescriptor object must be the Socket variant
+        //Otherwise, return with an err as the fd refers to something other than a socket
         if let Some(filedesc_enum) = &mut *unlocked_fd {
             match filedesc_enum {
                 Socket(ref mut sockfdobj) => {
+                    //We would like to pass the socket handle data to the function
+                    //without giving it ownership sockfdobj, which may be in use
+                    //by other threads accessing other fields
                     let sock_tmp = sockfdobj.handle.clone();
                     let mut sockhandle = sock_tmp.write();
+                    //Possible address families are Unix, V4, V6
+                    //Error occurs if remoteaddr's address family does not match
+                    //the domain of the socket pointed to by fd
                     if remoteaddr.get_family() != sockhandle.domain as u16 {
                         return syscall_error(
                             Errno::EINVAL,
@@ -739,6 +845,7 @@ impl Cage {
                         );
                     }
 
+                    // ** Why do we not use sock_tmp as the arugment instead of sockfdobj, since sock_tmp is the clone?? ** //
                     match sockhandle.protocol {
                         IPPROTO_UDP => {
                             return self.connect_udp(&mut *sockhandle, sockfdobj, remoteaddr)
@@ -768,6 +875,18 @@ impl Cage {
         }
     }
 
+    //User datagram protocol is a standardized communication protocol that transfers data 
+    //between computers in a network. However, unlike other protocols such as TCP, UDP 
+    //simplifies data transfer by sending packets (or, more specifically, datagrams) 
+    //directly to the receiver without first establishing a two-way connection.
+    //Read more at https://spiceworks.com/tech/networking/articles/user-datagram-protocol-udp/
+    //
+    //The function sets up a connection on a UDP socket
+    //Args: sockhandle is a mut reference to the SocketHandle of the local socket
+    //      sockfdobj is a mut reference to the Socket Description of the local socket
+    //      remoteaddr is a reference to the remote address that the local socket will connect to 
+    //On success, zero is returned. On error, -errno is returned, and
+    //errno is set to indicate the error.
     fn connect_udp(
         &self,
         sockhandle: &mut SocketHandle,
@@ -778,8 +897,16 @@ impl Cage {
         //we don't need to check connection state for UDP, it's connectionless!
         sockhandle.remoteaddr = Some(remoteaddr.clone());
         match sockhandle.localaddr {
+            //If the socket is assigned a local address, then return with success
             Some(_) => return 0,
+            //Otherwise, assign a local address to the socket
             None => {
+                //Note, assign_new_addr expects a reference to SocketHandle, but sockhandle is a mut reference.
+                //This is why we need to dereference and reference the sockhandle pointer
+                //An error occurs if the sockhandle domain is not AF_UNIX, AF_INET, AF_INET6
+                //
+                // ** The function assign_new_addr calls the new address a remote addr 
+                // but here we are assigning it to localaddr. The variable names are a bit confusing **/
                 let localaddr = match Self::assign_new_addr(
                     &*sockhandle,
                     sockhandle.domain,
@@ -789,21 +916,39 @@ impl Cage {
                     Err(e) => return e,
                 };
 
+                //Set up the connection with the local address
                 let bindret = self.bind_inner_socket(&mut *sockhandle, &localaddr, true);
                 // udp now connected so lets set rawfd for select
+                // ** What does it mean to set rawfd for select in the comment above?? ** //
                 sockfdobj.rawfd = sockhandle.innersocket.as_ref().unwrap().raw_sys_fd;
                 return bindret;
             }
         };
     }
 
+    //Transmission Control Protocol (TCP) is a standard protocol on the internet 
+    //that ensures the reliable transmission of data between devices on a network.
+    //Read more at https://www.techtarget.com/searchnetworking/definition/TCP
+    //
+    //The function sets up a connection on a TCP socket
+    //Args: sockhandle is a mut reference to the SocketHandle of the local socket
+    //      sockfdobj is a mut reference to the Socket Description of the local socket
+    //      remoteaddr is a reference to the remote address that the local socket will connect to 
+    //On success, zero is returned. On error, -errno is returned, and
+    //errno is set to indicate the error.
     fn connect_tcp(
         &self,
         sockhandle: &mut SocketHandle,
         sockfdobj: &mut SocketDesc,
         remoteaddr: &interface::GenSockaddr,
     ) -> i32 {
-        // TCP connection logic
+        //If socket is already connected, we can not reconnect with the same socket
+        // ** According to man pages, it may be possible dissolve the
+        // association by connecting to an address with the sa_family member
+        // of sockaddr set to AF_UNSPEC; thereafter, the socket can be
+        // connected to another address. 
+        //
+        // It doesnt seem like we have this implemented ** //
         if sockhandle.state != ConnState::NOTCONNECTED {
             return syscall_error(
                 Errno::EISCONN,
@@ -812,6 +957,8 @@ impl Cage {
             );
         }
 
+        //In the case that the domain is AF_UNIX, AF_INET, or AF_INET6, perform a connection
+        //Otherwise, return with an error due to the domain being unsupported in lind
         match sockhandle.domain {
             AF_UNIX => self.connect_tcp_unix(&mut *sockhandle, sockfdobj, remoteaddr),
             AF_INET | AF_INET6 => self.connect_tcp_inet(&mut *sockhandle, sockfdobj, remoteaddr),
@@ -819,6 +966,12 @@ impl Cage {
         }
     }
 
+    //The function sets up a connection on a TCP socket with a unix address family
+    //Args: sockhandle is a mut reference to the SocketHandle of the local socket
+    //      sockfdobj is a mut reference to the Socket Description of the local socket
+    //      remoteaddr is a reference to the remote address that the local socket will connect to 
+    //On success, zero is returned. On error, -errno is returned, and
+    //errno is set to indicate the error.
     fn connect_tcp_unix(
         &self,
         sockhandle: &mut SocketHandle,
@@ -826,14 +979,19 @@ impl Cage {
         remoteaddr: &interface::GenSockaddr,
     ) -> i32 {
         // TCP domain socket logic
+        //Check if the local address of the socket handle is not set
         if let None = sockhandle.localaddr {
+            //Assign a new local address for the Unix domain socket in sockhandle. This is necessary as
+            //each Unix domain socket needs a unique address (path) to distinguish it from other sockets.
             let localaddr = Self::assign_new_addr_unix(&sockhandle);
             self.bind_inner_socket(&mut *sockhandle, &localaddr, false);
         }
+        //Normalize the remote address to a path buffer
         let remotepathbuf = normpath(convpath(remoteaddr.path()), self);
 
-        // try to get and hold reference to the key-value pair, so other process can't
-        // alter it
+        //NET_METADATA.domsock_paths is the set of all currently bound domain sockets
+        //try to get and hold reference to the key-value pair, so other process can't alter it
+        // ** How does the line below hold a reference to the key so other processes can't alter it ? ** //
         let path_ref = NET_METADATA.domsock_paths.get(&remotepathbuf);
         // if the entry doesn't exist, return an error.
         if path_ref.is_none() {
@@ -842,36 +1000,51 @@ impl Cage {
 
         let (pipe1, pipe2) = create_unix_sockpipes();
 
+        //Setup the socket handle with the remote address
         sockhandle.remoteaddr = Some(remoteaddr.clone());
         sockhandle.unix_info.as_mut().unwrap().sendpipe = Some(pipe1.clone());
         sockhandle.unix_info.as_mut().unwrap().receivepipe = Some(pipe2.clone());
 
+        //Check if the socket is set to blocking mode
+        //connvar is necessary to synchronize connect and accept
+        //as we are performing it in the user space
         let connvar = if sockfdobj.flags & O_NONBLOCK == 0 {
             Some(interface::RustRfc::new(ConnCondVar::new()))
         } else {
             None
         };
 
-        // receive_pipe and send_pipe need to be swapped here
-        // because the receive_pipe and send_pipe are opposites between the
-        // sender and receiver. Swapping here also means we do not need to swap in
-        // accept.
+        //receive_pipe and send_pipe need to be swapped here because the receive_pipe 
+        //and send_pipe are opposites between the sender and receiver. 
+        //Swapping here also means we do not need to swap in accept.
         let entry = DomsockTableEntry {
             sockaddr: sockhandle.localaddr.unwrap().clone(),
             receive_pipe: Some(pipe1.clone()).unwrap(),
             send_pipe: Some(pipe2.clone()).unwrap(),
             cond_var: connvar.clone(),
         };
+        //Access the domsock_accept_table, which keeps track of socket paths and 
+        //details pertaining to them: the socket address, receive and send pipes, and cond_var
         NET_METADATA
             .domsock_accept_table
             .insert(remotepathbuf, entry);
+        //Update the sock handle state to indicate that it is connected
         sockhandle.state = ConnState::CONNECTED;
+        //If the socket is set to blocking mode, wait until a thread
+        //accepts the connection
         if sockfdobj.flags & O_NONBLOCK == 0 {
             connvar.unwrap().wait();
         }
-        return 0;
+        //return 0 to indicate success in the connection
+        return 0; //** Would a Rustacean use the key word return or simply put 0 ??? **/
     }
 
+    //The function sets up a connection on a TCP socket with an inet address family
+    //Args: sockhandle is a mut reference to the SocketHandle of the local socket
+    //      sockfdobj is a mut reference to the Socket Description of the local socket
+    //      remoteaddr is a reference to the remote address that the local socket will connect to 
+    //On success, zero is returned. On error, -errno is returned, and
+    //errno is set to indicate the error.
     fn connect_tcp_inet(
         &self,
         sockhandle: &mut SocketHandle,
@@ -882,6 +1055,8 @@ impl Cage {
         //for TCP, actually create the internal socket object and connect it
         let remoteclone = remoteaddr.clone();
 
+        //In the case that the socket is connected, return with error
+        //as we do not want a new connection
         if sockhandle.state != ConnState::NOTCONNECTED {
             return syscall_error(
                 Errno::EISCONN,
@@ -890,9 +1065,14 @@ impl Cage {
             );
         }
 
+        //In the case that the socket is not connected
         if let None = sockhandle.localaddr {
+            //Set the socket fd in the socket handle
             Self::force_innersocket(sockhandle);
 
+            //Return a new address based on the domain of the socket handle
+            //This won't return a clone of the local address as the socket handle
+            //does not contain a local address based on the check above
             let localaddr = match Self::assign_new_addr(
                 &*sockhandle,
                 sockhandle.domain,
@@ -901,6 +1081,11 @@ impl Cage {
                 Ok(a) => a,
                 Err(e) => return e,
             };
+
+            //Performs libc bind call to assign the local address to the fd in 
+            //Socket within innersocket
+            //Any errors are a result of the libc bind call
+            //Here are the list of possible errors https://man7.org/linux/man-pages/man2/bind.2.html
             let bindret = sockhandle.innersocket.as_ref().unwrap().bind(&localaddr);
             if bindret < 0 {
                 sockhandle.localaddr = Some(localaddr);
@@ -920,6 +1105,9 @@ impl Cage {
         }
 
         let mut inprogress = false;
+        //Performs libc connect call to connect the socket referred to by the raw_sys_fd
+        //in Socket to the address specified by remoteclone
+        //Here are the list of possible errors https://www.man7.org/linux/man-pages/man2/connect.2.html 
         let connectret = sockhandle
             .innersocket
             .as_ref()
@@ -927,6 +1115,11 @@ impl Cage {
             .connect(&remoteclone);
         if connectret < 0 {
             match Errno::from_discriminant(interface::get_errno()) {
+                //EINPROGRESS signifies that the socket is non-blocking and 
+                //the connection could not be established immediately. 
+                //https://www.gnu.org/software/libc/manual/html_node/Connecting.html
+                // ** Another connect call on the same socket, before the connection is completely established, 
+                //will fail with EALREADY. This doesn't seem to be implemented specifically **
                 Ok(i) => {
                     if i == Errno::EINPROGRESS {
                         inprogress = true;
@@ -938,10 +1131,15 @@ impl Cage {
             };
         }
 
+        //Setup the socket handle as connected, insert the remote address of the connection,
+        //and reset the errno in case it is set to EINPROGRESS
         sockhandle.state = ConnState::CONNECTED;
         sockhandle.remoteaddr = Some(remoteaddr.clone());
         sockhandle.errno = 0;
         // set the rawfd for select
+        // ** What does the above comment mean ?? ** //
+        //The raw fd of the socket is the set to be the same as the fd set by the kernal in the libc connect call
+        // ** Will this ever cause issues of indexing into an fd that is already set by lind ?? ** //
         sockfdobj.rawfd = sockhandle.innersocket.as_ref().unwrap().raw_sys_fd;
         if inprogress {
             sockhandle.state = ConnState::INPROGRESS;

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -403,9 +403,6 @@ impl Cage {
     /// * ENOMEM - Insufficient kernel memory was available.
     /// * ENOTDIR - A component of the path prefix is not a directory.
     /// * EROFS - The socket inode would reside on a read-only filesystem.
-    //
-    // ** Should this comment be left ??:
-    //    we assume we've converted into a RustSockAddr in the dispatcher
     pub fn bind_syscall(&self, fd: i32, localaddr: &interface::GenSockaddr) -> i32 {
         self.bind_inner(fd, localaddr, false)
     }
@@ -691,11 +688,6 @@ impl Cage {
     //Return a new address based on the domain of the socket handle
     //If a socket handle contains a local address, return a clone of the local
     // address
-
-    //** I've seen checks previously that make sure the input domain matches the
-    //** domain
-    // of the sockhandle. Possibly consider adding it in the function at the
-    // beginning? **/
     fn assign_new_addr(
         sockhandle: &SocketHandle,
         domain: i32,

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -314,7 +314,7 @@ impl Cage {
     pub fn force_innersocket(sockhandle: &mut SocketHandle) {
         //The innersocket is an Option wrapped around the raw sys fd
         //Depending on domain, innersocket may or may not be necessary
-        //Ex: Unix sockets do not have a kernal fd
+        //Ex: Unix sockets do not have a kernel fd
         //If innersocket is not available, then create a socket and insert its
         //fd into innersocket
         if let None = sockhandle.innersocket {
@@ -974,7 +974,7 @@ impl Cage {
                 // syscall from libc, which takes the rawfd as the argument instead of
                 // the fake fd used by lind.
                 // The raw fd of the socket is the set to be the same as the fd set by the
-                // kernal in the libc connect call
+                // kernel in the libc connect call
                 sockfdobj.rawfd = sockhandle.innersocket.as_ref().unwrap().raw_sys_fd;
                 return bindret;
             }
@@ -1203,7 +1203,7 @@ impl Cage {
         // syscall from libc, which takes the rawfd as the argument instead of
         // the fake fd used by lind.
         // The raw fd of the socket is the set to be the same as the fd set by the
-        // kernal in the libc connect call
+        // kernel in the libc connect call
         sockfdobj.rawfd = sockhandle.innersocket.as_ref().unwrap().raw_sys_fd;
         if inprogress {
             sockhandle.state = ConnState::INPROGRESS;

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -155,51 +155,57 @@ impl Cage {
     /// ## `socket_syscall`
     ///
     /// ### Description
-    /// This function creates a new socket, ensuring the requested domain, socket type, 
-    /// and protocol are supported by SafePosix. 
-    /// It validates the requested communication domain, socket type, and protocol, permitting only combinations that are known 
-    /// to be safe and secure.
+    /// This function creates a new socket, ensuring the requested domain,
+    /// socket type, and protocol are supported by SafePosix.
+    /// It validates the requested communication domain, socket type, and
+    /// protocol, permitting only combinations that are known to be safe and
+    /// secure.
     ///
     /// ### Function Arguments
-    /// * `domain`: The communication domain for the socket. Supported values are 
-    ///   `PF_INET` (Internet Protocol) and `PF_UNIX` (Unix domain sockets).
-    /// * `socktype`: The socket type. Supported values are `SOCK_STREAM` (stream sockets) and `SOCK_DGRAM` (datagram sockets).
-    /// * `protocol`: The protocol to use for communication. This defaults to TCP for stream sockets 
-    ///   (`SOCK_STREAM`) and UDP for datagram sockets (`SOCK_DGRAM`).
+    /// * `domain`: The communication domain for the socket. Supported values
+    ///   are `PF_INET` (Internet Protocol) and `PF_UNIX` (Unix domain sockets).
+    /// * `socktype`: The socket type. Supported values are `SOCK_STREAM`
+    ///   (stream sockets) and `SOCK_DGRAM` (datagram sockets).
+    /// * `protocol`: The protocol to use for communication. This defaults to
+    ///   TCP for stream sockets (`SOCK_STREAM`) and UDP for datagram sockets
+    ///   (`SOCK_DGRAM`).
     ///
     /// ### Returns
     /// * The new file descriptor representing the socket on success.
     ///
     /// ### Errors
-    /// * `EOPNOTSUPP(95)`: If an unsupported combination of domain, socket type, or protocol is requested.
+    /// * `EOPNOTSUPP(95)`: If an unsupported combination of domain, socket
+    ///   type, or protocol is requested.
     /// * `EINVAL(22)`: If an invalid combination of flags is provided.
     /// ### Panics
     /// There are no panics in this syscall.
     pub fn socket_syscall(&self, domain: i32, socktype: i32, protocol: i32) -> i32 {
         let real_socktype = socktype & 0x7; //get the type without the extra flags, it's stored in the last 3 bits
         let nonblocking = (socktype & SOCK_NONBLOCK) != 0; // Checks if the socket should be non-blocking.
-        //Check blocking status for storage in the file descriptor, we'll need this for calls that don't access the kernel 
-        //socket, unix sockets, and properly directing kernel calls for recv and accept
+                                                           //Check blocking status for storage in the file descriptor, we'll need this for
+                                                           // calls that don't access the kernel
+                                                           // socket, unix sockets, and properly directing kernel calls for recv and accept
         let cloexec = (socktype & SOCK_CLOEXEC) != 0;
-        // Checks if the 'close-on-exec' flag is set. This flag ensures the socket is automatically closed if the current
-        // process executes another program, preventing unintended inheritance of the socket by the new program.
-       
+        // Checks if the 'close-on-exec' flag is set. This flag ensures the socket is
+        // automatically closed if the current process executes another program,
+        // preventing unintended inheritance of the socket by the new program.
+
         // additional flags are not supported
         // filtering out any socktypes with unexpected flags set.
-        // This is important as we dont want to pass down any flags that are not supported by SafePOSIX.
-        // which may potentially cause issues with the underlying libc call. or the socket creation process.
-        // leading to unexpected behavior.
+        // This is important as we dont want to pass down any flags that are not
+        // supported by SafePOSIX. which may potentially cause issues with the
+        // underlying libc call. or the socket creation process. leading to
+        // unexpected behavior.
         if socktype & !(SOCK_NONBLOCK | SOCK_CLOEXEC | 0x7) != 0 {
-            return syscall_error(
-                Errno::EOPNOTSUPP,
-                "socket",
-                "Invalid combination of flags"
-            );
+            return syscall_error(Errno::EOPNOTSUPP, "socket", "Invalid combination of flags");
         }
-        //SafePOSIX intentionally supports only a restricted subset of socket types . This is to make sure that 
-        // applications not creating other socket types which may lead to security issues. 
-        //By using the match statement, SafePOSIX ensures that only these approved socket types are allowed.
-        match real_socktype {// Handles different socket types SOCK_STREAM or SOCK_DGRAM in this cases
+        //SafePOSIX intentionally supports only a restricted subset of socket types .
+        // This is to make sure that applications not creating other socket
+        // types which may lead to security issues. By using the match
+        // statement, SafePOSIX ensures that only these approved socket types are
+        // allowed.
+        match real_socktype {
+            // Handles different socket types SOCK_STREAM or SOCK_DGRAM in this cases
             SOCK_STREAM => {
                 //SOCK_STREAM defaults to TCP for protocol, otherwise protocol is unsupported
                 let newprotocol = if protocol == 0 { IPPROTO_TCP } else { protocol };
@@ -211,8 +217,10 @@ impl Cage {
                         "The only SOCK_STREAM implemented is TCP. Unknown protocol input.",
                     );
                 }
-                match domain {// Handles different communication domains in this case PF_INET/PF_UNIX 
-                    PF_INET | PF_INET6 | PF_UNIX => {// Internet Protocol (PF_INET) and Unix Domain Sockets (PF_UNIX)
+                match domain {
+                    // Handles different communication domains in this case PF_INET/PF_UNIX
+                    PF_INET | PF_INET6 | PF_UNIX => {
+                        // Internet Protocol (PF_INET) and Unix Domain Sockets (PF_UNIX)
                         //PR_INET / AF_INET and PF_UNIX / AF_UNIX are the same
                         //https://man7.org/linux/man-pages/man2/socket.2.html
                         let sockfdobj = self._socket_initializer(
@@ -223,18 +231,22 @@ impl Cage {
                             cloexec,
                             ConnState::NOTCONNECTED,
                         );
-                        // Creates a SafePOSIX socket descriptor using '_socket_initializer', a helper function 
-                        // that encapsulates the internal details of socket creation and initialization.
+                        // Creates a SafePOSIX socket descriptor using '_socket_initializer', a
+                        // helper function that encapsulates the internal
+                        // details of socket creation and initialization.
                         return self._socket_inserter(Socket(sockfdobj));
-                        // Inserts the newly created socket descriptor into the cage's file descriptor table,
-                        // making it accessible to the application.Returns the file descriptor representing the socket.
+                        // Inserts the newly created socket descriptor into the
+                        // cage's file descriptor table,
+                        // making it accessible to the application.Returns the
+                        // file descriptor representing the socket.
                     }
                     _ => {
                         return syscall_error(
                             Errno::EOPNOTSUPP,
                             "socket",
                             "trying to use an unimplemented domain",
-                        );// Returns an error if an unsupported domain is requested.
+                        ); // Returns an error if an unsupported domain is
+                           // requested.
                     }
                 }
             }
@@ -250,12 +262,16 @@ impl Cage {
                         "The only SOCK_DGRAM implemented is UDP. Unknown protocol input.",
                     );
                 }
-                // SafePOSIX intentionally supports only a restricted subset of socket types . This is to make sure
-                // that applications not creating other socket types which may lead to security issues. 
-                //By using the match statement,  SafePOSIX ensures that only these approved socket types are allowed.
-                match domain {// Handles different communication domains in this case PF_INET/PF_UNIX 
-                    PF_INET | PF_INET6 | PF_UNIX => {// Internet Protocol (PF_INET) and Unix Domain Sockets (PF_UNIX)
-                        //PR_INET / AF_INET and PF_UNIX / AF_UNIX are the same 
+                // SafePOSIX intentionally supports only a restricted subset of socket types .
+                // This is to make sure that applications not creating other
+                // socket types which may lead to security issues. By using the
+                // match statement,  SafePOSIX ensures that only these approved socket types are
+                // allowed.
+                match domain {
+                    // Handles different communication domains in this case PF_INET/PF_UNIX
+                    PF_INET | PF_INET6 | PF_UNIX => {
+                        // Internet Protocol (PF_INET) and Unix Domain Sockets (PF_UNIX)
+                        //PR_INET / AF_INET and PF_UNIX / AF_UNIX are the same
                         //https://man7.org/linux/man-pages/man2/socket.2.html
                         let sockfdobj = self._socket_initializer(
                             domain,
@@ -265,11 +281,14 @@ impl Cage {
                             cloexec,
                             ConnState::NOTCONNECTED,
                         );
-                        // Creates a SafePOSIX socket descriptor using '_socket_initializer', a helper 
-                        // function that encapsulates the internal details of socket creation and initialization.
+                        // Creates a SafePOSIX socket descriptor using '_socket_initializer', a
+                        // helper function that encapsulates the internal
+                        // details of socket creation and initialization.
                         return self._socket_inserter(Socket(sockfdobj));
-                        // Inserts the newly created socket descriptor into the cage's file descriptor table,making it accessible to the application. 
-                        // Returns the file descriptor (an integer) representing the socket.
+                        // Inserts the newly created socket descriptor into the
+                        // cage's file descriptor table,making it accessible to
+                        // the application. Returns the
+                        // file descriptor (an integer) representing the socket.
                     }
                     _ => {
                         return syscall_error(
@@ -286,7 +305,7 @@ impl Cage {
                     Errno::EOPNOTSUPP,
                     "socket",
                     "trying to use an unimplemented socket type",
-                );// Returns an error if an unsupported domain is requested.
+                ); // Returns an error if an unsupported domain is requested.
             }
         }
     }
@@ -385,7 +404,7 @@ impl Cage {
     /// * ENOTDIR - A component of the path prefix is not a directory.
     /// * EROFS - The socket inode would reside on a read-only filesystem.
     //
-    // ** Should this comment be left ??: 
+    // ** Should this comment be left ??:
     //    we assume we've converted into a RustSockAddr in the dispatcher
     pub fn bind_syscall(&self, fd: i32, localaddr: &interface::GenSockaddr) -> i32 {
         self.bind_inner(fd, localaddr, false)
@@ -641,21 +660,26 @@ impl Cage {
             syscall_error(Errno::EBADF, "bind", "invalid file descriptor")
         }
     }
-    
+
     //Assign address in unix domain
+    //This helped function is used when we know we are working with unix sockets
+    //so we can return the address without possibilites of errors
+    //that come from INET sockets
     fn assign_new_addr_unix(sockhandle: &SocketHandle) -> interface::GenSockaddr {
-        //If the socket handle has a local address set, return a clone of the addr. 
-        //This is because we do not want to assign a new address to a socket that is already assigned one
+        //If the socket handle has a local address set, return a clone of the addr.
+        //This is because we do not want to assign a new address to a socket that is
+        // already assigned one
         if let Some(addr) = sockhandle.localaddr.clone() {
             addr
         } else {
             //path will be in the format of /sockID, where ID is of type
-            //usize before being converted toa string type
+            //usize before being converted to a string type
             //The UD_ID_COUNTER begins counting at 0
             let path = interface::gen_ud_path();
-            //Unix domains paths can't exceed 108 bytes. If this happens, process will panic
-            //Set the newremote address based on the Unix domain and the path
-            //Note, Unix domain socket addresses expect a null-terminated string or zero-padded path
+            //Unix domains paths can't exceed 108 bytes. If this happens, process will
+            // panic Set the newremote address based on the Unix domain and the
+            // path Note, Unix domain socket addresses expect a null-terminated
+            // string or zero-padded path
             let newremote = interface::GenSockaddr::Unix(interface::new_sockaddr_unix(
                 AF_UNIX as u16,
                 path.as_bytes(),
@@ -665,17 +689,28 @@ impl Cage {
     }
 
     //Return a new address based on the domain of the socket handle
-    //If a socket handle contains a local address, return a clone of the local address
+    //If a socket handle contains a local address, return a clone of the local
+    // address
 
-    //** I've seen checks previously that make sure the input domain matches the domain
-    // of the sockhandle. Possibly consider adding it in the function at the beginning? **/
+    //** I've seen checks previously that make sure the input domain matches the
+    //** domain
+    // of the sockhandle. Possibly consider adding it in the function at the
+    // beginning? **/
     fn assign_new_addr(
         sockhandle: &SocketHandle,
         domain: i32,
         rebindability: bool,
     ) -> Result<interface::GenSockaddr, i32> {
+        //The input domain must match the domain of the socket handle
+        if domain != sockhandle.domain as i32 {
+            return Err(syscall_error(
+                Errno::EINVAL,
+                "assign_new_addr",
+                "An address with an invalid family for the given domain was specified",
+            ));
+        }
         //If the socket handle has a local address set, return a Result
-        //type containing a clone of the addr. This is because we do not 
+        //type containing a clone of the addr. This is because we do not
         //want to assign a new address to a socket that already contains one
         if let Some(addr) = &sockhandle.localaddr {
             Ok(addr.clone())
@@ -689,9 +724,10 @@ impl Cage {
                     //usize before being converted toa string type
                     //The UD_ID_COUNTER begins counting at 0
                     let path = interface::gen_ud_path();
-                    //Unix domains paths can't exceed 108 bytes. If this happens, process will panic
-                    //Set the newremote address based on the Unix domain and the path
-                    //Note, Unix domain socket addresses expect a null-terminated string or zero-padded path
+                    //Unix domains paths can't exceed 108 bytes. If this happens, process will
+                    // panic Set the newremote address based on the Unix domain
+                    // and the path Note, Unix domain socket addresses expect a
+                    // null-terminated string or zero-padded path
                     newremote = interface::GenSockaddr::Unix(interface::new_sockaddr_unix(
                         AF_UNIX as u16,
                         path.as_bytes(),
@@ -699,7 +735,7 @@ impl Cage {
                 }
                 AF_INET => {
                     //Initialize and assign values to the remote address for a connection
-                    //if a process binds to 0.0.0.0, all incoming connection to 
+                    //if a process binds to 0.0.0.0, all incoming connection to
                     //this machine are forwarded to this process
                     newremote = interface::GenSockaddr::V4(interface::SockaddrV4::default());
                     let addr = interface::GenIpaddr::V4(interface::V4Addr::default());
@@ -708,7 +744,7 @@ impl Cage {
                     //Arguments being passed in ...
                     //port is set to 0 to use any available port
                     //Possible protocols are IPPROTO_UDP and IPPROTO_TCP
-                    //Will panic for unknown protocols 
+                    //Will panic for unknown protocols
                     newremote.set_port(
                         match NET_METADATA._reserve_localport(
                             addr.clone(),
@@ -724,7 +760,7 @@ impl Cage {
                 }
                 AF_INET6 => {
                     //Initialize and assign values to the remote address for a connection
-                    //if a process binds to [0; 16] all incoming connection to 
+                    //if a process binds to [0; 16] all incoming connection to
                     //this machine are forwarded to this process
                     newremote = interface::GenSockaddr::V6(interface::SockaddrV6::default());
                     let addr = interface::GenIpaddr::V6(interface::V6Addr::default());
@@ -733,7 +769,7 @@ impl Cage {
                     //Arguments being passed in ...
                     //port is set to 0 to use any available port
                     //Possible protocols are IPPROTO_UDP and IPPROTO_TCP
-                    //Will panic for unknown protocols 
+                    //Will panic for unknown protocols
                     newremote.set_port(
                         match NET_METADATA._reserve_localport(
                             addr.clone(),
@@ -760,74 +796,98 @@ impl Cage {
     }
 
     /// ### Description
-    /// 
+    ///
     /// `connect_syscall` connects the socket referred to by the
-    /// file descriptor fd to the address specified by remoteaddr. 
-    /// 
+    /// file descriptor fd to the address specified by remoteaddr.
+    ///
     /// ### Arguments
-    /// 
-    /// it accepts two parameters: 
+    ///
+    /// it accepts two parameters:
     /// * `fd` - an open file descriptor
     /// * `remoteaddr` - the address to request a connection to
-    /// 
+    ///
     /// ### Returns
-    /// 
+    ///
     /// for a successful call, zero is returned. On
     /// error, -errno is returned, and errno is set to indicate the error.
-    /// 
-    /// ### Errors
-    /// 
-    /// * EADDRNOTAVAIL - The specified address is not available from the local machine.
-    /// * EAFNOSUPPORT - The specified address is not a valid address for the address family of the specified socket.
-    /// * EALREADY - A connection request is already in progress for the specified socket.
-    /// * EBADF - The socket argument is not a valid file descriptor.
-    /// * ECONNREFUSED - The target address was not listening for connections or refused the connection request.
-    /// * EINPROGRESS - O_NONBLOCK is set for the file descriptor for the socket and the connection cannot be immediately established; the connection shall be established asynchronously.
-    /// * EINTR - The attempt to establish a connection was interrupted by delivery of a signal that was caught; the connection shall be established asynchronously.
-    /// * EISCONN - The specified socket is connection-mode and is already connected.
-    /// * ENETUNREACH - No route to the network is present.
-    /// * ENOTSOCK - The socket argument does not refer to a socket.
-    /// * EPROTOTYPE - The specified address has a different type than the socket bound to the specified peer address.
-    /// * ETIMEDOUT - The attempt to connect timed out before a connection was made.
-    /// 
-    /// If the address family of the socket is AF_UNIX, then connect() shall fail if:
     ///
-    /// * EIO - An I/O error occurred while reading from or writing to the file system.
-    /// * ELOOP - A loop exists in symbolic links encountered during resolution of the pathname in address.
-    /// * ENAMETOOLONG - A component of a pathname exceeded {NAME_MAX} characters, or an entire pathname exceeded {PATH_MAX} characters.
-    /// * ENOENT - A component of the pathname does not name an existing file or the pathname is an empty string.
-    /// * ENOTDIR - A component of the path prefix of the pathname in address is not a directory.
+    /// ### Errors
+    ///
+    /// * EADDRNOTAVAIL - The specified address is not available from the local
+    ///   machine.
+    /// * EAFNOSUPPORT - The specified address is not a valid address for the
+    ///   address family of the specified socket.
+    /// * EALREADY - A connection request is already in progress for the
+    ///   specified socket.
+    /// ** EBADF - The socket argument is not a valid file descriptor.
+    /// * ECONNREFUSED - The target address was not listening for connections or
+    ///   refused the connection request.
+    /// ** EINPROGRESS - O_NONBLOCK is set for the file descriptor for the
+    ///    socket and the connection cannot be immediately established; the
+    ///    connection shall be established asynchronously.
+    /// * EINTR - The attempt to establish a connection was interrupted by
+    ///   delivery of a signal that was caught; the connection shall be
+    ///   established asynchronously.
+    /// ** EISCONN - The specified socket is connection-mode and is already
+    ///    connected.
+    /// * ENETUNREACH - No route to the network is present.
+    /// ** ENOTSOCK - The socket argument does not refer to a socket.
+    /// * EPROTOTYPE - The specified address has a different type than the
+    ///   socket bound to the specified peer address.
+    /// * ETIMEDOUT - The attempt to connect timed out before a connection was
+    ///   made.
+    ///
+    /// If the address family of the socket is AF_UNIX, then connect() shall
+    /// fail if:
+    ///
+    /// * EIO - An I/O error occurred while reading from or writing to the file
+    ///   system.
+    /// * ELOOP - A loop exists in symbolic links encountered during resolution
+    ///   of the pathname in address.
+    /// * ENAMETOOLONG - A component of a pathname exceeded {NAME_MAX}
+    ///   characters, or an entire pathname exceeded {PATH_MAX} characters.
+    /// ** ENOENT - A component of the pathname does not name an existing file
+    ///    or the pathname is an empty string.
+    /// * ENOTDIR - A component of the path prefix of the pathname in address is
+    ///   not a directory.
     ///
     /// The connect() function may fail if:
-    /// 
-    /// * EACCES - Search permission is denied for a component of the path prefix; or write access to the named socket is denied.
-    /// * EADDRINUSE - Attempt to establish a connection that uses addresses that are already in use.
+    ///
+    /// * EACCES - Search permission is denied for a component of the path
+    ///   prefix; or write access to the named socket is denied.
+    /// * EADDRINUSE - Attempt to establish a connection that uses addresses
+    ///   that are already in use.
     /// * ECONNRESET - Remote host reset the connection request.
-    /// * EHOSTUNREACH - The destination host cannot be reached (probably because the host is down or a remote router cannot reach it).
-    /// * EINVAL - The address_len argument is not a valid length for the address family; or invalid address family in the sockaddr structure.
-    /// * ELOOP - More than {SYMLOOP_MAX} symbolic links were encountered during resolution of the pathname in address.
-    /// * ENAMETOOLONG - Pathname resolution of a symbolic link produced an intermediate result whose length exceeds {PATH_MAX}.
-    /// * ENETDOWN - The local network interface used to reach the destination is down.
+    /// * EHOSTUNREACH - The destination host cannot be reached (probably
+    ///   because the host is down or a remote router cannot reach it).
+    /// ** EINVAL - The address_len argument is not a valid length for the
+    ///    address family; or invalid address family in the sockaddr structure.
+    /// * ELOOP - More than {SYMLOOP_MAX} symbolic links were encountered during
+    ///   resolution of the pathname in address.
+    /// * ENAMETOOLONG - Pathname resolution of a symbolic link produced an
+    ///   intermediate result whose length exceeds {PATH_MAX}.
+    /// * ENETDOWN - The local network interface used to reach the destination
+    ///   is down.
     /// * ENOBUFS- No buffer space is available.
-    /// * EOPNOTSUPP - The socket is listening and cannot be connected.
-    /// 
+    /// ** EOPNOTSUPP - The socket is listening and cannot be connected.
+    ///
+    /// ** Indicates the error may be returned from RustPOSIX
+    ///
     /// ### Panics
-    /// 
+    ///
     /// * Unknown errno value from bind libc call, will cause panic
     /// * Unknown errno value from connect libc call, will cause panic.
-    /// 
-    /// for more detailed description of all the commands and return values, see 
+    ///
+    /// for more detailed description of all the commands and return values, see
     /// [connect(3)](https://linux.die.net/man/3/connect)
-
-    // ** I think we are missing some implementation details mentioned on the man page
-    // under the Description section ** //
     pub fn connect_syscall(&self, fd: i32, remoteaddr: &interface::GenSockaddr) -> i32 {
         //If fd is out of range of [0,MAXFD], process will panic
         //Otherwise, we obtain a write gaurd to the Option<FileDescriptor> object
         let checkedfd = self.get_filedescriptor(fd).unwrap();
         let mut unlocked_fd = checkedfd.write();
         //Pattern match such that FileDescriptor object must be the Socket variant
-        //Otherwise, return with an err as the fd refers to something other than a socket
+        //Otherwise, return with an err as the fd refers to something other than a
+        // socket
         if let Some(filedesc_enum) = &mut *unlocked_fd {
             match filedesc_enum {
                 Socket(ref mut sockfdobj) => {
@@ -876,18 +936,18 @@ impl Cage {
         }
     }
 
-    //User datagram protocol is a standardized communication protocol that transfers data 
-    //between computers in a network. However, unlike other protocols such as TCP, UDP 
-    //simplifies data transfer by sending packets (or, more specifically, datagrams) 
-    //directly to the receiver without first establishing a two-way connection.
-    //Read more at https://spiceworks.com/tech/networking/articles/user-datagram-protocol-udp/
+    //User datagram protocol is a standardized communication protocol that
+    // transfers data between computers in a network. However, unlike other
+    // protocols such as TCP, UDP simplifies data transfer by sending packets
+    // (or, more specifically, datagrams) directly to the receiver without first
+    // establishing a two-way connection. Read more at https://spiceworks.com/tech/networking/articles/user-datagram-protocol-udp/
     //
     //The function sets up a connection on a UDP socket
     //Args: sockhandle is a mut reference to the SocketHandle of the local socket
-    //      sockfdobj is a mut reference to the Socket Description of the local socket
-    //      remoteaddr is a reference to the remote address that the local socket will connect to 
-    //On success, zero is returned. On error, -errno is returned, and
-    //errno is set to indicate the error.
+    //      sockfdobj is a mut reference to the Socket Description of the local
+    // socket      remoteaddr is a reference to the remote address that the
+    // local socket will connect to On success, zero is returned. On error,
+    // -errno is returned, and errno is set to indicate the error.
     fn connect_udp(
         &self,
         sockhandle: &mut SocketHandle,
@@ -902,9 +962,10 @@ impl Cage {
             Some(_) => return 0,
             //Otherwise, assign a local address to the socket
             None => {
-                //Note, assign_new_addr expects a reference to SocketHandle, but sockhandle is a mut reference.
-                //This is why we need to dereference and reference the sockhandle pointer
-                //An error occurs if the sockhandle domain is not AF_UNIX, AF_INET, AF_INET6
+                //Note, assign_new_addr expects a reference to SocketHandle, but sockhandle is
+                // a mut reference. This is why we need to dereference and
+                // reference the sockhandle pointer An error occurs if the
+                // sockhandle domain is not AF_UNIX, AF_INET, AF_INET6
                 let localaddr = match Self::assign_new_addr(
                     &*sockhandle,
                     sockhandle.domain,
@@ -920,36 +981,37 @@ impl Cage {
                 // logics for AF_INET socket right now, so we have to call the select
                 // syscall from libc, which takes the rawfd as the argument instead of
                 // the fake fd used by lind.
-                // The raw fd of the socket is the set to be the same as the fd set by the kernal in the libc connect call
+                // The raw fd of the socket is the set to be the same as the fd set by the
+                // kernal in the libc connect call
                 sockfdobj.rawfd = sockhandle.innersocket.as_ref().unwrap().raw_sys_fd;
                 return bindret;
             }
         };
     }
 
-    //Transmission Control Protocol (TCP) is a standard protocol on the internet 
+    //Transmission Control Protocol (TCP) is a standard protocol on the internet
     //that ensures the reliable transmission of data between devices on a network.
     //Read more at https://www.techtarget.com/searchnetworking/definition/TCP
     //
     //The function sets up a connection on a TCP socket
     //Args: sockhandle is a mut reference to the SocketHandle of the local socket
-    //      sockfdobj is a mut reference to the Socket Description of the local socket
-    //      remoteaddr is a reference to the remote address that the local socket will connect to 
-    //On success, zero is returned. On error, -errno is returned, and
-    //errno is set to indicate the error.
+    //      sockfdobj is a mut reference to the Socket Description of the local
+    // socket      remoteaddr is a reference to the remote address that the
+    // local socket will connect to On success, zero is returned. On error,
+    // -errno is returned, and errno is set to indicate the error.
     fn connect_tcp(
         &self,
         sockhandle: &mut SocketHandle,
         sockfdobj: &mut SocketDesc,
         remoteaddr: &interface::GenSockaddr,
     ) -> i32 {
-        //If socket is already connected, we can not reconnect with the same socket
-        // ** According to man pages, it may be possible dissolve the
+        //BUG:
+        // According to man pages, it may be possible dissolve the
         // association by connecting to an address with the sa_family member
         // of sockaddr set to AF_UNSPEC; thereafter, the socket can be
-        // connected to another address. 
+        // connected to another address.
         //
-        // It doesnt seem like we have this implemented ** //
+        //If socket is already connected, we can not reconnect with the same socket
         if sockhandle.state != ConnState::NOTCONNECTED {
             return syscall_error(
                 Errno::EISCONN,
@@ -958,8 +1020,9 @@ impl Cage {
             );
         }
 
-        //In the case that the domain is AF_UNIX, AF_INET, or AF_INET6, perform a connection
-        //Otherwise, return with an error due to the domain being unsupported in lind
+        //In the case that the domain is AF_UNIX, AF_INET, or AF_INET6, perform a
+        // connection Otherwise, return with an error due to the domain being
+        // unsupported in lind
         match sockhandle.domain {
             AF_UNIX => self.connect_tcp_unix(&mut *sockhandle, sockfdobj, remoteaddr),
             AF_INET | AF_INET6 => self.connect_tcp_inet(&mut *sockhandle, sockfdobj, remoteaddr),
@@ -969,10 +1032,10 @@ impl Cage {
 
     //The function sets up a connection on a TCP socket with a unix address family
     //Args: sockhandle is a mut reference to the SocketHandle of the local socket
-    //      sockfdobj is a mut reference to the Socket Description of the local socket
-    //      remoteaddr is a reference to the remote address that the local socket will connect to 
-    //On success, zero is returned. On error, -errno is returned, and
-    //errno is set to indicate the error.
+    //      sockfdobj is a mut reference to the Socket Description of the local
+    // socket      remoteaddr is a reference to the remote address that the
+    // local socket will connect to On success, zero is returned. On error,
+    // -errno is returned, and errno is set to indicate the error.
     fn connect_tcp_unix(
         &self,
         sockhandle: &mut SocketHandle,
@@ -982,8 +1045,9 @@ impl Cage {
         // TCP domain socket logic
         //Check if the local address of the socket handle is not set
         if let None = sockhandle.localaddr {
-            //Assign a new local address for the Unix domain socket in sockhandle. This is necessary as
-            //each Unix domain socket needs a unique address (path) to distinguish it from other sockets.
+            //Assign a new local address for the Unix domain socket in sockhandle. This is
+            // necessary as each Unix domain socket needs a unique address
+            // (path) to distinguish it from other sockets.
             let localaddr = Self::assign_new_addr_unix(&sockhandle);
             self.bind_inner_socket(&mut *sockhandle, &localaddr, false);
         }
@@ -991,7 +1055,8 @@ impl Cage {
         let remotepathbuf = normpath(convpath(remoteaddr.path()), self);
 
         //NET_METADATA.domsock_paths is the set of all currently bound domain sockets
-        //try to get and hold reference to the key-value pair, so other process can't alter it
+        //try to get and hold reference to the key-value pair, so other process can't
+        // alter it
         let path_ref = NET_METADATA.domsock_paths.get(&remotepathbuf);
         // if the entry doesn't exist, return an error.
         if path_ref.is_none() {
@@ -1014,17 +1079,22 @@ impl Cage {
             None
         };
 
-        //receive_pipe and send_pipe need to be swapped here because the receive_pipe 
-        //and send_pipe are opposites between the sender and receiver. 
-        //Swapping here also means we do not need to swap in accept.
+        //The receive_pipe of the socket that is accepting the connection is assigned
+        // the send_pipe of the socket that is requesting the connection.
+        //Similiarly, the send_pipe of the socket that is accepting the connection is
+        // assigned the receive_pipe of the socket that is requesting the
+        // connection. Swapping the pipes here means that in accept sys call we
+        // can use the pipes as placed in the domsock_accept_table without
+        // confusion
         let entry = DomsockTableEntry {
             sockaddr: sockhandle.localaddr.unwrap().clone(),
             receive_pipe: Some(pipe1.clone()).unwrap(),
             send_pipe: Some(pipe2.clone()).unwrap(),
             cond_var: connvar.clone(),
         };
-        //Access the domsock_accept_table, which keeps track of socket paths and 
-        //details pertaining to them: the socket address, receive and send pipes, and cond_var
+        //Access the domsock_accept_table, which keeps track of socket paths and
+        //details pertaining to them: the socket address, receive and send pipes, and
+        // cond_var
         NET_METADATA
             .domsock_accept_table
             .insert(remotepathbuf, entry);
@@ -1036,16 +1106,15 @@ impl Cage {
         if sockfdobj.flags & O_NONBLOCK == 0 {
             connvar.unwrap().wait();
         }
-        //return 0 to indicate success in the connection
-        return 0; //successfull TCP connection over Unix domain
+        return 0; //successful TCP connection over Unix domain
     }
 
     //The function sets up a connection on a TCP socket with an inet address family
     //Args: sockhandle is a mut reference to the SocketHandle of the local socket
-    //      sockfdobj is a mut reference to the Socket Description of the local socket
-    //      remoteaddr is a reference to the remote address that the local socket will connect to 
-    //On success, zero is returned. On error, -errno is returned, and
-    //errno is set to indicate the error.
+    //      sockfdobj is a mut reference to the Socket Description of the local
+    // socket      remoteaddr is a reference to the remote address that the
+    // local socket will connect to On success, zero is returned. On error,
+    // -errno is returned, and errno is set to indicate the error.
     fn connect_tcp_inet(
         &self,
         sockhandle: &mut SocketHandle,
@@ -1083,7 +1152,7 @@ impl Cage {
                 Err(e) => return e,
             };
 
-            //Performs libc bind call to assign the local address to the fd in 
+            //Performs libc bind call to assign the local address to the fd in
             //Socket within innersocket
             //Any errors are a result of the libc bind call
             //Here are the list of possible errors https://man7.org/linux/man-pages/man2/bind.2.html
@@ -1106,9 +1175,9 @@ impl Cage {
         }
 
         let mut inprogress = false;
-        //Performs libc connect call to connect the socket referred to by the raw_sys_fd
-        //in Socket to the address specified by remoteclone
-        //Here are the list of possible errors https://www.man7.org/linux/man-pages/man2/connect.2.html 
+        //Performs libc connect call to connect the socket referred to by the
+        // raw_sys_fd in Socket to the address specified by remoteclone
+        //Here are the list of possible errors https://www.man7.org/linux/man-pages/man2/connect.2.html
         let connectret = sockhandle
             .innersocket
             .as_ref()
@@ -1116,11 +1185,11 @@ impl Cage {
             .connect(&remoteclone);
         if connectret < 0 {
             match Errno::from_discriminant(interface::get_errno()) {
-                //EINPROGRESS signifies that the socket is non-blocking and 
-                //the connection could not be established immediately. 
+                //EINPROGRESS signifies that the socket is non-blocking and
+                //the connection could not be established immediately.
                 //https://www.gnu.org/software/libc/manual/html_node/Connecting.html
-                // ** Another connect call on the same socket, before the connection is completely established, 
-                // will fail with EALREADY. This doesn't seem to be implemented specifically **
+                // BUG: Another connect call on the same socket, before the connection is completely
+                // established, should fail with EALREADY.
                 Ok(i) => {
                     if i == Errno::EINPROGRESS {
                         inprogress = true;
@@ -1132,16 +1201,17 @@ impl Cage {
             };
         }
 
-        //Setup the socket handle as connected, insert the remote address of the connection,
-        //and reset the errno in case it is set to EINPROGRESS
+        //Setup the socket handle as connected, insert the remote address of the
+        // connection, and reset the errno in case it is set to EINPROGRESS
         sockhandle.state = ConnState::CONNECTED;
         sockhandle.remoteaddr = Some(remoteaddr.clone());
         sockhandle.errno = 0;
-        // Set the rawfd for select_syscall as we cannot implement the select 
-        // logics for AF_INET socket right now, so we have to call the select 
-        // syscall from libc, which takes the rawfd as the argument instead of 
+        // Set the rawfd for select_syscall as we cannot implement the select
+        // logics for AF_INET socket right now, so we have to call the select
+        // syscall from libc, which takes the rawfd as the argument instead of
         // the fake fd used by lind.
-        // The raw fd of the socket is the set to be the same as the fd set by the kernal in the libc connect call
+        // The raw fd of the socket is the set to be the same as the fd set by the
+        // kernal in the libc connect call
         sockfdobj.rawfd = sockhandle.innersocket.as_ref().unwrap().raw_sys_fd;
         if inprogress {
             sockhandle.state = ConnState::INPROGRESS;

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -212,7 +212,7 @@ impl Cage {
                     );
                 }
                 match domain {// Handles different communication domains in this case PF_INET/PF_UNIX 
-                    PF_INET | PF_UNIX => {// Internet Protocol (PF_INET) and Unix Domain Sockets (PF_UNIX)
+                    PF_INET | PF_INET6 | PF_UNIX => {// Internet Protocol (PF_INET) and Unix Domain Sockets (PF_UNIX)
                         //PR_INET / AF_INET and PF_UNIX / AF_UNIX are the same
                         //https://man7.org/linux/man-pages/man2/socket.2.html
                         let sockfdobj = self._socket_initializer(
@@ -254,7 +254,7 @@ impl Cage {
                 // that applications not creating other socket types which may lead to security issues. 
                 //By using the match statement,  SafePOSIX ensures that only these approved socket types are allowed.
                 match domain {// Handles different communication domains in this case PF_INET/PF_UNIX 
-                    PF_INET | PF_UNIX => {// Internet Protocol (PF_INET) and Unix Domain Sockets (PF_UNIX)
+                    PF_INET | PF_INET6 | PF_UNIX => {// Internet Protocol (PF_INET) and Unix Domain Sockets (PF_UNIX)
                         //PR_INET / AF_INET and PF_UNIX / AF_UNIX are the same 
                         //https://man7.org/linux/man-pages/man2/socket.2.html
                         let sockfdobj = self._socket_initializer(

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -534,8 +534,9 @@ pub mod net_tests {
     }
 
     #[test]
+    #[ignore]
     //Test connect sys call using AF_INET6/IPv6 address family and UDP socket type
-    //** Currently failing ** //
+    //Currently failing as IPv6 is not implemented via gen_netdevs
     pub fn ut_lind_net_connect_basic_udp_ipv6() {
         lindrustinit(0);
         let cage = interface::cagetable_getref(1);

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -534,6 +534,41 @@ pub mod net_tests {
     }
 
     #[test]
+    //Test connect sys call using AF_INET6/IPv6 address family and UDP socket type
+    //** Currently failing ** //
+    pub fn ut_lind_net_connect_basic_udp_ipv6() {
+        lindrustinit(0);
+        let cage = interface::cagetable_getref(1);
+
+        //Initialize initial socket fd and remote socket to connect to
+        let sockfd = cage.socket_syscall(AF_INET6, SOCK_DGRAM, 0);
+        let port: u16 = generate_random_port();
+        let mut socket = interface::GenSockaddr::V6(interface::SockaddrV6 {
+            sin6_family: AF_INET6 as u16,
+            sin6_port: port.to_be(),
+            sin6_addr: interface::V6Addr {
+                s6_addr: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]},
+            sin6_flowinfo: 0,
+            sin6_scope_id: 0,
+        }); //::1 LOCALHOST
+        assert_eq!(cage.connect_syscall(sockfd, &socket), 0);
+
+        //Change the port and retarget the socket
+        let port: u16 = generate_random_port();
+        socket = interface::GenSockaddr::V6(interface::SockaddrV6 {
+            sin6_family: AF_INET6 as u16,
+            sin6_port: port.to_be(),
+            sin6_addr: interface::V6Addr {
+                s6_addr: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]},
+            sin6_flowinfo: 0,
+            sin6_scope_id: 0,
+        }); //::1 LOCALHOST
+        assert_eq!(cage.connect_syscall(sockfd, &socket), 0);
+
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+    
     pub fn ut_lind_net_getpeername() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -541,7 +541,7 @@ pub mod net_tests {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup
         let _thelock = setup::lock_and_init();
-        
+
         let cage = interface::cagetable_getref(1);
 
         //Initialize initial socket fd and remote socket to connect to
@@ -551,7 +551,8 @@ pub mod net_tests {
             sin6_family: AF_INET6 as u16,
             sin6_port: port.to_be(),
             sin6_addr: interface::V6Addr {
-                s6_addr: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]},
+                s6_addr: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+            },
             sin6_flowinfo: 0,
             sin6_scope_id: 0,
         }); //::1 LOCALHOST
@@ -563,7 +564,8 @@ pub mod net_tests {
             sin6_family: AF_INET6 as u16,
             sin6_port: port.to_be(),
             sin6_addr: interface::V6Addr {
-                s6_addr: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]},
+                s6_addr: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+            },
             sin6_flowinfo: 0,
             sin6_scope_id: 0,
         }); //::1 LOCALHOST
@@ -572,7 +574,7 @@ pub mod net_tests {
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
     }
-    
+
     pub fn ut_lind_net_getpeername() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup
@@ -1960,9 +1962,10 @@ pub mod net_tests {
 
         let cage = interface::cagetable_getref(1);
 
-        // Following checks are inplace to ensure that the socket types are correctly defined
-        // and that the assumptions about the values of the socket types are correct across platforms.
-        // Check that SOCK_STREAM only uses the lowest 3 bits
+        // Following checks are inplace to ensure that the socket types are correctly
+        // defined and that the assumptions about the values of the socket types
+        // are correct across platforms. Check that SOCK_STREAM only uses the
+        // lowest 3 bits
         assert_eq!(SOCK_STREAM & !0x7, 0);
 
         // Check that SOCK_DGRAM only uses the lowest 3 bits
@@ -1975,35 +1978,53 @@ pub mod net_tests {
         assert_eq!(SOCK_CLOEXEC & 0x7, 0);
 
         //let's check an illegal operation...
-        // RDM is not a valid socket type for SOCK_DGRAM (UDP) as its not implemented yet.
+        // RDM is not a valid socket type for SOCK_DGRAM (UDP) as its not implemented
+        // yet.
         let sockfd5 = cage.socket_syscall(AF_INET, SOCK_RDM, 0);
-        assert!(sockfd5 < 0, "Expected an error, got a valid file descriptor");
+        assert!(
+            sockfd5 < 0,
+            "Expected an error, got a valid file descriptor"
+        );
 
         //let's check an illegal operation...
         //invalid protocol for SOCK_STREAM Type.
         let sockfd6 = cage.socket_syscall(AF_INET, SOCK_STREAM, 999);
-        assert!(sockfd6 < 0, "Expected an error, got a valid file descriptor");
+        assert!(
+            sockfd6 < 0,
+            "Expected an error, got a valid file descriptor"
+        );
 
         //let's check an illegal operation...
         //invalid domain for socket
         let sockfd7 = cage.socket_syscall(999, SOCK_STREAM, 0);
-        assert!(sockfd7 < 0, "Expected an error, got a valid file descriptor");
+        assert!(
+            sockfd7 < 0,
+            "Expected an error, got a valid file descriptor"
+        );
 
         //let's check an illegal operation...
         //invalid socket type flags combination
         let sockfd8 = cage.socket_syscall(AF_INET, SOCK_STREAM | 0x100000, 0);
-        assert!(sockfd8 < 0, "Expected an error, got a valid file descriptor");
+        assert!(
+            sockfd8 < 0,
+            "Expected an error, got a valid file descriptor"
+        );
 
         //let's check an illegal operation...
         //invalid socket type protocol combination
         let sockfd9 = cage.socket_syscall(AF_INET, SOCK_STREAM, IPPROTO_UDP);
-        assert!(sockfd9 < 0, "Expected an error, got a valid file descriptor");
+        assert!(
+            sockfd9 < 0,
+            "Expected an error, got a valid file descriptor"
+        );
 
         //let's check an illegal operation...
         //invalid socket type protocol combination
         let sockfd10 = cage.socket_syscall(AF_INET, SOCK_DGRAM, IPPROTO_TCP);
-        assert!(sockfd10 < 0, "Expected an error, got a valid file descriptor");
-
+        assert!(
+            sockfd10 < 0,
+            "Expected an error, got a valid file descriptor"
+        );
 
         let mut sockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
         assert!(sockfd > 0, "Expected a valid file descriptor, got error");
@@ -2013,25 +2034,33 @@ pub mod net_tests {
 
         let sockfd3 = cage.socket_syscall(AF_INET, SOCK_DGRAM, 0);
         assert!(sockfd3 > 0, "Expected a valid file descriptor, got error");
-        
+
         let sockfd4 = cage.socket_syscall(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
         assert!(sockfd4 > 0, "Expected a valid file descriptor, got error");
-
-
-
 
         //let's check an illegal operation...
         // let sockfd7 = cage.socket_syscall(AF_INET, !0b111 | 0b001, 0);
         // assert!(sockfd7 < 0, "Expected an error, got a valid file descriptor");
 
         let sockfddomain = cage.socket_syscall(AF_UNIX, SOCK_DGRAM, 0);
-        assert!(sockfddomain > 0, "Expected a valid file descriptor, got error");
+        assert!(
+            sockfddomain > 0,
+            "Expected a valid file descriptor, got error"
+        );
 
         sockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
         assert!(sockfd > 0, "Expected a valid file descriptor, got error");
 
-        assert_eq!(cage.close_syscall(sockfd), 0, "Expected successful close, got error");
-        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS, "Expected successful exit, got error");
+        assert_eq!(
+            cage.close_syscall(sockfd),
+            0,
+            "Expected successful close, got error"
+        );
+        assert_eq!(
+            cage.exit_syscall(EXIT_SUCCESS),
+            EXIT_SUCCESS,
+            "Expected successful exit, got error"
+        );
         lindrustfinalize();
     }
 

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -538,7 +538,10 @@ pub mod net_tests {
     //Test connect sys call using AF_INET6/IPv6 address family and UDP socket type
     //Currently failing as IPv6 is not implemented via gen_netdevs
     pub fn ut_lind_net_connect_basic_udp_ipv6() {
-        lindrustinit(0);
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+        
         let cage = interface::cagetable_getref(1);
 
         //Initialize initial socket fd and remote socket to connect to


### PR DESCRIPTION
## Description

Fixes # (issue)

<!-- Please include a summary of the changes and the related issue. --> 
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

All functions related to and including connect_syscall were commented out
A single test case was added to test out a UDP connection using the AF_INET6 address family. After feedback based on the correctness of the test, I will add more tests to the PR.

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

Test A attempts to set up a UDP connection using the AF_INET6 address family. Currently, the test fails. 
To reproduce run cargo test --lib command inside the safeposix-rust directory.

- Test A - `lind_project/src/safeposix-rust/src/tests/networking_tests.rs/ut_lind_net_connect_basic_udp_ipv6()`

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
