### PR TITLE
Updates to "read_syscall" and "pread_syscall".

### DIFF
--- a/src/interface/misc.rs
+++ b/src/interface/misc.rs
@@ -204,6 +204,9 @@ pub fn sigcheck() -> bool {
 }
 
 pub fn fillrandom(bufptr: *mut u8, count: usize) -> i32 {
+    // Potential Bug: The fillrandom function is reading from the /dev/urandom
+    // file, where it should read from "/dev/random" file. And, there should be
+    // a seperate function for reading from "/dev/random" file.
     let slice = unsafe { std::slice::from_raw_parts_mut(bufptr, count) };
     let mut f = std::fs::OpenOptions::new()
         .read(true)

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1493,6 +1493,7 @@ impl Cage {
                         // For `Socket` type inode, a panic is returned as socket type files are not
                         // supported.
                         Inode::Socket(_) => {
+                            // Read is not supported for Socket type inodes.
                             panic!("read(): Socket inode found on a filedesc fd.")
                         }
 
@@ -1741,13 +1742,14 @@ impl Cage {
 
     /// ### Description
     ///
-    /// The `_read_chr_file()` helper function reads from character devices by
-    /// matching the device number (DevNo) of the DeviceInode. It handles
-    /// `/dev/null`, `/dev/zero`, `/dev/random`, and `/dev/urandom` by
-    /// performing the appropriate actions for each device. If the device is
-    /// unsupported, it returns an error indicating that the operation is
-    /// not supported. This function is used for interacting with special
-    /// character files in a Unix-like filesystem.
+    /// The `_read_chr_file()` helper function is used by `read_syscall()` and
+    /// `pread_syscall()` for reading from character device type files.
+    /// It reads from character devices by matching the device number (DevNo)
+    /// of the DeviceInode. It handles `/dev/null`, `/dev/zero`, `/dev/random`,
+    /// and `/dev/urandom` by performing the appropriate actions for each
+    /// device. If the device is unsupported, it returns an error indicating
+    /// that the operation is not supported. This function is used for
+    /// interacting with special character files in a Unix-like filesystem.
     ///
     /// ### Function Arguments
     ///

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1422,11 +1422,8 @@ impl Cage {
     /// For more detailed description of all the commands and return values, see
     /// [read(2)](https://man7.org/linux/man-pages/man2/read.2.html)
     pub fn read_syscall(&self, fd: i32, buf: *mut u8, count: usize) -> i32 {
-        // Attempt to get the file descriptor; handle error if it does not exist
-        let checkedfd = match self.get_filedescriptor(fd) {
-            Ok(fd) => fd,
-            Err(_) => return syscall_error(Errno::EBADF, "read", "Invalid file descriptor."),
-        };
+        // Attempt to get the file descriptor
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
         // Acquire a write lock on the file descriptor to ensure exclusive access.
         let mut unlocked_fd = checkedfd.write();
 
@@ -1638,11 +1635,8 @@ impl Cage {
     /// For more detailed description of all the commands and return values, see
     /// [pread(2)](https://man7.org/linux/man-pages/man2/pread.2.html)
     pub fn pread_syscall(&self, fd: i32, buf: *mut u8, count: usize, offset: isize) -> i32 {
-        // Attempt to get the file descriptor; handle error if it does not exist
-        let checkedfd = match self.get_filedescriptor(fd) {
-            Ok(fd) => fd,
-            Err(_) => return syscall_error(Errno::EBADF, "pread", "Invalid file descriptor."),
-        };
+        // Attempt to get the file descriptor
+        let checkedfd = self.get_filedescriptor(fd).unwrap();
         // Acquire a write lock on the file descriptor to ensure exclusive access.
         let mut unlocked_fd = checkedfd.write();
 

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1098,9 +1098,9 @@ impl Cage {
     /// truncating an existing one by combining the O_CREAT, O_TRUNC, and
     /// O_WRONLY flags.
     /// There are generally two cases which occur when this syscall happens:
-    /// Case 1: If the file to be opened doesn't exist, then due to O_CREAT flag,
-    /// a new file is created at the given location and a new file descriptor is
-    /// created and returned.
+    /// Case 1: If the file to be opened doesn't exist, then due to O_CREAT
+    /// flag, a new file is created at the given location and a new file
+    /// descriptor is created and returned.
     /// Case 2: If the file already exists, then due to O_TRUNC flag, the file
     /// size gets reduced to 0, and the existing file descriptor is returned.
     ///
@@ -1590,7 +1590,7 @@ impl Cage {
         }
     }
 
-    /// ## ------------------READ SYSCALL------------------
+    /// ## ------------------PREAD SYSCALL------------------
     /// ### Description
     ///
     /// The `pread_syscall()` attempts to read `count` bytes from the file
@@ -1617,9 +1617,7 @@ impl Cage {
     /// Upon successful completion of this call, we return the number of bytes
     /// read. This number will never be greater than `count`. The value returned
     /// may be less than `count` if the number of bytes left in the file is less
-    /// than `count`, if the `pread_syscall()` was interrupted by a signal, or
-    /// if the file is a pipe or FIFO or special file and has fewer than
-    /// `count` bytes immediately available for reading.
+    /// than `count`.
     ///
     /// ### Errors
     ///
@@ -1627,8 +1625,8 @@ impl Cage {
     ///   not opened for reading.
     /// * EISDIR - The file descriptor opened for reading is a directory.
     /// * EOPNOTSUPP - Reading from streams is not supported.
-    /// * EINVAL - File descriptor is attached to an object which is unsuitable
-    ///   for reading.
+    /// * ESPIPE - The file descriptor opened for reading is either of type
+    ///   Socket, Stream, Pipe, or Epoll.
     ///
     /// ### Panics
     ///

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1487,10 +1487,9 @@ impl Cage {
                             self._read_chr_file(&char_inode_obj, buf, count)
                         }
 
-                        // For `Socket` type inode, a panic is returned as socket type files are not
-                        // supported.
+                        // A Sanity check where the File type fd should not have a `Socket` type
+                        // inode and should panic.
                         Inode::Socket(_) => {
-                            // Read is not supported for Socket type inodes.
                             panic!("read(): Socket inode found on a filedesc fd.")
                         }
 
@@ -1687,8 +1686,8 @@ impl Cage {
                             // the character device and updates the buffer `buf` with them.
                             self._read_chr_file(&char_inode_obj, buf, count)
                         }
-                        // For `Socket` type inode, a panic is returned as socket type files are not
-                        // supported.
+                        // A Sanity check where the File type fd should not have a `Socket` type
+                        // inode and should panic.
                         Inode::Socket(_) => {
                             panic!("pread(): Socket inode found on a filedesc fd")
                         }

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1366,17 +1366,81 @@ impl Cage {
         0 //success!
     }
 
-    //------------------------------------READ SYSCALL------------------------------------
-
+    /// ## ------------------READ SYSCALL------------------
+    /// ### Description
+    ///
+    /// The `read_syscall()` attempts to read `count` bytes from the file
+    /// associated with the open file descriptor, `fd`, into the buffer
+    /// pointed to by `buf`. On files that support seeking (for example, a
+    /// regular file), the read operation commences at the file offset, and
+    /// the file offset is incremented by the number of bytes read. If the
+    /// file offset is at or past the end of file, no bytes are read,
+    /// and read_syscall() returns zero. If the `count` of the bytes to be read
+    /// is 0, the read_syscall() returns 0. No data transfer will occur past
+    /// the current end-of-file. If the starting position is at or after the
+    /// end-of-file, 0 will be returned The reading mechanism is different
+    /// for each type of file descriptor, which is discussed in the
+    /// implementation.
+    ///
+    /// ### Function Arguments
+    ///
+    /// The `read_syscall()` receives three arguments:
+    /// * `fd` - This argument refers to the file descriptor from which the data
+    ///   is to be read.
+    /// * `buf` - This argument refers to the mutable buffer into which the file
+    ///   data is to be stored and then returned back. This value is greater
+    ///   than or equal to zero.
+    /// * `count` - This argument refers to the number of bytes of data to be
+    ///   read from the file. This value should be greater than or equal to
+    ///   zero.
+    ///
+    /// ### Returns
+    ///
+    /// Upon successful completion of this call, we return the number of bytes
+    /// read. This number will never be greater than `count`. The value returned
+    /// may be less than `count` if the number of bytes left in the file is less
+    /// than `count`, if the read_syscall() was interrupted by a signal, or if
+    /// the file is a pipe or FIFO or special file and has fewer than
+    /// `count` bytes immediately available for reading.
+    ///
+    /// ### Errors
+    ///
+    /// * EBADF - Given file descriptor in the arguments is invalid; the file is
+    ///   not opened for reading.
+    /// * EISDIR - The file descriptor opened for reading is a directory.
+    /// * EOPNOTSUPP - Reading from streams is not supported.
+    /// * EINVAL - File descriptor is attached to an object which is unsuitable
+    ///   for reading
+    ///
+    /// ### Panics
+    ///
+    /// * If the parent inode does not exist in the inode table, causing
+    ///   unwrap() to panic.
+    /// * When the file type filedescriptor contains a Socket as an inode.
+    /// * When there is some other issue fetching the file descriptor.
+    ///
+    /// For more detailed description of all the commands and return values, see
+    /// [read(2)](https://man7.org/linux/man-pages/man2/read.2.html)
     pub fn read_syscall(&self, fd: i32, buf: *mut u8, count: usize) -> i32 {
-        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        // Attempt to get the file descriptor; handle error if it does not exist
+        let checkedfd = match self.get_filedescriptor(fd) {
+            Ok(fd) => fd,
+            Err(_) => return syscall_error(Errno::EBADF, "read", "Invalid file descriptor."),
+        };
+        // Acquire a write lock on the file descriptor to ensure exclusive access.
         let mut unlocked_fd = checkedfd.write();
+
+        // Check if the file descriptor object is valid
         if let Some(filedesc_enum) = &mut *unlocked_fd {
-            //delegate to pipe, stream, or socket helper if specified by file descriptor
-            // enum type (none of them are implemented yet)
+            // There are different types of file descriptors (File, Sockets, Stream, PIPE),
+            // Based on the enum type, each file descriptor has a different implementation
+            // for reading data from the file.
             match filedesc_enum {
-                //we must borrow the filedesc object as a mutable reference to update the position
+                // We must borrow the filedesc object as a mutable reference to update the position
                 File(ref mut normalfile_filedesc_obj) => {
+                    // Return an error if the file cannot be not opened for reading.
+                    // The function `is_wronly` checks for write only permissions, for a file
+                    // which if true, returns an error, else the file can be opened for reading.
                     if is_wronly(normalfile_filedesc_obj.flags) {
                         return syscall_error(
                             Errno::EBADF,
@@ -1385,22 +1449,33 @@ impl Cage {
                         );
                     }
 
+                    // Get the inode object from the inode table associated with the file
+                    // descriptor.
                     let inodeobj = FS_METADATA
                         .inodetable
                         .get(&normalfile_filedesc_obj.inode)
                         .unwrap();
 
-                    //delegate to character if it's a character file, checking based on the type of
-                    // the inode object
+                    // Match the type of inode object with the type (File, Socket, CharDev, Dir)
                     match &*inodeobj {
+                        // For `File` type inode, the reading happens from the current position
+                        // of the object pointed by `position`. The fileobject is fetched from
+                        // the FileObjectTable and we start reading into the buffer `buf` until
+                        // `count` number of bytes.
                         Inode::File(_) => {
+                            // Get the current position of the File Descriptor Object.
                             let position = normalfile_filedesc_obj.position;
+                            // Get the file object associated with the file descriptor object
                             let fileobject =
                                 FILEOBJECTTABLE.get(&normalfile_filedesc_obj.inode).unwrap();
 
+                            // `readat` function reads from file at specified offset into provided
+                            // C-buffer. If successful, then the position in the file descriptor
+                            // object is updated by adding the number of bytes read (bytesread).
+                            // This ensures that the next read operation will start from the correct
+                            // position.
                             if let Ok(bytesread) = fileobject.readat(buf, count, position) {
                                 //move position forward by the number of bytes we've read
-
                                 normalfile_filedesc_obj.position += bytesread;
                                 bytesread as i32
                             } else {
@@ -1409,14 +1484,23 @@ impl Cage {
                             }
                         }
 
+                        // For `CharDev` type inode, the reading happens from the Character Device
+                        // file, with each device type returning different results returned
+                        // from the `_read_chr_file` file.
                         Inode::CharDev(char_inode_obj) => {
+                            // reads from character devices by matching the device number (DevNo) of
+                            // the DeviceInode.
                             self._read_chr_file(&char_inode_obj, buf, count)
                         }
 
+                        // For `Socket` type inode, a panic is returned as socket type files are not
+                        // supported.
                         Inode::Socket(_) => {
                             panic!("read(): Socket inode found on a filedesc fd.")
                         }
 
+                        // For `Dir` type inode, an error is returned as reading from a directory is
+                        // not allowed
                         Inode::Dir(_) => syscall_error(
                             Errno::EISDIR,
                             "read",
@@ -1424,16 +1508,28 @@ impl Cage {
                         ),
                     }
                 }
+                // For `Socket` type file descriptor, a read is equivalent to a `recv_syscall` so we
+                // transfer control there. A `recv_syscall` is used for receiving message from a
+                // socket.
                 Socket(_) => {
                     drop(unlocked_fd);
                     self.recv_common(fd, buf, count, 0, &mut None)
                 }
+                // Reading from `Stream` type file descriptors is not supported.
                 Stream(_) => syscall_error(
                     Errno::EOPNOTSUPP,
                     "read",
                     "reading from stdin not implemented yet",
                 ),
+                // The `Pipe` type file descriptor handles read through blocking and non-blocking
+                // modes differently to ensure appropriate behavior based on the flags set on the
+                // pipe. In blocking mode, the read_from_pipe function will wait until data is
+                // available to read. This means that if the pipe is empty, the read operation will
+                // block (wait) until data is written to the pipe. In non-blocking mode, the
+                // read_from_pipe function will return immediately with an EAGAIN error if there is
+                // no data available to read. This prevents the function from blocking.
                 Pipe(pipe_filedesc_obj) => {
+                    // Return an error if the pipe cannot be not opened for reading.
                     if is_wronly(pipe_filedesc_obj.flags) {
                         return syscall_error(
                             Errno::EBADF,
@@ -1441,36 +1537,48 @@ impl Cage {
                             "specified file not open for reading",
                         );
                     }
+                    // Check if the `O_NONBLOCK` flag is set in the pipe's flags.
+                    // If `O_NONBLOCK` is set, we set nonblocking to true, indicating that the pipe
+                    // operates in non-blocking mode.
                     let mut nonblocking = false;
                     if pipe_filedesc_obj.flags & O_NONBLOCK != 0 {
                         nonblocking = true;
                     }
+
+                    // Ensures that the function keeps trying to read data until it either succeeds
+                    // or encounters a non-retryable error.
                     loop {
                         // loop over pipe reads so we can periodically check for cancellation
                         let ret = pipe_filedesc_obj
                             .pipe
                             .read_from_pipe(buf, count, nonblocking)
                             as i32;
+                        // Check if the pipe is in blocking mode and the read returned EAGAIN.
+                        // It means that no data is currently available and the read should be tried
+                        // again later.
                         if pipe_filedesc_obj.flags & O_NONBLOCK == 0
                             && ret == -(Errno::EAGAIN as i32)
                         {
+                            // Check if the cancel status is set
                             if self
                                 .cancelstatus
                                 .load(interface::RustAtomicOrdering::Relaxed)
                             {
-                                // if the cancel status is set in the cage, we trap around a cancel
-                                // point until the individual thread
-                                // is signaled to cancel itself
+                                // If the cancel status is set in the cage, we trap around a cancel
+                                // point until the individual thread is signaled to cancel itself
                                 loop {
                                     interface::cancelpoint(self.cageid);
                                 }
                             }
-                            continue; //received EAGAIN on blocking pipe, try
-                                      // again
+                            // Received `EAGAIN` and no cancellation is requested, continue the loop
+                            // to try reading from the pipe again
+                            continue;
                         }
-                        return ret; // if we get here we can return
+                        // If the read was successful, return the result
+                        return ret;
                     }
                 }
+                // Reading from `Epoll` type file descriptors is not supported.
                 Epoll(_) => syscall_error(
                     Errno::EINVAL,
                     "read",
@@ -1482,14 +1590,75 @@ impl Cage {
         }
     }
 
-    //------------------------------------PREAD SYSCALL------------------------------------
+    /// ## ------------------READ SYSCALL------------------
+    /// ### Description
+    ///
+    /// The `pread_syscall()` attempts to read `count` bytes from the file
+    /// associated with the open file descriptor, `fd`, into the buffer
+    /// pointed to by `buf`, starting at the given `offset`. Unlike `read()`,
+    /// `pread()` does not change the file offset.
+    ///
+    /// ### Function Arguments
+    ///
+    /// The `pread_syscall()` receives four arguments:
+    /// * `fd` - This argument refers to the file descriptor from which the data
+    ///   is to be read.
+    /// * `buf` - This argument refers to the mutable buffer into which the file
+    ///   data is to be stored and then returned back. This value is greater
+    ///   than or equal to zero.
+    /// * `count` - This argument refers to the number of bytes of data to be
+    ///   read from the file. This value should be greater than or equal to
+    ///   zero.
+    /// * `offset` - This argument specifies the file offset at which the read
+    ///   is to begin. The file offset is not changed by this operation.
+    ///
+    /// ### Returns
+    ///
+    /// Upon successful completion of this call, we return the number of bytes
+    /// read. This number will never be greater than `count`. The value returned
+    /// may be less than `count` if the number of bytes left in the file is less
+    /// than `count`, if the `pread_syscall()` was interrupted by a signal, or
+    /// if the file is a pipe or FIFO or special file and has fewer than
+    /// `count` bytes immediately available for reading.
+    ///
+    /// ### Errors
+    ///
+    /// * EBADF - Given file descriptor in the arguments is invalid; the file is
+    ///   not opened for reading.
+    /// * EISDIR - The file descriptor opened for reading is a directory.
+    /// * EOPNOTSUPP - Reading from streams is not supported.
+    /// * EINVAL - File descriptor is attached to an object which is unsuitable
+    ///   for reading.
+    ///
+    /// ### Panics
+    ///
+    /// * If the parent inode does not exist in the inode table, causing
+    ///   unwrap() to panic.
+    /// * When the file type file descriptor contains a Socket as an inode.
+    /// * When there is some other issue fetching the file descriptor.
+    ///
+    /// For more detailed description of all the commands and return values, see
+    /// [pread(2)](https://man7.org/linux/man-pages/man2/pread.2.html)
     pub fn pread_syscall(&self, fd: i32, buf: *mut u8, count: usize, offset: isize) -> i32 {
-        let checkedfd = self.get_filedescriptor(fd).unwrap();
+        // Attempt to get the file descriptor; handle error if it does not exist
+        let checkedfd = match self.get_filedescriptor(fd) {
+            Ok(fd) => fd,
+            Err(_) => return syscall_error(Errno::EBADF, "pread", "Invalid file descriptor."),
+        };
+        // Acquire a write lock on the file descriptor to ensure exclusive access.
         let mut unlocked_fd = checkedfd.write();
+
+        // Check if the file descriptor object is valid
         if let Some(filedesc_enum) = &mut *unlocked_fd {
+            // There are different types of file descriptors (File, Sockets, Stream, PIPE),
+            // Based on the enum type, each file descriptor has a different implementation
+            // for reading data from the file.
             match filedesc_enum {
                 //we must borrow the filedesc object as a mutable reference to update the position
                 File(ref mut normalfile_filedesc_obj) => {
+                    // Return an error if the file cannot be not opened for reading.
+                    // The function `is_wronly` checks for write only permissions, for a file
+                    // which if true, returns an error, else the file can be opened for reading.
                     if is_wronly(normalfile_filedesc_obj.flags) {
                         return syscall_error(
                             Errno::EBADF,
@@ -1498,18 +1667,21 @@ impl Cage {
                         );
                     }
 
+                    // Get the inode object from the inode table associated with the file
+                    // descriptor.
                     let inodeobj = FS_METADATA
                         .inodetable
                         .get(&normalfile_filedesc_obj.inode)
                         .unwrap();
 
-                    //delegate to character if it's a character file, checking based on the type of
-                    // the inode object
+                    // Match the type of inode object with the type (File, Socket, CharDev, Dir)
                     match &*inodeobj {
                         Inode::File(_) => {
+                            // Fetch the file object from the file object table
                             let fileobject =
                                 FILEOBJECTTABLE.get(&normalfile_filedesc_obj.inode).unwrap();
 
+                            // Attempt to read from the file at the specified offset
                             if let Ok(bytesread) = fileobject.readat(buf, count, offset as usize) {
                                 bytesread as i32
                             } else {
@@ -1518,14 +1690,21 @@ impl Cage {
                             }
                         }
 
+                        // For `CharDev` type inode, the reading happens from the Character Device
+                        // file, with each device type returning different results returned
+                        // from the `_read_chr_file` file.
                         Inode::CharDev(char_inode_obj) => {
+                            // reads from character devices by matching the device number (DevNo) of
+                            // the DeviceInode.
                             self._read_chr_file(&char_inode_obj, buf, count)
                         }
-
+                        // For `Socket` type inode, a panic is returned as socket type files are not
+                        // supported.
                         Inode::Socket(_) => {
                             panic!("pread(): Socket inode found on a filedesc fd")
                         }
-
+                        // For `Dir` type inode, an error is returned as reading from a directory is
+                        // not allowed
                         Inode::Dir(_) => syscall_error(
                             Errno::EISDIR,
                             "pread",
@@ -1533,21 +1712,30 @@ impl Cage {
                         ),
                     }
                 }
+                // Return an error for Sockets, as they do not support the concept of seeking to a
+                // specific offset because data arrives in a continuous stream from the network.
                 Socket(_) => syscall_error(
                     Errno::ESPIPE,
                     "pread",
                     "file descriptor is associated with a socket, cannot seek",
                 ),
+                // Return an error for Streams, as like sockets, streams are sequential and do not
+                // support seeking to an offset.
                 Stream(_) => syscall_error(
                     Errno::ESPIPE,
                     "pread",
                     "file descriptor is associated with a stream, cannot seek",
                 ),
+                // Return an error for Pipes, as they are designed for sequential reads and writes
+                // between processes. Seeking within a pipe would not make sense because data is
+                // read in the order it was written, making pread inapplicable.
                 Pipe(_) => syscall_error(
                     Errno::ESPIPE,
                     "pread",
                     "file descriptor is associated with a pipe, cannot seek",
                 ),
+                // Return an error for Epoll, as Epoll file descriptors are for event notification
+                // and do not hold any data themselves.
                 Epoll(_) => syscall_error(
                     Errno::ESPIPE,
                     "pread",
@@ -1559,12 +1747,57 @@ impl Cage {
         }
     }
 
+    /// ### Description
+    ///
+    /// The `_read_chr_file()` helper function reads from character devices by
+    /// matching the device number (DevNo) of the DeviceInode. It handles
+    /// `/dev/null`, `/dev/zero`, `/dev/random`, and `/dev/urandom` by
+    /// performing the appropriate actions for each device. If the device is
+    /// unsupported, it returns an error indicating that the operation is
+    /// not supported. This function is used for interacting with special
+    /// character files in a Unix-like filesystem.
+    ///
+    /// ### Function Arguments
+    ///
+    /// The `_read_chr_file()` receives three arguments:
+    /// * `inodeobj` - This argument refers to the DeviceInode object, which
+    ///   contains metadata about the character device.
+    /// * `buf` - This argument refers to the mutable buffer into which the data
+    ///   is to be stored and then returned back.
+    /// * `count` - This argument refers to the number of bytes of data to be
+    ///   read from the file. This value should be greater than or equal to
+    ///   zero.
+    ///
+    /// ### Returns
+    ///
+    /// Upon successful completion of this call, we return the number of bytes
+    /// read. This number will never be greater than `count`. The value returned
+    /// may be less than `count` if the number of bytes left in the file is less
+    /// than `count`, if the read_syscall() was interrupted by a signal, or if
+    /// the file is a pipe or FIFO or special file and has fewer than
+    /// `count` bytes immediately available for reading.
+    ///
+    /// ### Errors
+    ///
+    /// * EOPNOTSUPP - When read from the unspecified object is not permitted
+    ///
+    /// ### Panics
+    ///
+    /// * This function does not panic in any cases.
     fn _read_chr_file(&self, inodeobj: &DeviceInode, buf: *mut u8, count: usize) -> i32 {
+        // Determine which character device is being read from, based on the device
+        // number (dev) in the DeviceInode object.
         match inodeobj.dev {
-            NULLDEVNO => 0, //reading from /dev/null always reads 0 bytes
+            // reading from /dev/null always reads 0 bytes indicating an end-of-file condition.
+            NULLDEVNO => 0,
+            // reading from /dev/zero fills the buffer with zeroes
             ZERODEVNO => interface::fillzero(buf, count),
+            // reading from /dev/random fills the buffer with random bytes
             RANDOMDEVNO => interface::fillrandom(buf, count),
+            // reading from /dev/urandom also fills the buffer with random bytes
             URANDOMDEVNO => interface::fillrandom(buf, count),
+            // for any device number not specifically handled above,
+            // we return an error
             _ => syscall_error(
                 Errno::EOPNOTSUPP,
                 "read or pread",

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1688,7 +1688,8 @@ impl Cage {
                         // from the `_read_chr_file` file.
                         Inode::CharDev(char_inode_obj) => {
                             // reads from character devices by matching the device number (DevNo) of
-                            // the DeviceInode.
+                            // the DeviceInode. This function returns the number of bytes read from
+                            // the character device and updates the buffer `buf` with them.
                             self._read_chr_file(&char_inode_obj, buf, count)
                         }
                         // For `Socket` type inode, a panic is returned as socket type files are not

--- a/src/safeposix/syscalls/sys_calls.rs
+++ b/src/safeposix/syscalls/sys_calls.rs
@@ -43,6 +43,8 @@ use crate::safeposix::filesystem::{decref_dir, metawalk, Inode, FS_METADATA};
 use crate::safeposix::net::NET_METADATA;
 use crate::safeposix::shm::SHM_METADATA;
 
+
+
 impl Cage {
     fn unmap_shm_mappings(&self) {
         //unmap shm mappings on exit or exec
@@ -70,67 +72,60 @@ impl Cage {
     }
 
     /// ### Description
-    ///
+    /// 
     ///'fork_syscall` creates a new process (cage object)
-    /// The newly created child process is an exact copy of the
-    /// parent process (the process that calls fork)
+    /// The newly created child process is an exact copy of the 
+    /// parent process (the process that calls fork) 
     /// apart from it's cage_id and the parent_id
-    /// In this function we clone the mutex table, condition variables table,
-    /// semaphore table and the file descriptors and create
-    /// a new Cage object with these cloned tables.
-    /// We also update the shared memory mappings - and create mappings
-    /// from the new Cage object the the
-    /// parent Cage object's memory mappings.
-    ///
+    /// In this function we clone the mutex table, condition variables table, 
+    /// semaphore table and the file descriptors and create 
+    /// a new Cage object with these cloned tables. 
+    /// We also update the shared memory mappings - and create mappings 
+    /// from the new Cage object the the 
+    /// parent Cage object's memory mappings. 
+    /// 
     /// ### Arguments
-    ///
+    /// 
     /// It accepts one parameter:
-    ///
+    /// 
     /// * `child_cageid` : an integer representing the pid of the child process
-    ///
+    /// 
     /// ### Errors
     ///    
-    /// There are 2 scenarios where the call to `fork_syscall` might return an
-    /// error
-    ///
+    /// There are 2 scenarios where the call to `fork_syscall` might return an error
+    /// 
     /// * When the RawMutex::create() call fails to create a new Mutex object
-    /// * When the RawCondvar::create() call fails to create a new Condition
-    ///   Variable object
-    ///
+    /// * When the RawCondvar::create() call fails to create a new Condition Variable object
+    /// 
     /// ### Returns
-    ///
-    /// On success it returns a value of 0, and the new child Cage object is
-    /// added to Cagetable
-    ///
-    /// ### Panics
-    ///
+    /// 
+    /// On success it returns a value of 0, and the new child Cage object is added to Cagetable
+    /// 
+    /// ### Panics 
+    /// 
     /// This system call has no scenarios where it panics
-    ///
+    /// 
     /// To learn more about the syscall and possible error values, see
-    /// [fork(2)](https://man7.org/linux/man-pages/man2/fork.2.html)
+    /// [fork(2)](https://man7.org/linux/man-pages/man2/fork.2.html) 
 
     pub fn fork_syscall(&self, child_cageid: u64) -> i32 {
-        //Create a new mutex table that replicates the mutex table of the parent
-        // (calling) Cage object Since the child process inherits all the locks
-        // that the parent process holds,
+        //Create a new mutex table that replicates the mutex table of the parent (calling) Cage object
+        //Since the child process inherits all the locks that the parent process holds,
         let mutextable = self.mutex_table.read();
         // Initialize the child object's mutex table
         let mut new_mutex_table = vec![];
         //Loop through each element in the mutex table
-        //Each entry in the mutex table represents a `lock` which the parent process
-        // holds Copying them into the child's Cage exhibits the inheritance of
-        // the lock
+        //Each entry in the mutex table represents a `lock` which the parent process holds
+        //Copying them into the child's Cage exhibits the inheritance of the lock 
         for elem in mutextable.iter() {
             if elem.is_some() {
-                //If the mutex is `Some` - we create a new mutex and store it in the child's
-                // mutex table The create method returns a new struct obejct
-                // that represents a Mutex
+                //If the mutex is `Some` - we create a new mutex and store it in the child's mutex table
+                //The create method returns a new struct obejct that represents a Mutex
                 let new_mutex_result = interface::RawMutex::create();
                 match new_mutex_result {
                     // If the mutex creation is successful we push it on the child's table
                     Ok(new_mutex) => new_mutex_table.push(Some(interface::RustRfc::new(new_mutex))),
-                    // If the mutex creation returns an error, we abort the system call and return
-                    // the appropriate error
+                    // If the mutex creation returns an error, we abort the system call and return the appropriate error
                     Err(_) => {
                         match Errno::from_discriminant(interface::get_errno()) {
                             Ok(i) => {
@@ -147,19 +142,17 @@ impl Cage {
                     }
                 }
             } else {
-                // If the mutex is `None` - we mimic the same behavior in the child's mutex
-                // table
+                // If the mutex is `None` - we mimic the same behavior in the child's mutex table
                 new_mutex_table.push(None);
             }
         }
         drop(mutextable);
 
         //Construct a replica of the condition variables table in the child cage object
-        //This table stores condition variables - which are special variables that the
-        // process uses to determine whether certain conditions have been met or
-        // not. Threads use condition variables to stop or resume their
-        // operation depending on the value of these variables. Read the CondVar
-        // table of the calling process
+        //This table stores condition variables - which are special variables that the process
+        //uses to determine whether certain conditions have been met or not. Threads use condition variables
+        //to stop or resume their operation depending on the value of these variables.  
+        //Read the CondVar table of the calling process
         let cvtable = self.cv_table.read();
         // Initialize the table for the child process
         let mut new_cv_table = vec![];
@@ -167,12 +160,10 @@ impl Cage {
         for elem in cvtable.iter() {
             if elem.is_some() {
                 //Create a condvar to store in the child's Cage object
-                //Returns the condition variable struct object which implements theb signal,
-                // wait, broadcast and timed_wait methods
+                //Returns the condition variable struct object which implements theb signal, wait, broadcast and timed_wait methods
                 let new_cv_result = interface::RawCondvar::create();
                 match new_cv_result {
-                    // If the result of the creation of the RawCondVar is successful - push it onto
-                    // the child's mutex table
+                    // If the result of the creation of the RawCondVar is successful - push it onto the child's mutex table
                     Ok(new_cv) => new_cv_table.push(Some(interface::RustRfc::new(new_cv))),
                     // If the creation was unsucessful - return an Error
                     Err(_) => {
@@ -191,16 +182,15 @@ impl Cage {
                     }
                 }
             } else {
-                // If the value is None - mimic the behavior in the child's condition variable
-                // table
+                // If the value is None - mimic the behavior in the child's condition variable table
                 new_cv_table.push(None);
             }
         }
         drop(cvtable);
 
         //Clone the file descriptor table in the child's Cage object
-        //Each entry in the file descriptor table points to an open file description
-        // which in turn references the actual inodes of the files on disk
+        //Each entry in the file descriptor table points to an open file description which
+        //in turn references the actual inodes of the files on disk
         let newfdtable = init_fdtable();
         //Loop from 0 to maximum value of file descriptor index
         for fd in 0..MAXFD {
@@ -221,9 +211,8 @@ impl Cage {
                         if let Some(inodenum) = inodenum_option {
                             let mut inode = FS_METADATA.inodetable.get_mut(&inodenum).unwrap();
                             //Since the child Cage also inherits the parent's fd table
-                            //We increment the reference count on the actual inodes of the files on
-                            // disk Since the child Cage is a new
-                            // process that also references those files
+                            //We increment the reference count on the actual inodes of the files on disk
+                            //Since the child Cage is a new process that also references those files
                             match *inode {
                                 Inode::File(ref mut f) => {
                                     f.refcount += 1;
@@ -250,14 +239,13 @@ impl Cage {
                         let sock_tmp = socket_filedesc_obj.handle.clone();
                         let mut sockhandle = sock_tmp.write();
                         let socket_type = sockhandle.domain;
-                        //Here we only increment the reference for AF_UNIX socket type
+                        //Here we only increment the reference for AF_UNIX socket type 
                         //Since these are the only sockets that have an inode associated with them
                         if socket_type == AF_UNIX {
                             //Increment the appropriate reference counter of the correct socket
-                            //Each socket has two pipes associated with them - a read and write
-                            // pipe Here we grab these two pipes and
-                            // increment their references individually
-                            // And also increment the reference count of the socket as a whole
+                            //Each socket has two pipes associated with them - a read and write pipe 
+                            //Here we grab these two pipes and increment their references individually
+                            //And also increment the reference count of the socket as a whole
                             if let Some(sockinfo) = &sockhandle.unix_info {
                                 if let Some(sendpipe) = sockinfo.sendpipe.as_ref() {
                                     sendpipe.incr_ref(O_WRONLY);
@@ -267,9 +255,9 @@ impl Cage {
                                 }
                                 if let Inode::Socket(ref mut sock) =
                                     *(FS_METADATA.inodetable.get_mut(&sockinfo.inode).unwrap())
-                                {
-                                    sock.refcount += 1;
-                                }
+                                    {
+                                        sock.refcount += 1;
+                                    }
                             }
                         }
                         drop(sockhandle);
@@ -280,16 +268,17 @@ impl Cage {
                 let newfdobj = filedesc_enum.clone();
                 // Insert the file descriptor object into the new file descriptor table
                 let _insertval = newfdtable[fd as usize].write().insert(newfdobj);
+                
             }
         }
 
         //We read the current working directory of the parent Cage object
         let cwd_container = self.cwd.read();
-        //We try to resolve the inode of the current working directory - if the
-        //resolution is successful we update the reference count of the current working
-        // directory since the newly created Child cage object also references
-        // the same directory If the resolution is not successful - the code
-        // panics since the cwd's inode cannot be resolved correctly
+        //We try to resolve the inode of the current working directory - if the 
+        //resolution is successful we update the reference count of the current working directory
+        //since the newly created Child cage object also references the same directory
+        //If the resolution is not successful - the code panics since the cwd's inode cannot be resolved
+        //correctly
         if let Some(cwdinodenum) = metawalk(&cwd_container) {
             if let Inode::Dir(ref mut cwddir) =
                 *(FS_METADATA.inodetable.get_mut(&cwdinodenum).unwrap())
@@ -302,17 +291,16 @@ impl Cage {
             panic!("We changed from a directory that was not a directory in chdir!");
         }
 
-        // We clone the parent cage's main threads and store them and index 0
-        // This is done since there isn't a thread established for the child Cage object
-        // yet - And there is no threadId to store it at.
-        // The child Cage object can then initialize and store the sigset appropriately
-        // when it establishes its own main thread id.
+        // We clone the parent cage's main threads and store them and index 0 
+        // This is done since there isn't a thread established for the child Cage object yet - 
+        // And there is no threadId to store it at. 
+        // The child Cage object can then initialize and store the sigset appropriately when it establishes its own 
+        // main thread id.
         let newsigset = interface::RustHashMap::new();
         // Here we check if Lind is being run under the test suite or not
         if !interface::RUSTPOSIX_TESTSUITE.load(interface::RustAtomicOrdering::Relaxed) {
-            // When rustposix runs independently (not as Lind paired with NaCL runtime) we
-            // do not handle signals The test suite runs rustposix independently
-            // and hence we do not handle signals for the test suite
+            // When rustposix runs independently (not as Lind paired with NaCL runtime) we do not handle signals
+            // The test suite runs rustposix independently and hence we do not handle signals for the test suite
             let mainsigsetatomic = self
                 .sigset
                 .get(
@@ -328,22 +316,20 @@ impl Cage {
             newsigset.insert(0, mainsigset);
         }
 
-        // Construct a new semaphore table in child cage which equals to the one in the
-        // parent cage
+        // Construct a new semaphore table in child cage which equals to the one in the parent cage 
         let semtable = &self.sem_table;
         let new_semtable: interface::RustHashMap<
             u32,
             interface::RustRfc<interface::RustSemaphore>,
         > = interface::RustHashMap::new();
-        // Loop all pairs of semaphores and insert their copies into the new semaphore
-        // table Each pair consists of a key which is 32 bit unsigned integer
+        // Loop all pairs of semaphores and insert their copies into the new semaphore table
+        // Each pair consists of a key which is 32 bit unsigned integer
         // And a Semaphore Object implemented as RustSemaphore
         for pair in semtable.iter() {
             new_semtable.insert((*pair.key()).clone(), pair.value().clone());
         }
 
-        // Create a new cage object using the cloned tables and the child id passed as a
-        // parameter
+        // Create a new cage object using the cloned tables and the child id passed as a parameter
         let cageobj = Cage {
             cageid: child_cageid,
             cwd: interface::RustLock::new(self.cwd.read().clone()),

--- a/src/safeposix/syscalls/sys_calls.rs
+++ b/src/safeposix/syscalls/sys_calls.rs
@@ -43,8 +43,6 @@ use crate::safeposix::filesystem::{decref_dir, metawalk, Inode, FS_METADATA};
 use crate::safeposix::net::NET_METADATA;
 use crate::safeposix::shm::SHM_METADATA;
 
-
-
 impl Cage {
     fn unmap_shm_mappings(&self) {
         //unmap shm mappings on exit or exec
@@ -72,60 +70,67 @@ impl Cage {
     }
 
     /// ### Description
-    /// 
+    ///
     ///'fork_syscall` creates a new process (cage object)
-    /// The newly created child process is an exact copy of the 
-    /// parent process (the process that calls fork) 
+    /// The newly created child process is an exact copy of the
+    /// parent process (the process that calls fork)
     /// apart from it's cage_id and the parent_id
-    /// In this function we clone the mutex table, condition variables table, 
-    /// semaphore table and the file descriptors and create 
-    /// a new Cage object with these cloned tables. 
-    /// We also update the shared memory mappings - and create mappings 
-    /// from the new Cage object the the 
-    /// parent Cage object's memory mappings. 
-    /// 
+    /// In this function we clone the mutex table, condition variables table,
+    /// semaphore table and the file descriptors and create
+    /// a new Cage object with these cloned tables.
+    /// We also update the shared memory mappings - and create mappings
+    /// from the new Cage object the the
+    /// parent Cage object's memory mappings.
+    ///
     /// ### Arguments
-    /// 
+    ///
     /// It accepts one parameter:
-    /// 
+    ///
     /// * `child_cageid` : an integer representing the pid of the child process
-    /// 
+    ///
     /// ### Errors
     ///    
-    /// There are 2 scenarios where the call to `fork_syscall` might return an error
-    /// 
+    /// There are 2 scenarios where the call to `fork_syscall` might return an
+    /// error
+    ///
     /// * When the RawMutex::create() call fails to create a new Mutex object
-    /// * When the RawCondvar::create() call fails to create a new Condition Variable object
-    /// 
+    /// * When the RawCondvar::create() call fails to create a new Condition
+    ///   Variable object
+    ///
     /// ### Returns
-    /// 
-    /// On success it returns a value of 0, and the new child Cage object is added to Cagetable
-    /// 
-    /// ### Panics 
-    /// 
+    ///
+    /// On success it returns a value of 0, and the new child Cage object is
+    /// added to Cagetable
+    ///
+    /// ### Panics
+    ///
     /// This system call has no scenarios where it panics
-    /// 
+    ///
     /// To learn more about the syscall and possible error values, see
-    /// [fork(2)](https://man7.org/linux/man-pages/man2/fork.2.html) 
+    /// [fork(2)](https://man7.org/linux/man-pages/man2/fork.2.html)
 
     pub fn fork_syscall(&self, child_cageid: u64) -> i32 {
-        //Create a new mutex table that replicates the mutex table of the parent (calling) Cage object
-        //Since the child process inherits all the locks that the parent process holds,
+        //Create a new mutex table that replicates the mutex table of the parent
+        // (calling) Cage object Since the child process inherits all the locks
+        // that the parent process holds,
         let mutextable = self.mutex_table.read();
         // Initialize the child object's mutex table
         let mut new_mutex_table = vec![];
         //Loop through each element in the mutex table
-        //Each entry in the mutex table represents a `lock` which the parent process holds
-        //Copying them into the child's Cage exhibits the inheritance of the lock 
+        //Each entry in the mutex table represents a `lock` which the parent process
+        // holds Copying them into the child's Cage exhibits the inheritance of
+        // the lock
         for elem in mutextable.iter() {
             if elem.is_some() {
-                //If the mutex is `Some` - we create a new mutex and store it in the child's mutex table
-                //The create method returns a new struct obejct that represents a Mutex
+                //If the mutex is `Some` - we create a new mutex and store it in the child's
+                // mutex table The create method returns a new struct obejct
+                // that represents a Mutex
                 let new_mutex_result = interface::RawMutex::create();
                 match new_mutex_result {
                     // If the mutex creation is successful we push it on the child's table
                     Ok(new_mutex) => new_mutex_table.push(Some(interface::RustRfc::new(new_mutex))),
-                    // If the mutex creation returns an error, we abort the system call and return the appropriate error
+                    // If the mutex creation returns an error, we abort the system call and return
+                    // the appropriate error
                     Err(_) => {
                         match Errno::from_discriminant(interface::get_errno()) {
                             Ok(i) => {
@@ -142,17 +147,19 @@ impl Cage {
                     }
                 }
             } else {
-                // If the mutex is `None` - we mimic the same behavior in the child's mutex table
+                // If the mutex is `None` - we mimic the same behavior in the child's mutex
+                // table
                 new_mutex_table.push(None);
             }
         }
         drop(mutextable);
 
         //Construct a replica of the condition variables table in the child cage object
-        //This table stores condition variables - which are special variables that the process
-        //uses to determine whether certain conditions have been met or not. Threads use condition variables
-        //to stop or resume their operation depending on the value of these variables.  
-        //Read the CondVar table of the calling process
+        //This table stores condition variables - which are special variables that the
+        // process uses to determine whether certain conditions have been met or
+        // not. Threads use condition variables to stop or resume their
+        // operation depending on the value of these variables. Read the CondVar
+        // table of the calling process
         let cvtable = self.cv_table.read();
         // Initialize the table for the child process
         let mut new_cv_table = vec![];
@@ -160,10 +167,12 @@ impl Cage {
         for elem in cvtable.iter() {
             if elem.is_some() {
                 //Create a condvar to store in the child's Cage object
-                //Returns the condition variable struct object which implements theb signal, wait, broadcast and timed_wait methods
+                //Returns the condition variable struct object which implements theb signal,
+                // wait, broadcast and timed_wait methods
                 let new_cv_result = interface::RawCondvar::create();
                 match new_cv_result {
-                    // If the result of the creation of the RawCondVar is successful - push it onto the child's mutex table
+                    // If the result of the creation of the RawCondVar is successful - push it onto
+                    // the child's mutex table
                     Ok(new_cv) => new_cv_table.push(Some(interface::RustRfc::new(new_cv))),
                     // If the creation was unsucessful - return an Error
                     Err(_) => {
@@ -182,15 +191,16 @@ impl Cage {
                     }
                 }
             } else {
-                // If the value is None - mimic the behavior in the child's condition variable table
+                // If the value is None - mimic the behavior in the child's condition variable
+                // table
                 new_cv_table.push(None);
             }
         }
         drop(cvtable);
 
         //Clone the file descriptor table in the child's Cage object
-        //Each entry in the file descriptor table points to an open file description which
-        //in turn references the actual inodes of the files on disk
+        //Each entry in the file descriptor table points to an open file description
+        // which in turn references the actual inodes of the files on disk
         let newfdtable = init_fdtable();
         //Loop from 0 to maximum value of file descriptor index
         for fd in 0..MAXFD {
@@ -211,8 +221,9 @@ impl Cage {
                         if let Some(inodenum) = inodenum_option {
                             let mut inode = FS_METADATA.inodetable.get_mut(&inodenum).unwrap();
                             //Since the child Cage also inherits the parent's fd table
-                            //We increment the reference count on the actual inodes of the files on disk
-                            //Since the child Cage is a new process that also references those files
+                            //We increment the reference count on the actual inodes of the files on
+                            // disk Since the child Cage is a new
+                            // process that also references those files
                             match *inode {
                                 Inode::File(ref mut f) => {
                                     f.refcount += 1;
@@ -239,13 +250,14 @@ impl Cage {
                         let sock_tmp = socket_filedesc_obj.handle.clone();
                         let mut sockhandle = sock_tmp.write();
                         let socket_type = sockhandle.domain;
-                        //Here we only increment the reference for AF_UNIX socket type 
+                        //Here we only increment the reference for AF_UNIX socket type
                         //Since these are the only sockets that have an inode associated with them
                         if socket_type == AF_UNIX {
                             //Increment the appropriate reference counter of the correct socket
-                            //Each socket has two pipes associated with them - a read and write pipe 
-                            //Here we grab these two pipes and increment their references individually
-                            //And also increment the reference count of the socket as a whole
+                            //Each socket has two pipes associated with them - a read and write
+                            // pipe Here we grab these two pipes and
+                            // increment their references individually
+                            // And also increment the reference count of the socket as a whole
                             if let Some(sockinfo) = &sockhandle.unix_info {
                                 if let Some(sendpipe) = sockinfo.sendpipe.as_ref() {
                                     sendpipe.incr_ref(O_WRONLY);
@@ -255,9 +267,9 @@ impl Cage {
                                 }
                                 if let Inode::Socket(ref mut sock) =
                                     *(FS_METADATA.inodetable.get_mut(&sockinfo.inode).unwrap())
-                                    {
-                                        sock.refcount += 1;
-                                    }
+                                {
+                                    sock.refcount += 1;
+                                }
                             }
                         }
                         drop(sockhandle);
@@ -268,17 +280,16 @@ impl Cage {
                 let newfdobj = filedesc_enum.clone();
                 // Insert the file descriptor object into the new file descriptor table
                 let _insertval = newfdtable[fd as usize].write().insert(newfdobj);
-                
             }
         }
 
         //We read the current working directory of the parent Cage object
         let cwd_container = self.cwd.read();
-        //We try to resolve the inode of the current working directory - if the 
-        //resolution is successful we update the reference count of the current working directory
-        //since the newly created Child cage object also references the same directory
-        //If the resolution is not successful - the code panics since the cwd's inode cannot be resolved
-        //correctly
+        //We try to resolve the inode of the current working directory - if the
+        //resolution is successful we update the reference count of the current working
+        // directory since the newly created Child cage object also references
+        // the same directory If the resolution is not successful - the code
+        // panics since the cwd's inode cannot be resolved correctly
         if let Some(cwdinodenum) = metawalk(&cwd_container) {
             if let Inode::Dir(ref mut cwddir) =
                 *(FS_METADATA.inodetable.get_mut(&cwdinodenum).unwrap())
@@ -291,16 +302,17 @@ impl Cage {
             panic!("We changed from a directory that was not a directory in chdir!");
         }
 
-        // We clone the parent cage's main threads and store them and index 0 
-        // This is done since there isn't a thread established for the child Cage object yet - 
-        // And there is no threadId to store it at. 
-        // The child Cage object can then initialize and store the sigset appropriately when it establishes its own 
-        // main thread id.
+        // We clone the parent cage's main threads and store them and index 0
+        // This is done since there isn't a thread established for the child Cage object
+        // yet - And there is no threadId to store it at.
+        // The child Cage object can then initialize and store the sigset appropriately
+        // when it establishes its own main thread id.
         let newsigset = interface::RustHashMap::new();
         // Here we check if Lind is being run under the test suite or not
         if !interface::RUSTPOSIX_TESTSUITE.load(interface::RustAtomicOrdering::Relaxed) {
-            // When rustposix runs independently (not as Lind paired with NaCL runtime) we do not handle signals
-            // The test suite runs rustposix independently and hence we do not handle signals for the test suite
+            // When rustposix runs independently (not as Lind paired with NaCL runtime) we
+            // do not handle signals The test suite runs rustposix independently
+            // and hence we do not handle signals for the test suite
             let mainsigsetatomic = self
                 .sigset
                 .get(
@@ -316,20 +328,22 @@ impl Cage {
             newsigset.insert(0, mainsigset);
         }
 
-        // Construct a new semaphore table in child cage which equals to the one in the parent cage 
+        // Construct a new semaphore table in child cage which equals to the one in the
+        // parent cage
         let semtable = &self.sem_table;
         let new_semtable: interface::RustHashMap<
             u32,
             interface::RustRfc<interface::RustSemaphore>,
         > = interface::RustHashMap::new();
-        // Loop all pairs of semaphores and insert their copies into the new semaphore table
-        // Each pair consists of a key which is 32 bit unsigned integer
+        // Loop all pairs of semaphores and insert their copies into the new semaphore
+        // table Each pair consists of a key which is 32 bit unsigned integer
         // And a Semaphore Object implemented as RustSemaphore
         for pair in semtable.iter() {
             new_semtable.insert((*pair.key()).clone(), pair.value().clone());
         }
 
-        // Create a new cage object using the cloned tables and the child id passed as a parameter
+        // Create a new cage object using the cloned tables and the child id passed as a
+        // parameter
         let cageobj = Cage {
             cageid: child_cageid,
             cwd: interface::RustLock::new(self.cwd.read().clone()),

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -2896,4 +2896,291 @@ pub mod fs_tests {
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
     }
+
+    #[test]
+    pub fn ut_lind_fs_read_write_only_fd() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        // Test to create a file with write only permissions, and check if
+        // a valid error is returned when the file is used for reading.
+        let fd = cage.open_syscall("/test_file", O_CREAT | O_WRONLY, S_IRWXA);
+        let mut read_buf = sizecbuf(5);
+        assert_eq!(
+            cage.read_syscall(fd, read_buf.as_mut_ptr(), 5),
+            -(Errno::EBADF as i32)
+        );
+
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    #[test]
+    pub fn ut_lind_fs_read_from_directory() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        // Create a directory and try to read from it.
+        // We should expect an error (EISDIR) as reading from a directory is not
+        // supported.
+        let path = "/test_dir";
+        assert_eq!(cage.mkdir_syscall(path, S_IRWXA), 0);
+        let fd = cage.open_syscall(path, O_RDONLY, S_IRWXA);
+
+        let mut read_buf = sizecbuf(5);
+        assert_eq!(
+            cage.read_syscall(fd, read_buf.as_mut_ptr(), 5),
+            -(Errno::EISDIR as i32)
+        );
+
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    #[test]
+    pub fn ut_lind_fs_read_from_epoll() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        // Create an Epoll and try to read from it.
+        // We should expect an error (EINVAL) as reading from an Epoll is not supported.
+        let epfd = cage.epoll_create_syscall(1);
+        assert!(epfd > 0);
+        let mut read_buf = sizecbuf(5);
+        assert_eq!(
+            cage.read_syscall(epfd, read_buf.as_mut_ptr(), 5),
+            -(Errno::EINVAL as i32)
+        );
+
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    #[test]
+    pub fn ut_lind_fs_read_from_regular_file() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        // This test mainly tests two scenarios for reading from a regular file:
+        // * Reading from a file should initially start from 0 position.
+        // * Once read, the position of the seek pointer in the file descriptor should
+        // increment by the count of bytes read. If the read is performed again, then
+        // the position should continue from the point it was previously left.
+        let fd = cage.open_syscall("/test_file", O_CREAT | O_TRUNC | O_RDWR, S_IRWXA);
+        assert!(fd >= 0);
+
+        // Write sample data to the file.
+        assert_eq!(cage.write_syscall(fd, str2cbuf("hello there!"), 12), 12);
+
+        // Set the initial position to 0 in the file descriptor.
+        assert_eq!(cage.lseek_syscall(fd, 0, SEEK_SET), 0);
+
+        // Read first 5 bytes from the file, and assert the result.
+        let mut read_buf1 = sizecbuf(5);
+        assert_eq!(cage.read_syscall(fd, read_buf1.as_mut_ptr(), 5), 5);
+        assert_eq!(
+            cbuf2str(&read_buf1), 
+            "hello"
+        );
+
+        // Read next 7 bytes which should start from the previous position.
+        let mut read_buf2 = sizecbuf(7);
+        assert_eq!(cage.read_syscall(fd, read_buf2.as_mut_ptr(), 7), 7);
+        assert_eq!(
+            cbuf2str(&read_buf2),
+            " there!"
+        );
+
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    #[test]
+    pub fn ut_lind_fs_read_from_chardev_file() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        // This test mainly tests the case for reading from a character device type file.
+        // In this case, we are trying to read 100 bytes from the "/dev/zero" file,
+        // which should return 100 bytes of "0" filled characters.
+        let path = "/dev/zero";
+        let fd = cage.open_syscall(path, O_RDWR, S_IRWXA);
+
+        // Verify if the returned count of bytes is 100.
+        let mut read_bufzero = sizecbuf(100);
+        assert_eq!(
+            cage.read_syscall(fd, read_bufzero.as_mut_ptr(), 100),
+            100
+        );
+        // Verify if the characters present in the buffer are all "0".
+        assert_eq!(
+            cbuf2str(&read_bufzero),
+            std::iter::repeat("\0")
+                .take(100)
+                .collect::<String>()
+                .as_str()
+        );
+        assert_eq!(cage.close_syscall(fd), 0);
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    #[test]
+    pub fn ut_lind_fs_read_from_sockets() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        // This test mainly tests the case for reading data from a pair of Sockets.
+        // In this case, we create a socket pair of two sockets, and send data through
+        // one socket, and try to read it from the other one using `read_syscall()`.
+        let mut socketpair = interface::SockPair::default();
+
+        // Verify if the socketpair is formed successfully.
+        assert_eq!(
+            Cage::socketpair_syscall(cage.clone(), AF_UNIX, SOCK_STREAM, 0, &mut socketpair),
+            0
+        );
+        // Verify if the number of bytes sent to socket1 is correct.
+        assert_eq!(
+            cage.send_syscall(socketpair.sock1, str2cbuf("test"), 4, 0),
+            4
+        );
+        // Verify if the number of bytes received by socket2 is correct.
+        let mut buf2 = sizecbuf(4);
+        assert_eq!(
+            cage.read_syscall(socketpair.sock2, buf2.as_mut_ptr(), 4), 
+            4
+        );
+        // Verify if the data received inside the buffer is correct.
+        assert_eq!(
+            cbuf2str(&buf2), 
+            "test"
+        );
+        // Close the sockets
+        assert_eq!(cage.close_syscall(socketpair.sock1), 0);
+        assert_eq!(cage.close_syscall(socketpair.sock2), 0);
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    #[test]
+    pub fn ut_lind_fs_read_from_pipe_blocking_mode() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        // This test mainly tests the case of reading data from the pipe.
+        // We create two pipes, i.e., Read and Write and validate if the data
+        // received is correct or not.
+
+        // Create a pipe of read and write file descriptors.
+        let mut pipe_fds = PipeArray::default();
+        assert_eq!(cage.pipe_syscall(&mut pipe_fds), 0);
+        let read_fd = pipe_fds.readfd;
+        let write_fd = pipe_fds.writefd;
+
+        let write_data = "Testing";
+        let mut buf = sizecbuf(7);
+
+        // Write data to the pipe
+        assert_eq!(
+            cage.write_syscall(write_fd, write_data.as_ptr(), write_data.len()), 
+            write_data.len() as i32
+        );
+
+        // Read the data from the pipe and verify its count.
+        assert_eq!(
+            cage.read_syscall(read_fd, buf.as_mut_ptr(), buf.len()), 
+            write_data.len() as i32
+        );
+        // Verify if the data returned in the pipe buffer is correct.
+        assert_eq!(
+            cbuf2str(&buf), 
+            write_data
+        );
+
+        // Close the file descriptors
+        assert_eq!(cage.close_syscall(read_fd), 0);
+        assert_eq!(cage.close_syscall(write_fd), 0);
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    #[test]
+    pub fn ut_lind_fs_read_from_pipe_nonblocking_mode() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        // This test mainly tests the case of reading data from the pipe, but in non-blocking mode.
+        // We create two pipes, i.e., Read and Write and validate if the data
+        // received is correct or not.
+        
+        // Create a pipe of read and write file descriptors.
+        let mut pipe_fds = PipeArray::default();
+        assert_eq!(cage.pipe_syscall(&mut pipe_fds), 0);
+        let read_fd = pipe_fds.readfd;
+        let write_fd = pipe_fds.writefd;
+
+        let write_data = "Testing";
+        let mut buf = sizecbuf(7);
+
+        // Set pipe to non-blocking mode
+        assert_eq!(
+            cage.fcntl_syscall(read_fd, F_SETFL, O_NONBLOCK),
+            0
+        );
+
+        // Read from the pipe (should return EAGAIN as there's no data yet)
+        assert_eq!(
+            cage.read_syscall(read_fd, buf.as_mut_ptr(), buf.len()), 
+            -(Errno::EAGAIN as i32)
+        );
+
+        // Write data to the pipe
+        assert_eq!(
+            cage.write_syscall(write_fd, write_data.as_ptr(), write_data.len()), 
+            write_data.len() as i32
+        );
+
+        // Read the data from the pipe and verify its count.
+        assert_eq!(
+            cage.read_syscall(read_fd, buf.as_mut_ptr(), buf.len()), 
+            write_data.len() as i32
+        );
+        // Verify if the data returned in the pipe buffer is correct.
+        assert_eq!(
+            cbuf2str(&buf), 
+            write_data
+        );
+
+        // Close the file descriptors
+        assert_eq!(cage.close_syscall(read_fd), 0);
+        assert_eq!(cage.close_syscall(write_fd), 0);
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
 }

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -2990,18 +2990,12 @@ pub mod fs_tests {
         // Read first 5 bytes from the file, and assert the result.
         let mut read_buf1 = sizecbuf(5);
         assert_eq!(cage.read_syscall(fd, read_buf1.as_mut_ptr(), 5), 5);
-        assert_eq!(
-            cbuf2str(&read_buf1), 
-            "hello"
-        );
+        assert_eq!(cbuf2str(&read_buf1), "hello");
 
         // Read next 7 bytes which should start from the previous position.
         let mut read_buf2 = sizecbuf(7);
         assert_eq!(cage.read_syscall(fd, read_buf2.as_mut_ptr(), 7), 7);
-        assert_eq!(
-            cbuf2str(&read_buf2),
-            " there!"
-        );
+        assert_eq!(cbuf2str(&read_buf2), " there!");
 
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
@@ -3015,18 +3009,16 @@ pub mod fs_tests {
 
         let cage = interface::cagetable_getref(1);
 
-        // This test mainly tests the case for reading from a character device type file.
-        // In this case, we are trying to read 100 bytes from the "/dev/zero" file,
-        // which should return 100 bytes of "0" filled characters.
+        // This test mainly tests the case for reading from a character device type
+        // file. In this case, we are trying to read 100 bytes from the
+        // "/dev/zero" file, which should return 100 bytes of "0" filled
+        // characters.
         let path = "/dev/zero";
         let fd = cage.open_syscall(path, O_RDWR, S_IRWXA);
 
         // Verify if the returned count of bytes is 100.
         let mut read_bufzero = sizecbuf(100);
-        assert_eq!(
-            cage.read_syscall(fd, read_bufzero.as_mut_ptr(), 100),
-            100
-        );
+        assert_eq!(cage.read_syscall(fd, read_bufzero.as_mut_ptr(), 100), 100);
         // Verify if the characters present in the buffer are all "0".
         assert_eq!(
             cbuf2str(&read_bufzero),
@@ -3065,15 +3057,9 @@ pub mod fs_tests {
         );
         // Verify if the number of bytes received by socket2 is correct.
         let mut buf2 = sizecbuf(4);
-        assert_eq!(
-            cage.read_syscall(socketpair.sock2, buf2.as_mut_ptr(), 4), 
-            4
-        );
+        assert_eq!(cage.read_syscall(socketpair.sock2, buf2.as_mut_ptr(), 4), 4);
         // Verify if the data received inside the buffer is correct.
-        assert_eq!(
-            cbuf2str(&buf2), 
-            "test"
-        );
+        assert_eq!(cbuf2str(&buf2), "test");
         // Close the sockets
         assert_eq!(cage.close_syscall(socketpair.sock1), 0);
         assert_eq!(cage.close_syscall(socketpair.sock2), 0);
@@ -3104,20 +3090,17 @@ pub mod fs_tests {
 
         // Write data to the pipe
         assert_eq!(
-            cage.write_syscall(write_fd, write_data.as_ptr(), write_data.len()), 
+            cage.write_syscall(write_fd, write_data.as_ptr(), write_data.len()),
             write_data.len() as i32
         );
 
         // Read the data from the pipe and verify its count.
         assert_eq!(
-            cage.read_syscall(read_fd, buf.as_mut_ptr(), buf.len()), 
+            cage.read_syscall(read_fd, buf.as_mut_ptr(), buf.len()),
             write_data.len() as i32
         );
         // Verify if the data returned in the pipe buffer is correct.
-        assert_eq!(
-            cbuf2str(&buf), 
-            write_data
-        );
+        assert_eq!(cbuf2str(&buf), write_data);
 
         // Close the file descriptors
         assert_eq!(cage.close_syscall(read_fd), 0);
@@ -3134,10 +3117,10 @@ pub mod fs_tests {
 
         let cage = interface::cagetable_getref(1);
 
-        // This test mainly tests the case of reading data from the pipe, but in non-blocking mode.
-        // We create two pipes, i.e., Read and Write and validate if the data
-        // received is correct or not.
-        
+        // This test mainly tests the case of reading data from the pipe, but in
+        // non-blocking mode. We create two pipes, i.e., Read and Write and
+        // validate if the data received is correct or not.
+
         // Create a pipe of read and write file descriptors.
         let mut pipe_fds = PipeArray::default();
         assert_eq!(cage.pipe_syscall(&mut pipe_fds), 0);
@@ -3148,33 +3131,27 @@ pub mod fs_tests {
         let mut buf = sizecbuf(7);
 
         // Set pipe to non-blocking mode
-        assert_eq!(
-            cage.fcntl_syscall(read_fd, F_SETFL, O_NONBLOCK),
-            0
-        );
+        assert_eq!(cage.fcntl_syscall(read_fd, F_SETFL, O_NONBLOCK), 0);
 
         // Read from the pipe (should return EAGAIN as there's no data yet)
         assert_eq!(
-            cage.read_syscall(read_fd, buf.as_mut_ptr(), buf.len()), 
+            cage.read_syscall(read_fd, buf.as_mut_ptr(), buf.len()),
             -(Errno::EAGAIN as i32)
         );
 
         // Write data to the pipe
         assert_eq!(
-            cage.write_syscall(write_fd, write_data.as_ptr(), write_data.len()), 
+            cage.write_syscall(write_fd, write_data.as_ptr(), write_data.len()),
             write_data.len() as i32
         );
 
         // Read the data from the pipe and verify its count.
         assert_eq!(
-            cage.read_syscall(read_fd, buf.as_mut_ptr(), buf.len()), 
+            cage.read_syscall(read_fd, buf.as_mut_ptr(), buf.len()),
             write_data.len() as i32
         );
         // Verify if the data returned in the pipe buffer is correct.
-        assert_eq!(
-            cbuf2str(&buf), 
-            write_data
-        );
+        assert_eq!(cbuf2str(&buf), write_data);
 
         // Close the file descriptors
         assert_eq!(cage.close_syscall(read_fd), 0);
@@ -3183,4 +3160,123 @@ pub mod fs_tests {
         lindrustfinalize();
     }
 
+    #[test]
+    pub fn ut_lind_fs_pread_write_only_fd() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        // Test to create a file with write only permissions, and check if
+        // a valid error is returned when the file is used for reading.
+        let fd = cage.open_syscall("/test_file", O_CREAT | O_WRONLY, S_IRWXA);
+        let mut read_buf = sizecbuf(5);
+        assert_eq!(
+            cage.pread_syscall(fd, read_buf.as_mut_ptr(), 5, 0),
+            -(Errno::EBADF as i32)
+        );
+
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    #[test]
+    pub fn ut_lind_fs_pread_from_file() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        // This test mainly tests two scenarios for reading from a file using
+        // `pread_syscall()`.
+        // * Reading from a file from the starting position offset(0).
+        // * Reading from a file from a random position offset.
+        let fd = cage.open_syscall("/test_file", O_CREAT | O_TRUNC | O_RDWR, S_IRWXA);
+        assert!(fd >= 0);
+
+        // Write sample data to the file.
+        assert_eq!(cage.write_syscall(fd, str2cbuf("hello there!"), 12), 12);
+
+        // Set the initial position to 0 in the file descriptor.
+        assert_eq!(cage.lseek_syscall(fd, 0, SEEK_SET), 0);
+
+        // Read first 5 bytes from the file, and assert the result.
+        let mut read_buf1 = sizecbuf(5);
+        assert_eq!(cage.pread_syscall(fd, read_buf1.as_mut_ptr(), 5, 0), 5);
+        assert_eq!(cbuf2str(&read_buf1), "hello");
+
+        // Read 5 bytes, but from the 6th position offset of the file.
+        let mut read_buf2 = sizecbuf(5);
+        assert_eq!(cage.pread_syscall(fd, read_buf2.as_mut_ptr(), 5, 6), 5);
+        assert_eq!(cbuf2str(&read_buf2), "there");
+
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    #[test]
+    pub fn ut_lind_fs_pread_from_directory() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+        let mut buf = sizecbuf(5);
+
+        // Test for invalid directory should fail
+        let path = "/test_dir";
+        assert_eq!(cage.mkdir_syscall(path, S_IRWXA), 0);
+        let fd = cage.open_syscall(path, O_CREAT | O_TRUNC | O_RDWR, S_IRWXA);
+        assert!(fd >= 0);
+        assert_eq!(
+            cage.pread_syscall(fd, buf.as_mut_ptr(), buf.len(), 0),
+            -(Errno::EISDIR as i32)
+        );
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    #[test]
+    pub fn ut_lind_fs_pread_invalid_types() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+        let mut buf = sizecbuf(5);
+
+        // Test for invalid pipe
+        // Try reading the data from the pipe and check for error.
+        let mut pipe_fds = PipeArray::default();
+        assert_eq!(cage.pipe_syscall(&mut pipe_fds), 0);
+        let read_fd = pipe_fds.readfd;
+        assert_eq!(
+            cage.pread_syscall(read_fd, buf.as_mut_ptr(), buf.len(), 0),
+            -(Errno::ESPIPE as i32)
+        );
+
+        // Test for invalid sockets
+        // Try reading the data from the socket and check for error.
+        let mut socketpair = interface::SockPair::default();
+        assert_eq!(
+            Cage::socketpair_syscall(cage.clone(), AF_UNIX, SOCK_STREAM, 0, &mut socketpair),
+            0
+        );
+        assert_eq!(
+            cage.pread_syscall(socketpair.sock2, buf.as_mut_ptr(), 4, 0),
+            -(Errno::ESPIPE as i32)
+        );
+
+        // Test for invalid epoll
+        // Try reading the data from the epoll and check for error.
+        let epfd = cage.epoll_create_syscall(1);
+        assert_eq!(
+            cage.pread_syscall(epfd, buf.as_mut_ptr(), 5, 0),
+            -(Errno::ESPIPE as i32)
+        );
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
 }


### PR DESCRIPTION
## Description

Fixes # (issue)
The following changes include the tests and comments in the code for the "read_syscall" and "pread_syscall" file system calls under RustPosix.
The tests were added to cover all the possible scenarios that might happen when calling the file system_calls  `read_syscall` and `pread_syscall`.

### Type of change
- [x]  This change just contains the tests for an existing file system call.
- [x]  This change contains the minor code changes and comments for read_syscall and pread_syscall.
- [x]  This change contains code reformatting for existing file system calls. 

## How Has This Been Tested?
Inorder to run the tests, we need to run `cargo test --lib` command inside the `safeposix-rust` directory.

All the tests are present under this directory: `lind_project/src/safeposix-rust/src/tests/fs_tests.rs`

- Test A - `ut_lind_fs_read_write_only_fd()`
- Test B - `ut_lind_fs_read_from_directory()`
- Test C - `ut_lind_fs_read_from_epoll()`
- Test D - `ut_lind_fs_read_from_regular_file()`
- Test E - `ut_lind_fs_read_from_chardev_file()`
- Test F -  `ut_lind_fs_read_from_sockets()`
- Test G - `ut_lind_fs_read_from_pipe_blocking_mode()`
- Test H - `ut_lind_fs_read_from_pipe_nonblocking_mode()`
- Test I - `ut_lind_fs_pread_write_only_fd()`
- Test J - `ut_lind_fs_pread_from_file()`
- Test K - `ut_lind_fs_pread_from_directory()`
- Test L - `ut_lind_fs_pread_invalid_types()`

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
