### PR TITLE
chdir_syscall() and fchdir_syscall() updates

### DIFF
--- a/src/safeposix/filesystem.rs
+++ b/src/safeposix/filesystem.rs
@@ -636,22 +636,3 @@ pub fn incref_root() {
         panic!("Root directory inode was not a directory");
     }
 }
-
-pub fn decref_dir(cwd_container: &interface::RustPathBuf) {
-    if let Some(cwdinodenum) = metawalk(&cwd_container) {
-        if let Inode::Dir(ref mut cwddir) = *(FS_METADATA.inodetable.get_mut(&cwdinodenum).unwrap())
-        {
-            cwddir.refcount -= 1;
-
-            //if the directory has been removed but this cwd was the last open handle to it
-            if cwddir.refcount == 0 && cwddir.linkcount == 0 {
-                FS_METADATA.inodetable.remove(&cwdinodenum);
-            }
-        } else {
-            panic!("Cage had a cwd that was not a directory!");
-        }
-    } else {
-        panic!("Cage had a cwd which did not exist!");
-    } //we probably want to handle this case, maybe cwd should be an inode
-      // number?? Not urgent
-}

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1098,9 +1098,9 @@ impl Cage {
     /// truncating an existing one by combining the O_CREAT, O_TRUNC, and
     /// O_WRONLY flags.
     /// There are generally two cases which occur when this syscall happens:
-    /// Case 1: If the file to be opened doesn't exist, then due to O_CREAT flag,
-    /// a new file is created at the given location and a new file descriptor is 
-    /// created and returned. 
+    /// Case 1: If the file to be opened doesn't exist, then due to O_CREAT
+    /// flag, a new file is created at the given location and a new file
+    /// descriptor is created and returned.
     /// Case 2: If the file already exists, then due to O_TRUNC flag, the file
     /// size gets reduced to 0, and the existing file descriptor is returned.
     ///
@@ -2160,8 +2160,8 @@ impl Cage {
 
     /// ### Description
     ///
-    /// The `fchdir_syscall()` function changes the current working 
-    /// directory of the calling process to the directory specified 
+    /// The `fchdir_syscall()` function changes the current working
+    /// directory of the calling process to the directory specified
     /// by an open file descriptor `fd`.
     ///
     /// ### Arguments
@@ -2207,8 +2207,8 @@ impl Cage {
         let path_string = match &*unlocked_fd {
             Some(File(normalfile_filedesc_obj)) => {
                 let inodenum = normalfile_filedesc_obj.inode;
-                //`pathnamefrominodenum` resolves the absolute path of a directory 
-                //from its inode and returns None in case any of the path components 
+                //`pathnamefrominodenum` resolves the absolute path of a directory
+                //from its inode and returns None in case any of the path components
                 //is not a directory
                 match pathnamefrominodenum(inodenum) {
                     Some(name) => name,
@@ -2240,8 +2240,8 @@ impl Cage {
 
     /// ### Description
     ///
-    /// The `chdir_syscall()` function changes the current working 
-    /// directory of the calling process to the directory specified 
+    /// The `chdir_syscall()` function changes the current working
+    /// directory of the calling process to the directory specified
     /// in `path`, which can be an absolute or a relative pathname.
     ///
     /// ### Arguments
@@ -2285,7 +2285,8 @@ impl Cage {
         if let Some(inodenum) = metawalk(&truepath) {
             //A sanity check to make sure that the last component of the
             //specified path is indeed a directory
-            if let Inode::Dir(ref mut _dir) = *(FS_METADATA.inodetable.get_mut(&inodenum).unwrap()) {
+            if let Inode::Dir(ref mut _dir) = *(FS_METADATA.inodetable.get_mut(&inodenum).unwrap())
+            {
                 //Obtain the write lock on the current working directory of the cage
                 //and change it to the new directory
                 let mut cwd_container = self.cwd.write();

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2233,7 +2233,7 @@ impl Cage {
         //Obtain the write lock on the current working directory of the cage
         //and change it to the new directory
         let mut cwd_container = self.cwd.write();
-        *cwd_container = interface::RustRfc::new(convpath(path_string.as_str()));
+        *cwd_container = interface::RustRfc::new(normpath(convpath(path_string.as_str()), self));
 
         0 // fchdir success
     }
@@ -2285,7 +2285,7 @@ impl Cage {
         if let Some(inodenum) = metawalk(&truepath) {
             //A sanity check to make sure that the last component of the
             //specified path is indeed a directory
-            if let Inode::Dir(ref mut dir) = *(FS_METADATA.inodetable.get_mut(&inodenum).unwrap()) {
+            if let Inode::Dir(ref mut _dir) = *(FS_METADATA.inodetable.get_mut(&inodenum).unwrap()) {
                 //Obtain the write lock on the current working directory of the cage
                 //and change it to the new directory
                 let mut cwd_container = self.cwd.write();

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2428,6 +2428,7 @@ impl Cage {
         //Finally, if it does not correspond to any file type, we return `Invalid file
         //descriptor` error.
         let path_string = match &*unlocked_fd {
+            None => return syscall_error(Errno::EBADF, "fchdir", "invalid file descriptor"),
             Some(File(normalfile_filedesc_obj)) => {
                 let inodenum = normalfile_filedesc_obj.inode;
                 //`pathnamefrominodenum` resolves the absolute path of a directory
@@ -2450,8 +2451,7 @@ impl Cage {
                     "fchdir",
                     "the file descriptor does not refer to a directory",
                 )
-            }
-            None => return syscall_error(Errno::EBADF, "fchdir", "invalid file descriptor"),
+            },
         };
         //Obtain the write lock on the current working directory of the cage
         //and change it to the new directory

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2423,7 +2423,7 @@ impl Cage {
         //If a table descriptor entry corresponds to a file, we check if it is
         //a directory file type. If it is not, we return `A component of path is
         //not a directory` error.
-        //If it is one of the special file types, wwe return `Cannot change working
+        //If it is one of the special file types, we return `Cannot change working
         //directory on this file descriptor` error.
         //Finally, if it does not correspond to any file type, we return `Invalid file
         //descriptor` error.

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2178,8 +2178,8 @@ impl Cage {
     ///
     /// ### Errors
     ///
-    /// * `ENOTDIR` - a component of `path` is not a directory.
     /// * `EBADF` - fd is not a valid file descriptor.
+    /// * `ENOTDIR` - the open file descriptor fildes does not refer to a directory.
     /// Other errors, like `EACCES`, `ENOMEM`, etc. are not supported.
     ///
     /// ### Panics
@@ -2277,9 +2277,11 @@ impl Cage {
         //Perfrom a walk down the file tree starting from the root directory to
         //obtain an inode number of the file whose pathname was specified.
         //`None` is returned if one of the following occurs while moving down
-        //the tree: accessing a child of a non-directory inode, accessing a
-        //child of a nonexistent parent directory, accessing a nonexistent child,
-        //accessing an unexpected component, like `.` or `..` directory reference.
+        //the tree: 
+        //1. Accessing a child of a non-directory inode 
+        //2. Accessing a child of a nonexistent parent directory
+        //3. Accessing a nonexistent child
+        //4. Accessing an unexpected component, like `.` or `..` directory reference.
         //In this case, `The file does not exist` error is returned.
         //Otherwise, a `Some()` option containing the inode number is returned.
         if let Some(inodenum) = metawalk(&truepath) {

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2195,7 +2195,37 @@ impl Cage {
         0 // fchdir success
     }
 
-    //------------------------------------CHDIR SYSCALL------------------------------------
+    /// ### Description
+    ///
+    /// The `chdir_syscall()` function changes the current working 
+    /// directory of the calling process to the directory specified 
+    /// in `path`, which can be an absolute or a relative pathname.
+    ///
+    /// ### Arguments
+    ///
+    /// The `chdir_syscall()` accepts one argument:
+    /// * `path` - the pathname, to which the current working
+    /// directory shall be changed.
+    ///
+    /// ### Returns
+    ///
+    /// Upon successful completion, zero is returned.
+    /// In case of a failure, an error is returned, and `errno` is set depending
+    /// on the error, e.g. EACCES, ENOENT, etc.
+    ///
+    /// ### Errors
+    ///
+    /// * `ENOTDIR` - a component of `path` is not a directory.
+    /// * `ENOENT` - the directory specified in path does not exist.
+    /// Other errors, like `EACCES`, `ENOMEM`, etc. are not supported.
+    ///
+    /// ### Panics
+    ///
+    /// The function panics when the previous working directory does not 
+    /// exist or does not have the directory file type flag.
+    ///
+    /// To learn more about the syscall and possible error values, see
+    /// [chdir(2)](https://man7.org/linux/man-pages/man2/chdir.2.html)
 
     pub fn chdir_syscall(&self, path: &str) -> i32 {
         let truepath = normpath(convpath(path), self);

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2158,15 +2158,58 @@ impl Cage {
         }
     }
 
-    //------------------------------------FCHDIR SYSCALL------------------------------------
+    /// ### Description
+    ///
+    /// The `fchdir_syscall()` function changes the current working 
+    /// directory of the calling process to the directory specified 
+    /// by an open file descriptor `fd`.
+    ///
+    /// ### Arguments
+    ///
+    /// The `fchdir_syscall()` accepts one argument:
+    /// * `fd` - an open file descriptor that specifies the directory
+    /// to which we want to change the current working directory.
+    ///
+    /// ### Returns
+    ///
+    /// Upon successful completion, zero is returned.
+    /// In case of a failure, an error is returned, and `errno` is set depending
+    /// on the error, e.g. `ENOTDIR`, `EBADF`, etc.
+    ///
+    /// ### Errors
+    ///
+    /// * `ENOTDIR` - a component of `path` is not a directory.
+    /// * `EBADF` - fd is not a valid file descriptor.
+    /// Other errors, like `EACCES`, `ENOMEM`, etc. are not supported.
+    ///
+    /// ### Panics
+    ///
+    /// * invalid or out-of-bounds file descriptor, calling unwrap() on which
+    /// causes a panic.
+    ///
+    /// To learn more about the syscall and possible error values, see
+    /// [fchdir(2)](https://linux.die.net/man/2/fchdir)
 
     pub fn fchdir_syscall(&self, fd: i32) -> i32 {
+        //BUG
+        //if the provided file descriptor is out of bounds, get_filedescriptor returns
+        //Err(), unwrapping on which  produces a 'panic!'
+        //otherwise, file descriptor table entry is stored in 'checkedfd'
         let checkedfd = self.get_filedescriptor(fd).unwrap();
         let unlocked_fd = checkedfd.read();
-
+        //If a table descriptor entry corresponds to a file, we check if it is
+        //a directory file type. If it is not, we return `A component of path is
+        //not a directory` error.
+        //If it is one of the special file types, wwe return `Cannot change working
+        //directory on this file descriptor` error.
+        //Finally, if it does not correspond to any file type, we return `Invalid file
+        //descriptor` error.
         let path_string = match &*unlocked_fd {
             Some(File(normalfile_filedesc_obj)) => {
                 let inodenum = normalfile_filedesc_obj.inode;
+                //`pathnamefrominodenum` resolves the absolute path of a directory 
+                //from its inode and returns None in case any of the path components 
+                //is not a directory
                 match pathnamefrominodenum(inodenum) {
                     Some(name) => name,
                     None => {
@@ -2180,16 +2223,16 @@ impl Cage {
             }
             Some(_) => {
                 return syscall_error(
-                    Errno::EACCES,
+                    Errno::ENOTDIR,
                     "fchdir",
-                    "cannot change working directory on this file descriptor",
+                    "the file descriptor does not refer to a directory",
                 )
             }
             None => return syscall_error(Errno::EBADF, "fchdir", "invalid file descriptor"),
         };
-
+        //Obtain the write lock on the current working directory of the cage
+        //and change it to the new directory
         let mut cwd_container = self.cwd.write();
-
         *cwd_container = interface::RustRfc::new(convpath(path_string.as_str()));
 
         0 // fchdir success
@@ -2221,20 +2264,33 @@ impl Cage {
     ///
     /// ### Panics
     ///
-    /// The function panics when the previous working directory does not 
-    /// exist or does not have the directory file type flag.
+    /// * when the previous working directory does not exist or does not
+    /// have the directory file type flag, the function panics
     ///
     /// To learn more about the syscall and possible error values, see
     /// [chdir(2)](https://man7.org/linux/man-pages/man2/chdir.2.html)
 
     pub fn chdir_syscall(&self, path: &str) -> i32 {
+        //Convert the provided pathname into an absolute path without `.` or `..`
+        //components.
         let truepath = normpath(convpath(path), self);
-        //Walk the file tree to get inode from path
+        //Perfrom a walk down the file tree starting from the root directory to
+        //obtain an inode number of the file whose pathname was specified.
+        //`None` is returned if one of the following occurs while moving down
+        //the tree: accessing a child of a non-directory inode, accessing a
+        //child of a nonexistent parent directory, accessing a nonexistent child,
+        //accessing an unexpected component, like `.` or `..` directory reference.
+        //In this case, `The file does not exist` error is returned.
+        //Otherwise, a `Some()` option containing the inode number is returned.
         if let Some(inodenum) = metawalk(&truepath) {
+            //A sanity check to make sure that the last component of the
+            //specified path is indeed a directory
             if let Inode::Dir(ref mut dir) = *(FS_METADATA.inodetable.get_mut(&inodenum).unwrap()) {
-                //increment refcount of new cwd inode to ensure that you can't remove a
-                // directory while it is the cwd of a cage
-                dir.refcount += 1;
+                //Obtain the write lock on the current working directory of the cage
+                //and change it to the new directory
+                let mut cwd_container = self.cwd.write();
+                *cwd_container = interface::RustRfc::new(truepath);
+                0 //chdir has succeeded!;
             } else {
                 return syscall_error(
                     Errno::ENOTDIR,
@@ -2249,15 +2305,6 @@ impl Cage {
                 "the directory referred to in path does not exist",
             );
         }
-        //at this point, syscall isn't an error
-        let mut cwd_container = self.cwd.write();
-
-        //decrement refcount of previous cwd's inode, to allow it to be removed if no
-        // cage has it as cwd
-        decref_dir(&*cwd_container);
-
-        *cwd_container = interface::RustRfc::new(truepath);
-        0 //chdir has succeeded!;
     }
 
     //------------------------------------DUP & DUP2 SYSCALLS------------------------------------

--- a/src/safeposix/syscalls/sys_calls.rs
+++ b/src/safeposix/syscalls/sys_calls.rs
@@ -39,7 +39,7 @@ use super::net_constants::*;
 use super::sys_constants::*;
 use crate::interface;
 use crate::safeposix::cage::{FileDescriptor::*, *};
-use crate::safeposix::filesystem::{decref_dir, metawalk, Inode, FS_METADATA};
+use crate::safeposix::filesystem::{metawalk, Inode, FS_METADATA};
 use crate::safeposix::net::NET_METADATA;
 use crate::safeposix::shm::SHM_METADATA;
 
@@ -482,7 +482,6 @@ impl Cage {
 
         //get file descriptor table into a vector
         let cwd_container = self.cwd.read();
-        decref_dir(&*cwd_container);
 
         //may not be removable in case of lindrustfinalize, we don't unwrap the remove
         // result

--- a/src/safeposix/syscalls/sys_calls.rs
+++ b/src/safeposix/syscalls/sys_calls.rs
@@ -43,8 +43,6 @@ use crate::safeposix::filesystem::{metawalk, Inode, FS_METADATA};
 use crate::safeposix::net::NET_METADATA;
 use crate::safeposix::shm::SHM_METADATA;
 
-
-
 impl Cage {
     fn unmap_shm_mappings(&self) {
         //unmap shm mappings on exit or exec
@@ -72,60 +70,67 @@ impl Cage {
     }
 
     /// ### Description
-    /// 
+    ///
     ///'fork_syscall` creates a new process (cage object)
-    /// The newly created child process is an exact copy of the 
-    /// parent process (the process that calls fork) 
+    /// The newly created child process is an exact copy of the
+    /// parent process (the process that calls fork)
     /// apart from it's cage_id and the parent_id
-    /// In this function we clone the mutex table, condition variables table, 
-    /// semaphore table and the file descriptors and create 
-    /// a new Cage object with these cloned tables. 
-    /// We also update the shared memory mappings - and create mappings 
-    /// from the new Cage object the the 
-    /// parent Cage object's memory mappings. 
-    /// 
+    /// In this function we clone the mutex table, condition variables table,
+    /// semaphore table and the file descriptors and create
+    /// a new Cage object with these cloned tables.
+    /// We also update the shared memory mappings - and create mappings
+    /// from the new Cage object the the
+    /// parent Cage object's memory mappings.
+    ///
     /// ### Arguments
-    /// 
+    ///
     /// It accepts one parameter:
-    /// 
+    ///
     /// * `child_cageid` : an integer representing the pid of the child process
-    /// 
+    ///
     /// ### Errors
     ///    
-    /// There are 2 scenarios where the call to `fork_syscall` might return an error
-    /// 
+    /// There are 2 scenarios where the call to `fork_syscall` might return an
+    /// error
+    ///
     /// * When the RawMutex::create() call fails to create a new Mutex object
-    /// * When the RawCondvar::create() call fails to create a new Condition Variable object
-    /// 
+    /// * When the RawCondvar::create() call fails to create a new Condition
+    ///   Variable object
+    ///
     /// ### Returns
-    /// 
-    /// On success it returns a value of 0, and the new child Cage object is added to Cagetable
-    /// 
-    /// ### Panics 
-    /// 
+    ///
+    /// On success it returns a value of 0, and the new child Cage object is
+    /// added to Cagetable
+    ///
+    /// ### Panics
+    ///
     /// This system call has no scenarios where it panics
-    /// 
+    ///
     /// To learn more about the syscall and possible error values, see
-    /// [fork(2)](https://man7.org/linux/man-pages/man2/fork.2.html) 
+    /// [fork(2)](https://man7.org/linux/man-pages/man2/fork.2.html)
 
     pub fn fork_syscall(&self, child_cageid: u64) -> i32 {
-        //Create a new mutex table that replicates the mutex table of the parent (calling) Cage object
-        //Since the child process inherits all the locks that the parent process holds,
+        //Create a new mutex table that replicates the mutex table of the parent
+        // (calling) Cage object Since the child process inherits all the locks
+        // that the parent process holds,
         let mutextable = self.mutex_table.read();
         // Initialize the child object's mutex table
         let mut new_mutex_table = vec![];
         //Loop through each element in the mutex table
-        //Each entry in the mutex table represents a `lock` which the parent process holds
-        //Copying them into the child's Cage exhibits the inheritance of the lock 
+        //Each entry in the mutex table represents a `lock` which the parent process
+        // holds Copying them into the child's Cage exhibits the inheritance of
+        // the lock
         for elem in mutextable.iter() {
             if elem.is_some() {
-                //If the mutex is `Some` - we create a new mutex and store it in the child's mutex table
-                //The create method returns a new struct obejct that represents a Mutex
+                //If the mutex is `Some` - we create a new mutex and store it in the child's
+                // mutex table The create method returns a new struct obejct
+                // that represents a Mutex
                 let new_mutex_result = interface::RawMutex::create();
                 match new_mutex_result {
                     // If the mutex creation is successful we push it on the child's table
                     Ok(new_mutex) => new_mutex_table.push(Some(interface::RustRfc::new(new_mutex))),
-                    // If the mutex creation returns an error, we abort the system call and return the appropriate error
+                    // If the mutex creation returns an error, we abort the system call and return
+                    // the appropriate error
                     Err(_) => {
                         match Errno::from_discriminant(interface::get_errno()) {
                             Ok(i) => {
@@ -142,17 +147,19 @@ impl Cage {
                     }
                 }
             } else {
-                // If the mutex is `None` - we mimic the same behavior in the child's mutex table
+                // If the mutex is `None` - we mimic the same behavior in the child's mutex
+                // table
                 new_mutex_table.push(None);
             }
         }
         drop(mutextable);
 
         //Construct a replica of the condition variables table in the child cage object
-        //This table stores condition variables - which are special variables that the process
-        //uses to determine whether certain conditions have been met or not. Threads use condition variables
-        //to stop or resume their operation depending on the value of these variables.  
-        //Read the CondVar table of the calling process
+        //This table stores condition variables - which are special variables that the
+        // process uses to determine whether certain conditions have been met or
+        // not. Threads use condition variables to stop or resume their
+        // operation depending on the value of these variables. Read the CondVar
+        // table of the calling process
         let cvtable = self.cv_table.read();
         // Initialize the table for the child process
         let mut new_cv_table = vec![];
@@ -160,10 +167,12 @@ impl Cage {
         for elem in cvtable.iter() {
             if elem.is_some() {
                 //Create a condvar to store in the child's Cage object
-                //Returns the condition variable struct object which implements theb signal, wait, broadcast and timed_wait methods
+                //Returns the condition variable struct object which implements theb signal,
+                // wait, broadcast and timed_wait methods
                 let new_cv_result = interface::RawCondvar::create();
                 match new_cv_result {
-                    // If the result of the creation of the RawCondVar is successful - push it onto the child's mutex table
+                    // If the result of the creation of the RawCondVar is successful - push it onto
+                    // the child's mutex table
                     Ok(new_cv) => new_cv_table.push(Some(interface::RustRfc::new(new_cv))),
                     // If the creation was unsucessful - return an Error
                     Err(_) => {
@@ -182,15 +191,16 @@ impl Cage {
                     }
                 }
             } else {
-                // If the value is None - mimic the behavior in the child's condition variable table
+                // If the value is None - mimic the behavior in the child's condition variable
+                // table
                 new_cv_table.push(None);
             }
         }
         drop(cvtable);
 
         //Clone the file descriptor table in the child's Cage object
-        //Each entry in the file descriptor table points to an open file description which
-        //in turn references the actual inodes of the files on disk
+        //Each entry in the file descriptor table points to an open file description
+        // which in turn references the actual inodes of the files on disk
         let newfdtable = init_fdtable();
         //Loop from 0 to maximum value of file descriptor index
         for fd in 0..MAXFD {
@@ -211,8 +221,9 @@ impl Cage {
                         if let Some(inodenum) = inodenum_option {
                             let mut inode = FS_METADATA.inodetable.get_mut(&inodenum).unwrap();
                             //Since the child Cage also inherits the parent's fd table
-                            //We increment the reference count on the actual inodes of the files on disk
-                            //Since the child Cage is a new process that also references those files
+                            //We increment the reference count on the actual inodes of the files on
+                            // disk Since the child Cage is a new
+                            // process that also references those files
                             match *inode {
                                 Inode::File(ref mut f) => {
                                     f.refcount += 1;
@@ -239,13 +250,14 @@ impl Cage {
                         let sock_tmp = socket_filedesc_obj.handle.clone();
                         let mut sockhandle = sock_tmp.write();
                         let socket_type = sockhandle.domain;
-                        //Here we only increment the reference for AF_UNIX socket type 
+                        //Here we only increment the reference for AF_UNIX socket type
                         //Since these are the only sockets that have an inode associated with them
                         if socket_type == AF_UNIX {
                             //Increment the appropriate reference counter of the correct socket
-                            //Each socket has two pipes associated with them - a read and write pipe 
-                            //Here we grab these two pipes and increment their references individually
-                            //And also increment the reference count of the socket as a whole
+                            //Each socket has two pipes associated with them - a read and write
+                            // pipe Here we grab these two pipes and
+                            // increment their references individually
+                            // And also increment the reference count of the socket as a whole
                             if let Some(sockinfo) = &sockhandle.unix_info {
                                 if let Some(sendpipe) = sockinfo.sendpipe.as_ref() {
                                     sendpipe.incr_ref(O_WRONLY);
@@ -255,9 +267,9 @@ impl Cage {
                                 }
                                 if let Inode::Socket(ref mut sock) =
                                     *(FS_METADATA.inodetable.get_mut(&sockinfo.inode).unwrap())
-                                    {
-                                        sock.refcount += 1;
-                                    }
+                                {
+                                    sock.refcount += 1;
+                                }
                             }
                         }
                         drop(sockhandle);
@@ -268,17 +280,16 @@ impl Cage {
                 let newfdobj = filedesc_enum.clone();
                 // Insert the file descriptor object into the new file descriptor table
                 let _insertval = newfdtable[fd as usize].write().insert(newfdobj);
-                
             }
         }
 
         //We read the current working directory of the parent Cage object
         let cwd_container = self.cwd.read();
-        //We try to resolve the inode of the current working directory - if the 
-        //resolution is successful we update the reference count of the current working directory
-        //since the newly created Child cage object also references the same directory
-        //If the resolution is not successful - the code panics since the cwd's inode cannot be resolved
-        //correctly
+        //We try to resolve the inode of the current working directory - if the
+        //resolution is successful we update the reference count of the current working
+        // directory since the newly created Child cage object also references
+        // the same directory If the resolution is not successful - the code
+        // panics since the cwd's inode cannot be resolved correctly
         if let Some(cwdinodenum) = metawalk(&cwd_container) {
             if let Inode::Dir(ref mut cwddir) =
                 *(FS_METADATA.inodetable.get_mut(&cwdinodenum).unwrap())
@@ -291,16 +302,17 @@ impl Cage {
             panic!("We changed from a directory that was not a directory in chdir!");
         }
 
-        // We clone the parent cage's main threads and store them and index 0 
-        // This is done since there isn't a thread established for the child Cage object yet - 
-        // And there is no threadId to store it at. 
-        // The child Cage object can then initialize and store the sigset appropriately when it establishes its own 
-        // main thread id.
+        // We clone the parent cage's main threads and store them and index 0
+        // This is done since there isn't a thread established for the child Cage object
+        // yet - And there is no threadId to store it at.
+        // The child Cage object can then initialize and store the sigset appropriately
+        // when it establishes its own main thread id.
         let newsigset = interface::RustHashMap::new();
         // Here we check if Lind is being run under the test suite or not
         if !interface::RUSTPOSIX_TESTSUITE.load(interface::RustAtomicOrdering::Relaxed) {
-            // When rustposix runs independently (not as Lind paired with NaCL runtime) we do not handle signals
-            // The test suite runs rustposix independently and hence we do not handle signals for the test suite
+            // When rustposix runs independently (not as Lind paired with NaCL runtime) we
+            // do not handle signals The test suite runs rustposix independently
+            // and hence we do not handle signals for the test suite
             let mainsigsetatomic = self
                 .sigset
                 .get(
@@ -316,20 +328,22 @@ impl Cage {
             newsigset.insert(0, mainsigset);
         }
 
-        // Construct a new semaphore table in child cage which equals to the one in the parent cage 
+        // Construct a new semaphore table in child cage which equals to the one in the
+        // parent cage
         let semtable = &self.sem_table;
         let new_semtable: interface::RustHashMap<
             u32,
             interface::RustRfc<interface::RustSemaphore>,
         > = interface::RustHashMap::new();
-        // Loop all pairs of semaphores and insert their copies into the new semaphore table
-        // Each pair consists of a key which is 32 bit unsigned integer
+        // Loop all pairs of semaphores and insert their copies into the new semaphore
+        // table Each pair consists of a key which is 32 bit unsigned integer
         // And a Semaphore Object implemented as RustSemaphore
         for pair in semtable.iter() {
             new_semtable.insert((*pair.key()).clone(), pair.value().clone());
         }
 
-        // Create a new cage object using the cloned tables and the child id passed as a parameter
+        // Create a new cage object using the cloned tables and the child id passed as a
+        // parameter
         let cageobj = Cage {
             cageid: child_cageid,
             cwd: interface::RustLock::new(self.cwd.read().clone()),

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -371,6 +371,27 @@ pub mod fs_tests {
     }
 
     #[test]
+    pub fn ut_lind_fs_chdir_removeddir() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        //testing the ability to make and change to directories
+
+        assert_eq!(cage.mkdir_syscall("/subdir1", S_IRWXA), 0);
+        assert_eq!(cage.mkdir_syscall("/subdir2", S_IRWXA), 0);
+        assert_eq!(cage.chdir_syscall("subdir1"), 0);
+        assert_eq!(cage.rmdir_syscall("/subdir1"), 0);
+        assert_eq!(cage.chdir_syscall("/subdir2"), 0);
+        //assert_eq!(cage.chdir_syscall("subdir1"), 0);
+
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    #[test]
     pub fn ut_lind_fs_dir_mode() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -356,6 +356,9 @@ pub mod fs_tests {
         assert_eq!(cage.mkdir_syscall("/subdir1", S_IRWXA), 0);
         assert_eq!(cage.mkdir_syscall("/subdir1/subdir2", S_IRWXA), 0);
 
+        //Changing to a new current working directory, and then obtaining 
+        //the current working directory using `getcwd_syscall()` to see
+        //if it was correctly changed
         assert_eq!(cage.chdir_syscall("subdir1"), 0);
         let mut buf1 = vec![0u8; 9];
         let bufptr1: *mut u8 = &mut buf1[0];
@@ -404,7 +407,7 @@ pub mod fs_tests {
 
         let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
         let filepath = "/TestFile1";
-        let fd1 = cage.open_syscall(filepath, flags, 0);
+        let _fd1 = cage.open_syscall(filepath, flags, 0);
 
         //Checking if passing a regular file pathname correctly
         //returns `The last component in path is not a directory` error
@@ -438,6 +441,9 @@ pub mod fs_tests {
         let fd1 = cage.open_syscall("/subdir1", O_RDWR, S_IRWXA);
         let fd2 = cage.open_syscall("/subdir1/subdir2", O_RDWR, S_IRWXA);
 
+        //Changing to a new current working directory, and then obtaining 
+        //the current working directory using `getcwd_syscall()` to see
+        //if it was correctly changed
         assert_eq!(cage.access_syscall("subdir1", F_OK), 0);
         assert_eq!(cage.fchdir_syscall(fd1), 0);
         let mut buf1 = vec![0u8; 9];

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -356,7 +356,7 @@ pub mod fs_tests {
         assert_eq!(cage.mkdir_syscall("/subdir1", S_IRWXA), 0);
         assert_eq!(cage.mkdir_syscall("/subdir1/subdir2", S_IRWXA), 0);
 
-        //Changing to a new current working directory, and then obtaining 
+        //Changing to a new current working directory, and then obtaining
         //the current working directory using `getcwd_syscall()` to see
         //if it was correctly changed
         assert_eq!(cage.chdir_syscall("subdir1"), 0);
@@ -417,7 +417,10 @@ pub mod fs_tests {
         //returns `The directory referred to in path does not exist` error.
         //`/arbitrarypath` is a pathname that does not correspond to any existing
         //directory pathname.
-        assert_eq!(cage.chdir_syscall("/arbitrarypath"), -(Errno::ENOENT as i32));
+        assert_eq!(
+            cage.chdir_syscall("/arbitrarypath"),
+            -(Errno::ENOENT as i32)
+        );
 
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
@@ -441,7 +444,7 @@ pub mod fs_tests {
         let fd1 = cage.open_syscall("/subdir1", O_RDWR, S_IRWXA);
         let fd2 = cage.open_syscall("/subdir1/subdir2", O_RDWR, S_IRWXA);
 
-        //Changing to a new current working directory, and then obtaining 
+        //Changing to a new current working directory, and then obtaining
         //the current working directory using `getcwd_syscall()` to see
         //if it was correctly changed
         assert_eq!(cage.access_syscall("subdir1", F_OK), 0);

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -343,28 +343,31 @@ pub mod fs_tests {
     }
 
     #[test]
-    pub fn ut_lind_fs_dir_chdir() {
+    pub fn ut_lind_fs_chdir_valid_args() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup
         let _thelock = setup::lock_and_init();
 
         let cage = interface::cagetable_getref(1);
 
-        //testing the ability to make and change to directories
+        //Testing the ability to make and change to directories
+        //using absolute and relative and `..` reference
 
         assert_eq!(cage.mkdir_syscall("/subdir1", S_IRWXA), 0);
         assert_eq!(cage.mkdir_syscall("/subdir1/subdir2", S_IRWXA), 0);
-        assert_eq!(cage.mkdir_syscall("/subdir1/subdir2/subdir3", 0), 0);
 
-        assert_eq!(cage.access_syscall("subdir1", F_OK), 0);
         assert_eq!(cage.chdir_syscall("subdir1"), 0);
+        let mut buf1 = vec![0u8; 9];
+        let bufptr1: *mut u8 = &mut buf1[0];
+        assert_eq!(cage.getcwd_syscall(bufptr1, 9), 0);
+        assert_eq!(std::str::from_utf8(&buf1).unwrap(), "/subdir1\0");
 
-        assert_eq!(cage.access_syscall("subdir2", F_OK), 0);
+        assert_eq!(cage.chdir_syscall("/subdir1/subdir2"), 0);
         assert_eq!(cage.chdir_syscall(".."), 0);
-
-        assert_eq!(cage.access_syscall("subdir1", F_OK), 0);
-        assert_eq!(cage.chdir_syscall("/subdir1/subdir2/subdir3"), 0);
-        assert_eq!(cage.access_syscall("../../../subdir1", F_OK), 0);
+        let mut buf1 = vec![0u8; 9];
+        let bufptr1: *mut u8 = &mut buf1[0];
+        assert_eq!(cage.getcwd_syscall(bufptr1, 9), 0);
+        assert_eq!(std::str::from_utf8(&buf1).unwrap(), "/subdir1\0");
 
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
@@ -378,14 +381,104 @@ pub mod fs_tests {
 
         let cage = interface::cagetable_getref(1);
 
-        //testing the ability to make and change to directories
-
+        //Checking if removing the current working directory
+        //works correctly
         assert_eq!(cage.mkdir_syscall("/subdir1", S_IRWXA), 0);
         assert_eq!(cage.mkdir_syscall("/subdir2", S_IRWXA), 0);
         assert_eq!(cage.chdir_syscall("subdir1"), 0);
         assert_eq!(cage.rmdir_syscall("/subdir1"), 0);
         assert_eq!(cage.chdir_syscall("/subdir2"), 0);
-        //assert_eq!(cage.chdir_syscall("subdir1"), 0);
+        assert_eq!(cage.chdir_syscall("subdir1"), -(Errno::ENOENT as i32));
+
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    #[test]
+    pub fn ut_lind_fs_chdir_invalid_args() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        //and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
+        let filepath = "/TestFile1";
+        let fd1 = cage.open_syscall(filepath, flags, 0);
+
+        //Checking if passing a regular file pathname correctly
+        //returns `The last component in path is not a directory` error
+        assert_eq!(cage.chdir_syscall("/TestFile1"), -(Errno::ENOTDIR as i32));
+
+        //Checking if a nonexistent pathname correctly
+        //returns `The directory referred to in path does not exist` error.
+        //`/arbitrarypath` is a pathname that does not correspond to any existing
+        //directory pathname.
+        assert_eq!(cage.chdir_syscall("/arbitrarypath"), -(Errno::ENOENT as i32));
+
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    #[test]
+    pub fn ut_lind_fs_fchdir_valid_args() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        //Testing the ability to make and change to directories
+        //using file descriptors
+
+        assert_eq!(cage.mkdir_syscall("/subdir1", S_IRWXA), 0);
+        assert_eq!(cage.mkdir_syscall("/subdir1/subdir2", S_IRWXA), 0);
+
+        //Retrieving a valid directory file descriptor
+        let fd1 = cage.open_syscall("/subdir1", O_RDWR, S_IRWXA);
+        let fd2 = cage.open_syscall("/subdir1/subdir2", O_RDWR, S_IRWXA);
+
+        assert_eq!(cage.access_syscall("subdir1", F_OK), 0);
+        assert_eq!(cage.fchdir_syscall(fd1), 0);
+        let mut buf1 = vec![0u8; 9];
+        let bufptr1: *mut u8 = &mut buf1[0];
+        assert_eq!(cage.getcwd_syscall(bufptr1, 9), 0);
+        assert_eq!(std::str::from_utf8(&buf1).unwrap(), "/subdir1\0");
+
+        assert_eq!(cage.access_syscall("subdir2", F_OK), 0);
+        assert_eq!(cage.fchdir_syscall(fd2), 0);
+        let mut buf2 = vec![0u8; 17];
+        let bufptr2: *mut u8 = &mut buf2[0];
+        assert_eq!(cage.getcwd_syscall(bufptr2, 17), 0);
+        assert_eq!(std::str::from_utf8(&buf2).unwrap(), "/subdir1/subdir2\0");
+
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    #[test]
+    pub fn ut_lind_fs_fchdir_invalid_args() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        //and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
+        let filepath = "/TestFile1";
+        let fd1 = cage.open_syscall(filepath, flags, 0);
+
+        //Checking if passing a regular file descriptor correctly
+        //returns `The last component in path is not a directory` error
+        assert_eq!(cage.fchdir_syscall(fd1), -(Errno::ENOTDIR as i32));
+
+        //Checking if passing an invalid file descriptor correctly
+        //results in `Invalid file descriptor` error
+        //Since the file corresponding to file descriptor `fd1` is closed,
+        //and no other file is opened after that, `fd1` file descriptor
+        //should be invalid
+        assert_eq!(cage.close_syscall(fd1), 0);
+        assert_eq!(cage.fchdir_syscall(fd1), -(Errno::EBADF as i32));
 
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();


### PR DESCRIPTION
## Description

Fixes # (issue)

The following changes more elaborate comments and new unit tests for `chdir_syscall()` and `fchdir_syscall()`.

### Type of change

- [ ] More detailed comments for `chdir_syscall()` and `fchdir_syscall()`.
- [ ] New unit tests for `chdir_syscall()` and `fchdir_syscall()`.
- [ ] Removal of incrementing/decrementing refcount for cwd to allow the complete removal of cwd from the filesystem

## How Has This Been Tested?

To run the tests, we need to run cargo test --lib command inside the safeposix-rust directory.

All the tests are present under this directory: lind_project/src/safeposix-rust/src/tests/fs_tests.rs

- Test A - `ut_lind_fs_chdir_valid_args()`
- Test B - `ut_lind_fs_chdir_removeddir()`
- Test C - `ut_lind_fs_chdir_invalid_args()`
- Test D - `ut_lind_fs_fchdir_valid_args()`
- Test E - `ut_lind_fs_fchdir_invalid_args()`

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)

