### PR TITLE
mmap_syscall() and munmap_syscall() updates

### DIFF
--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -1098,9 +1098,9 @@ impl Cage {
     /// truncating an existing one by combining the O_CREAT, O_TRUNC, and
     /// O_WRONLY flags.
     /// There are generally two cases which occur when this syscall happens:
-    /// Case 1: If the file to be opened doesn't exist, then due to O_CREAT flag,
-    /// a new file is created at the given location and a new file descriptor is
-    /// created and returned.
+    /// Case 1: If the file to be opened doesn't exist, then due to O_CREAT
+    /// flag, a new file is created at the given location and a new file
+    /// descriptor is created and returned.
     /// Case 2: If the file already exists, then due to O_TRUNC flag, the file
     /// size gets reduced to 0, and the existing file descriptor is returned.
     ///
@@ -2235,27 +2235,34 @@ impl Cage {
     ///
     /// ### Description
     /// This function duplicates a file descriptor. It creates a new file
-    /// descriptor that refers to the same open file description as the original file descriptor.
-    /// * Finding the Next Available File Descriptor: If `start_desc` is provided and it is already in use, the function
-    ///   will continue searching for the next available file descriptor starting from `start_desc`. If no file
-    ///   descriptors are available, it will return an error (`ENFILE`).
-    /// * If `fd` is equal to `start_fd`, the function returns `start_fd` as the new file
-    ///   descriptor. This is because in this scenario, the original and new file descriptors would point to the same
-    ///   file description.
-    /// * The `_dup2_helper` function is called to perform the actual file descriptor duplication, handling the
-    ///   allocation of a new file descriptor, updating the file descriptor table, and incrementing the reference count
-    ///   of the file object.
-    /// * The function modifies the global `filedescriptortable` array, adding a new entry for the
-    ///   duplicated file descriptor. It also increments the reference count of the file object associated with the
-    ///   original file descriptor.
-    /// * The `false` argument passed to `_dup2_helper` indicates that this call is from the `dup_syscall` function,
-    ///   not the `dup2_syscall` function.
+    /// descriptor that refers to the same open file description as the original
+    /// file descriptor.
+    /// * Finding the Next Available File Descriptor: If `start_desc` is
+    ///   provided and it is already in use, the function will continue
+    ///   searching for the next available file descriptor starting from
+    ///   `start_desc`. If no file descriptors are available, it will return an
+    ///   error (`ENFILE`).
+    /// * If `fd` is equal to `start_fd`, the function returns `start_fd` as the
+    ///   new file descriptor. This is because in this scenario, the original
+    ///   and new file descriptors would point to the same file description.
+    /// * The `_dup2_helper` function is called to perform the actual file
+    ///   descriptor duplication, handling the allocation of a new file
+    ///   descriptor, updating the file descriptor table, and incrementing the
+    ///   reference count of the file object.
+    /// * The function modifies the global `filedescriptortable` array, adding a
+    ///   new entry for the duplicated file descriptor. It also increments the
+    ///   reference count of the file object associated with the original file
+    ///   descriptor.
+    /// * The `false` argument passed to `_dup2_helper` indicates that this call
+    ///   is from the `dup_syscall` function, not the `dup2_syscall` function.
     ///
     /// ### Function Arguments
     /// * `fd`: The original file descriptor to duplicate.
-    /// * `start_desc`:  An optional starting file descriptor number. If provided, the new file descriptor will be
-    ///  assigned the first available file descriptor number starting from this value. If not provided, it defaults to
-    ///  `STARTINGFD`,which is the minimum designated file descriptor value for new file descriptors.
+    /// * `start_desc`:  An optional starting file descriptor number. If
+    ///   provided, the new file descriptor will be
+    ///  assigned the first available file descriptor number starting from this
+    /// value. If not provided, it defaults to  `STARTINGFD`,which is the
+    /// minimum designated file descriptor value for new file descriptors.
     ///
     /// ### Returns
     /// * The new file descriptor on success.
@@ -2301,27 +2308,33 @@ impl Cage {
     /// ## `dup2_syscall`
     ///
     /// ### Description
-    /// This function implements the `dup2` system call, which duplicates a file descriptor and assigns it to a new file
-    /// descriptor number. If the new file descriptor already exists, it is closed before the duplication takes place.
-    /// * File Descriptor Reuse:  If the new file descriptor (`newfd`) is already open, the function will first close the
-    ///   existing file descriptor silently (without returning an error) before allocating a new file descriptor and
-    ///   updating the file descriptor table.
-    /// * If `oldfd` and `newfd` are the same, the function returns `newfd` without closing it.
-    ///   This is because in this scenario, the original and new file descriptors would already point to the same file
-    ///   description.
+    /// This function implements the `dup2` system call, which duplicates a file
+    /// descriptor and assigns it to a new file descriptor number. If the
+    /// new file descriptor already exists, it is closed before the duplication
+    /// takes place.
+    /// * File Descriptor Reuse:  If the new file descriptor (`newfd`) is
+    ///   already open, the function will first close the existing file
+    ///   descriptor silently (without returning an error) before allocating a
+    ///   new file descriptor and updating the file descriptor table.
+    /// * If `oldfd` and `newfd` are the same, the function returns `newfd`
+    ///   without closing it. This is because in this scenario, the original and
+    ///   new file descriptors would already point to the same file description.
     /// * the global `filedescriptortable` array, replacing the entry for the
-    ///   new file descriptor with a new entry for the duplicated file descriptor. It also increments the reference count of the
-    ///   file object associated with the original file descriptor.
+    ///   new file descriptor with a new entry for the duplicated file
+    ///   descriptor. It also increments the reference count of the file object
+    ///   associated with the original file descriptor.
     ///
     /// ### Function Arguments
     /// * `oldfd`: The original file descriptor to duplicate.
-    /// * `newfd`: The new file descriptor number to assign to the duplicated file descriptor.
+    /// * `newfd`: The new file descriptor number to assign to the duplicated
+    ///   file descriptor.
     ///
     /// ### Returns
     /// * The new file descriptor on success.
     ///
     /// ### Errors
-    /// * `EBADF(9)`: If the original file descriptor (`oldfd`) is invalid or the new file descriptor (`newfd`) number is out of range.
+    /// * `EBADF(9)`: If the original file descriptor (`oldfd`) is invalid or
+    ///   the new file descriptor (`newfd`) number is out of range.
     ///  ###Panics
     /// * There are no panics for this syscall
     ///[dup2(2)](https://linux.die.net/man/2/dup2)
@@ -2359,28 +2372,42 @@ impl Cage {
     /// ## `_dup2_helper`
     ///
     /// ### Description
-    /// This helper function performs the actual file descriptor duplication process for both `dup` and `dup2` system calls.
-    /// It handles the allocation of a new file descriptor, updates the file descriptor table, and increments the reference count of the
-    /// associated file object.
-    /// * Duplication from `dup2_syscall`: If `fromdup2` is true, the function first closes the existing file descriptor
-    ///   at `newfd` (if any) before allocating a new file descriptor and updating the file descriptor table.
-    /// * Duplication from `dup_syscall`: If `fromdup2` is false, the function allocates a new file descriptor, finds the
-    ///   first available file descriptor number starting from `newfd`, and updates the file descriptor table.
-    /// * Reference Counting: The function increments the reference count of the file object associated with the original file
-    ///   descriptor. This ensures that the file object is not deleted until all its associated file descriptors are closed.
-    /// * Socket Handling: For domain sockets, the function increments the reference count of both the send and receive pipes
-    ///   associated with the socket.
+    /// This helper function performs the actual file descriptor duplication
+    /// process for both `dup` and `dup2` system calls. It handles the
+    /// allocation of a new file descriptor, updates the file descriptor table,
+    /// and increments the reference count of the associated file object.
+    /// * Duplication from `dup2_syscall`: If `fromdup2` is true, the function
+    ///   first closes the existing file descriptor at `newfd` (if any) before
+    ///   allocating a new file descriptor and updating the file descriptor
+    ///   table.
+    /// * Duplication from `dup_syscall`: If `fromdup2` is false, the function
+    ///   allocates a new file descriptor, finds the first available file
+    ///   descriptor number starting from `newfd`, and updates the file
+    ///   descriptor table.
+    /// * Reference Counting: The function increments the reference count of the
+    ///   file object associated with the original file descriptor. This ensures
+    ///   that the file object is not deleted until all its associated file
+    ///   descriptors are closed.
+    /// * Socket Handling: For domain sockets, the function increments the
+    ///   reference count of both the send and receive pipes associated with the
+    ///   socket.
     /// * Stream Handling: Streams are not currently supported for duplication
-    /// * Unhandled File Types: If the file descriptor is associated with a file type that is not handled by the function (i.e.,
-    ///   not a File, Pipe, Socket, or Stream), the function returns an error (`EACCES`).
+    /// * Unhandled File Types: If the file descriptor is associated with a file
+    ///   type that is not handled by the function (i.e., not a File, Pipe,
+    ///   Socket, or Stream), the function returns an error (`EACCES`).
     /// * The function does not handle streams.
-    /// * Socket Handling: If the file descriptor is associated with a socket, the function handles domain sockets differently
-    ///   by incrementing the reference count of both the send and receive pipes.
+    /// * Socket Handling: If the file descriptor is associated with a socket,
+    ///   the function handles domain sockets differently by incrementing the
+    ///   reference count of both the send and receive pipes.
     /// ### Function Arguments
-    /// * `self`:  A reference to the `FsCalls` struct, which contains the file descriptor table and other system-related data.
-    /// * `filedesc_enum`: A reference to the `FileDescriptor` object representing the file descriptor to be duplicated.
-    /// * `newfd`: The new file descriptor number to assign to the duplicated file descriptor.
-    /// * `fromdup2`: A boolean flag indicating whether the call is from `dup2_syscall` (true) or `dup_syscall` (false).
+    /// * `self`:  A reference to the `FsCalls` struct, which contains the file
+    ///   descriptor table and other system-related data.
+    /// * `filedesc_enum`: A reference to the `FileDescriptor` object
+    ///   representing the file descriptor to be duplicated.
+    /// * `newfd`: The new file descriptor number to assign to the duplicated
+    ///   file descriptor.
+    /// * `fromdup2`: A boolean flag indicating whether the call is from
+    ///   `dup2_syscall` (true) or `dup_syscall` (false).
     ///
     /// ### Returns
     /// * The new file descriptor on success.
@@ -2389,7 +2416,8 @@ impl Cage {
     /// * `ENFILE(23)`: If there are no available file descriptors.
     /// * `EACCES(13)`: If the file descriptor cannot be duplicated.
     /// ###Panics
-    /// * If the file descriptor is associated with a socket, and the inode does not match the file descriptor.
+    /// * If the file descriptor is associated with a socket, and the inode does
+    ///   not match the file descriptor.
 
     pub fn _dup2_helper(&self, filedesc_enum: &FileDescriptor, newfd: i32, fromdup2: bool) -> i32 {
         let (dupfd, mut dupfdguard) = if fromdup2 {
@@ -2408,8 +2436,9 @@ impl Cage {
         } else {
             let (newdupfd, guardopt) = self.get_next_fd(Some(newfd));
             if newdupfd < 0 {
-                // The function allocates a new file descriptor and updates the file descriptor table,
-                // handling the potential for file descriptor table overflow (resulting in an `ENFILE` error).
+                // The function allocates a new file descriptor and updates the file descriptor
+                // table, handling the potential for file descriptor table
+                // overflow (resulting in an `ENFILE` error).
                 return syscall_error(
                     Errno::ENFILE,
                     "dup2_helper",
@@ -2428,8 +2457,9 @@ impl Cage {
                 //incrementing the ref count so that when close is executed on the dup'd file
                 //the original file does not get a negative ref count
                 match *inodeobj {
-                    // increments the reference count of the file object associated with the original file descriptor
-                    // to ensure that the file object is not deleted until all its associated file descriptors are closed.
+                    // increments the reference count of the file object associated with the
+                    // original file descriptor to ensure that the file object
+                    // is not deleted until all its associated file descriptors are closed.
                     Inode::File(ref mut normalfile_inode_obj) => {
                         normalfile_inode_obj.refcount += 1;
                     }
@@ -2608,12 +2638,12 @@ impl Cage {
                             }
                             if dir_inode_obj.linkcount == 2 && dir_inode_obj.refcount == 0 {
                                 //The reference to the inode has to be dropped to avoid
-                                //deadlocking because the remove() method will need to 
-                                //acquire a reference to the same inode from the 
-                                //filesystem's inodetable. 
+                                //deadlocking because the remove() method will need to
+                                //acquire a reference to the same inode from the
+                                //filesystem's inodetable.
                                 //The inodetable represents a Rust DashMap that deadlocks
-                                //when trying to get a reference to its entry while holding any sort
-                                //of reference into it.
+                                //when trying to get a reference to its entry while holding any
+                                // sort of reference into it.
                                 drop(inodeobj);
                                 FS_METADATA.inodetable.remove(&inodenum);
                                 log_metadata(&FS_METADATA, inodenum);
@@ -3224,7 +3254,8 @@ impl Cage {
     /// read/write (`O_RDWR`) mode or `fildes` refers to a non-regular file.
     /// * `ENXIO` - addresses in the range [`off`, `off`+`len`) are invalid
     /// for the object specified by `fildes`.
-    /// * `EOPNOTSUPP` - Lind currently does not support mapping character files.
+    /// * `EOPNOTSUPP` - Lind currently does not support mapping character
+    ///   files.
     /// * `EBADF` - invalid file descriptor.
     /// Other errors, like `ENOMEM`, `EOVERFLOW`, etc. are not supported.
     ///
@@ -3247,8 +3278,9 @@ impl Cage {
         if len == 0 {
             return syscall_error(Errno::EINVAL, "mmap", "the value of len is 0");
         }
-        //Exactly one of the two flags (either `MAP_PRIVATE` or `MAP_SHARED`) must be set
-        if 0 == (flags & (MAP_PRIVATE | MAP_SHARED))  {
+        //Exactly one of the two flags (either `MAP_PRIVATE` or `MAP_SHARED`) must be
+        // set
+        if 0 == (flags & (MAP_PRIVATE | MAP_SHARED)) {
             return syscall_error(
                 Errno::EINVAL,
                 "mmap",
@@ -3363,7 +3395,8 @@ impl Cage {
     /// ### Errors
     ///
     /// * `EINVAL` - the value of len is 0 o
-    /// Other `EINVAL` errors are returned directly from the  call to `libc_mmap`
+    /// Other `EINVAL` errors are returned directly from the  call to
+    /// `libc_mmap`
     ///
     /// ### Panics
     ///
@@ -4163,32 +4196,37 @@ impl Cage {
     ///
     /// ### Description
     /// This function reads directory entries from a directory file descriptor
-    /// and returns them in a buffer. Reading directory entries using multiple read calls can be less efficient because it
-    /// involves reading the data in smaller chunks and then parsing it.
-    /// getdents can often be faster by reading directory entries in a more optimized way.
-    /// * The function first checks if the provided buffer size is sufficient to store at least one
-    ///   `ClippedDirent` structure.
-    /// * The function validates the provided file descriptor to ensure it represents a
-    ///   valid file.
+    /// and returns them in a buffer. Reading directory entries using multiple
+    /// read calls can be less efficient because it involves reading the
+    /// data in smaller chunks and then parsing it. getdents can often be
+    /// faster by reading directory entries in a more optimized way.
+    /// * The function first checks if the provided buffer size is sufficient to
+    ///   store at least one `ClippedDirent` structure.
+    /// * The function validates the provided file descriptor to ensure it
+    ///   represents a valid file.
     /// * The function checks if the file descriptor refers to a directory.
     /// * The function iterates over the directory entries in the
     ///   `filename_to_inode_dict` of the directory inode.
-    /// * For each entry, the function constructs a `ClippedDirent` structure, which
-    ///   contains the inode number, offset, and record length.
-    /// * It packs the constructed directory entries into the provided buffer (`dirp`).
+    /// * For each entry, the function constructs a `ClippedDirent` structure,
+    ///   which contains the inode number, offset, and record length.
+    /// * It packs the constructed directory entries into the provided buffer
+    ///   (`dirp`).
     /// * Updates the file position to the next directory entry to be read.
     ///
     /// ### Function Arguments
     /// * `fd`: A file descriptor representing the directory to read.
-    /// * `dirp`: A pointer to a buffer where the directory entries will be written.
+    /// * `dirp`: A pointer to a buffer where the directory entries will be
+    ///   written.
     /// * `bufsize`: The size of the buffer in bytes.
     ///
     /// ### Returns
     /// * The number of bytes written to the buffer on success.
     ///
     /// ### Errors
-    /// * `EINVAL(22)`: If the buffer size is too small or if the file descriptor is invalid.
-    /// * `ENOTDIR(20)`: If the file descriptor does not refer to a existing directory.
+    /// * `EINVAL(22)`: If the buffer size is too small or if the file
+    ///   descriptor is invalid.
+    /// * `ENOTDIR(20)`: If the file descriptor does not refer to a existing
+    ///   directory.
     /// * `ESPIPE(29)`: If the file descriptor does not refer to a file.
     /// * `EBADF(9)` : If the file descriptor is invalid.
     /// ### Panics
@@ -4198,9 +4236,10 @@ impl Cage {
         let mut vec: Vec<(interface::ClippedDirent, Vec<u8>)> = Vec::new();
 
         // make sure bufsize is at least greater than size of a ClippedDirent struct
-        // ClippedDirent is a simplified version of the traditional dirent structure used in POSIX systems
-        // By using a simpler structure, SafePosix can store and retrieve directory entries more efficiently,
-        // potentially improving performance compared to using the full dirent structure.
+        // ClippedDirent is a simplified version of the traditional dirent structure
+        // used in POSIX systems By using a simpler structure, SafePosix can
+        // store and retrieve directory entries more efficiently, potentially
+        // improving performance compared to using the full dirent structure.
         if bufsize <= interface::CLIPPED_DIRENT_SIZE {
             return syscall_error(Errno::EINVAL, "getdents", "Result buffer is too small.");
         }
@@ -4238,7 +4277,8 @@ impl Cage {
                                 // convert filename to a filename vector of u8
                                 let mut vec_filename: Vec<u8> = filename.as_bytes().to_vec();
                                 vec_filename.push(b'\0'); // make filename null-terminated
-                                // Push DT_UNKNOWN as d_type. This is a placeholder for now, as the actual file type is not yet determined.
+                                                          // Push DT_UNKNOWN as d_type. This is a placeholder for now, as the
+                                                          // actual file type is not yet determined.
                                 vec_filename.push(DT_UNKNOWN); // push DT_UNKNOWN as d_type (for now)
                                 temp_len =
                                     interface::CLIPPED_DIRENT_SIZE + vec_filename.len() as u32; // get length of current filename vector for padding calculation
@@ -4274,7 +4314,8 @@ impl Cage {
                                 count += 1;
                             }
                             // update file position
-                            // keeps track of the current position within the directory. It indicates which directory entry the
+                            // keeps track of the current position within the directory. It
+                            // indicates which directory entry the
                             // function should read next.
                             normalfile_filedesc_obj.position = interface::rust_min(
                                 position + count,

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -3331,7 +3331,7 @@ impl Cage {
                             }
                             let filesize = normalfile_inode_obj.size;
                             //The offset cannot be negative, and we cannot read past the end of the file
-                            if off < 0 || off > filesize as i64 || (off + len as i64) > (filesize as i64 + 1) {
+                            if off < 0 || off > filesize as i64 {
                                 return syscall_error(Errno::ENXIO, "mmap", "Addresses in the range [off,off+len) are invalid for the object specified by fildes.");
                             }
                             //Because of NaCl's internal workings we must allow mappings to extend past the end of the file

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -3642,7 +3642,7 @@ impl Cage {
                             }
                             //Because of NaCl's internal workings we must allow mappings to extend past the end of the file
                             let fobj = FILEOBJECTTABLE.get(&normalfile_filedesc_obj.inode).unwrap();
-                            //The actual memory mapping is not emulated inside Lind, so the call to the kernell
+                            //The actual memory mapping is not emulated inside Lind, so the call to the kernel
                             //is required. To perform this call, the file descriptor of the actual file
                             //stored on the host machine is needed. Since Lind's emulated filesystem
                             //does not match the underlying host's filesystem, the file descriptor

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -3171,7 +3171,69 @@ impl Cage {
         }
     }
 
-    //------------------------------------MMAP SYSCALL------------------------------------
+    /// ### Description
+    ///
+    /// The `mmap_syscall()` function creates a new mapping in the
+    /// virtual address space of the calling process.
+    ///
+    /// ### Arguments
+    ///
+    /// The `mmap_syscall()` accepts six arguments:
+    /// * `addr` - the starting address for the new mapping. If `addr`
+    /// is NULL, then the kernel chooses the (page-aligned) address at
+    /// which to create the mapping. If addr is not NULL, then the
+    /// kernel takes it as a hint about where to place the mapping.
+    /// * `len` - specifies the length of the mapping (which must be
+    /// greater than 0).
+    /// * `prot` - describes the desired memory protection of the
+    /// mapping, which must not conflict with the open mode of the file.
+    /// It is either `PROT_NONE` or the bitwise OR of one or more of the
+    /// following flags: `PROT_EXEC` (Pages may be executed), `PROT_READ`
+    /// (Pages may be read), `PROT_WRITE` (Pages may be written), `PROT_NONE`
+    /// (Pages may not be accessed).
+    /// * `flags` - determines whether updates to the mapping are visible
+    /// to other processes mapping the same region, and whether updates are
+    /// carried through to the underlying file. This behavior is determined
+    /// by including exactly one of the following values in flags: `MAP_SHARED`
+    /// (Share this mapping. Updates to the mapping are visible to other
+    /// processes mapping the same region, and in the case of file-backed
+    /// mappings are carried through to the underlying file) or `MAP_PRIVATE`
+    /// (Create a private copy-on-write mapping. Updates to the mapping are
+    /// not visible to other processes mapping the same file, and are not
+    /// carried through to the underlying file). `MAP_SHARED_VALIDATE` and
+    /// other flags are not validated in the current implementation but
+    /// are supported by the underlying `libc_mmap()` syscall.
+    /// * `filedes` - a file descriptor specifying the file that shall be
+    /// mapped.
+    /// * `off` - designates the offset in the file from which the mapping
+    /// should start.
+    ///
+    /// ### Returns
+    ///
+    /// On success, `mmap_syscall()` returns a pointer to the mapped area.
+    /// In case of a failure, an error is returned, and `errno` is set depending
+    /// on the error, e.g. EINVAL, ERANGE, etc.
+    ///
+    /// ### Errors
+    ///
+    /// * `EINVAL` - the value of len is 0 or `flags` contained neither
+    /// `MAP_PRIVATE` nor `MAP_SHARED` or `flags` contained both
+    /// `MAP_PRIVATE` and `MAP_SHARED`.
+    /// * `EACCES` - `fildes` is not open for reading or `MAP_SHARED`
+    /// was requested and PROT_WRITE is set, but fd is not open in
+    /// read/write (`O_RDWR`) mode or `fildes` refers to a non-regular file.
+    /// * `ENXIO` - addresses in the range [`off`, `off`+`len`) are invalid
+    /// for the object specified by `fildes`.
+    /// * `EOPNOTSUPP` - Lind currently does not support mapping character files.
+    /// * `EBADF` - invalid file descriptor.
+    /// Other errors, like `ENOMEM`, `EOVERFLOW`, etc. are not supported.
+    ///
+    /// ### Panics
+    ///
+    /// A panic occurs when a provided file descriptor is out of bounds.
+    ///
+    /// To learn more about the syscall, flags, possible error values, etc., see
+    /// [mmap(2)](https://man7.org/linux/man-pages/man2/mmap.2.html)
 
     pub fn mmap_syscall(
         &self,
@@ -3183,57 +3245,77 @@ impl Cage {
         off: i64,
     ) -> i32 {
         if len == 0 {
-            syscall_error(Errno::EINVAL, "mmap", "the value of len is 0");
+            return syscall_error(Errno::EINVAL, "mmap", "the value of len is 0");
         }
-
-        if 0 == flags & (MAP_PRIVATE | MAP_SHARED) {
-            syscall_error(
+        //Exactly one of the two flags (either `MAP_PRIVATE` or `MAP_SHARED`) must be set
+        if 0 == (flags & (MAP_PRIVATE | MAP_SHARED))  {
+            return syscall_error(
                 Errno::EINVAL,
                 "mmap",
                 "The value of flags is invalid (neither MAP_PRIVATE nor MAP_SHARED is set)",
             );
         }
-
-        if 0 != flags & MAP_ANONYMOUS {
+        if ((flags & MAP_PRIVATE) != 0) && ((flags & MAP_SHARED) != 0) {
+            return syscall_error(
+                Errno::EINVAL,
+                "mmap",
+                "The value of flags is invalid (MAP_PRIVATE and MAP_SHARED cannot be both set)",
+            );
+        }
+        //The `MAP_ANONYMOUS` flag specifies that the mapping
+        //is not backed by any file, so the `fildes` and `off`
+        //arguments should be ignored; however, some implementations
+        //require `fildes` to be -1, which we follow for the
+        //sake of portability.
+        if 0 != (flags & MAP_ANONYMOUS) {
             return interface::libc_mmap(addr, len, prot, flags, -1, 0);
         }
-
+        //BUG
+        //If the provided file descriptor is out of bounds, get_filedescriptor returns
+        //Err(), unwrapping on which  produces a 'panic!'
+        //otherwise, file descriptor table entry is stored in 'checkedfd'
         let checkedfd = self.get_filedescriptor(fildes).unwrap();
         let mut unlocked_fd = checkedfd.write();
         if let Some(filedesc_enum) = &mut *unlocked_fd {
-            //confirm fd type is mappable
+            //The current implementation supports only regular files
             match filedesc_enum {
                 File(ref mut normalfile_filedesc_obj) => {
                     let inodeobj = FS_METADATA
                         .inodetable
                         .get(&normalfile_filedesc_obj.inode)
                         .unwrap();
-
-                    //confirm inode type is mappable
+                    //Confirm inode type is mappable
                     match &*inodeobj {
                         Inode::File(normalfile_inode_obj) => {
-                            //if we want to write our changes back to the file the file needs to be open for reading and writing
-                            if (flags & MAP_SHARED != 0) && (flags & PROT_WRITE != 0) && (normalfile_filedesc_obj.flags & O_RDWR != 0) {
+                            //For any kind of memory mapping, the file should be
+                            //opened for reading, so if it was opened for write
+                            //only, the mapping should be denied
+                            if (normalfile_filedesc_obj.flags & O_WRONLY) != 0 {
+                                return syscall_error(Errno::EACCES, "mmap", "file descriptor is not open for reading");
+                            }
+                            //If we want to write our changes back to the file the file needs to be open for reading and writing
+                            if (flags & MAP_SHARED) != 0 && (prot & PROT_WRITE) != 0 && (normalfile_filedesc_obj.flags & O_RDWR) != O_RDWR {
                                 return syscall_error(Errno::EACCES, "mmap", "file descriptor is not open RDWR, but MAP_SHARED and PROT_WRITE are set");
                             }
                             let filesize = normalfile_inode_obj.size;
-                            if off < 0 || off > filesize as i64 {
+                            //The offset cannot be negative, and we cannot read past the end of the file
+                            if off < 0 || off > filesize as i64 || (off + len as i64) > (filesize as i64 + 1) {
                                 return syscall_error(Errno::ENXIO, "mmap", "Addresses in the range [off,off+len) are invalid for the object specified by fildes.");
                             }
-                            //because of NaCl's internal workings we must allow mappings to extend past the end of a file
+                            //Because of NaCl's internal workings we must allow mappings to extend past the end of the file
                             let fobj = FILEOBJECTTABLE.get(&normalfile_filedesc_obj.inode).unwrap();
-                            //we cannot mmap a rust file in quite the right way so we retrieve the fd number from it
-                            //this is the system fd number--the number of the lind.<inodenum> file in our host system
+                            //The actual memory mapping is not emulated inside Lind, so the call to the kernell
+                            //is required. To perform this call, the file descriptor of the actual file
+                            //stored on the host machine is needed. Since Lind's emulated filesystem
+                            //does not match the underlying host's filesystem, the file descriptor
+                            //provided to the `mmap_syscall()` cannot be used and must be converted
+                            //to the actual file descriptor stored in the host's filesystem.
                             let fobjfdno = fobj.as_fd_handle_raw_int();
-
-
                             interface::libc_mmap(addr, len, prot, flags, fobjfdno, off)
                         }
-
                         Inode::CharDev(_chardev_inode_obj) => {
                             syscall_error(Errno::EOPNOTSUPP, "mmap", "lind currently does not support mapping character files")
                         }
-
                         _ => {syscall_error(Errno::EACCES, "mmap", "the fildes argument refers to a file whose type is not supported by mmap")}
                     }
                 }
@@ -3248,15 +3330,60 @@ impl Cage {
         }
     }
 
-    //------------------------------------MUNMAP SYSCALL------------------------------------
+    /// ### Description
+    ///
+    /// The `munmap_syscall()` function shall remove any mappings
+    /// containing any part of the address space of the process
+    /// starting at `addr` and continuing for `len` bytes.
+    /// Further references to these pages shall result in the
+    /// generation of a `SIGSEGV` signal to the process. If there
+    /// are no mappings in the specified address range, then
+    /// `munmap_syscall()` has no effect.
+    /// The current implementation of the syscall solely relies
+    /// on the inner implementation of NaCl (except for a simple
+    /// `len` argument check) by creating a new mapping in the
+    /// specified memory region by using `MAP_FIXED` with
+    /// `PROT_NONE` flag to deny any access to the unmapped
+    /// memory region.
+    ///
+    /// ### Arguments
+    ///
+    /// The `munmap_syscall()` accepts two arguments:
+    /// * `addr` - the address starting from which the mapping
+    /// shall be removed
+    /// * `len` - specifies the length of the mapping that
+    /// shall be removed.
+    ///
+    /// ### Returns
+    ///
+    /// On success, `munmap_syscall()` returns 0.
+    /// In case of a failure, an error is returned, and `errno`
+    /// is set to `EINVAL`.
+    ///
+    /// ### Errors
+    ///
+    /// * `EINVAL` - the value of len is 0 o
+    /// Other `EINVAL` errors are returned directly from the  call to `libc_mmap`
+    ///
+    /// ### Panics
+    ///
+    /// There are no cases where this function panics.
+    ///
+    /// To learn more about the syscall, flags, possible error values, etc., see
+    /// [munmap(2)](https://linux.die.net/man/2/munmap)
 
     pub fn munmap_syscall(&self, addr: *mut u8, len: usize) -> i32 {
         if len == 0 {
-            syscall_error(Errno::EINVAL, "mmap", "the value of len is 0");
+            return syscall_error(Errno::EINVAL, "mmap", "the value of len is 0");
         }
-        //NaCl's munmap implementation actually just writes over the previously mapped
-        // data with PROT_NONE This frees all of the resources except page table
-        // space, and is put inside safeposix for consistency
+        //NaCl's munmap implementation actually just writes
+        //over the previously mapped data with PROT_NONE.
+        //This frees all of the resources except page table
+        //space, and is put inside safeposix for consistency.
+        //`MAP_FIXED` is used to precisely unmap the specified
+        //memory region, and `MAP_ANONYMOUS` is used to deny
+        //any further access to the unmapped memory region
+        //thereby emulating the unmapping process.
         interface::libc_mmap(
             addr,
             len,

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -3541,6 +3541,9 @@ impl Cage {
                         .unwrap();
                     //Confirm inode type is mappable
                     match &*inodeobj {
+                        Inode::CharDev(_chardev_inode_obj) => {
+                            syscall_error(Errno::EOPNOTSUPP, "mmap", "lind currently does not support mapping character files")
+                        }
                         Inode::File(normalfile_inode_obj) => {
                             //For any kind of memory mapping, the file should be
                             //opened for reading, so if it was opened for write
@@ -3567,9 +3570,6 @@ impl Cage {
                             //to the actual file descriptor stored in the host's filesystem.
                             let fobjfdno = fobj.as_fd_handle_raw_int();
                             interface::libc_mmap(addr, len, prot, flags, fobjfdno, off)
-                        }
-                        Inode::CharDev(_chardev_inode_obj) => {
-                            syscall_error(Errno::EOPNOTSUPP, "mmap", "lind currently does not support mapping character files")
                         }
                         _ => {syscall_error(Errno::EACCES, "mmap", "the fildes argument refers to a file whose type is not supported by mmap")}
                     }
@@ -3617,7 +3617,7 @@ impl Cage {
     ///
     /// ### Errors
     ///
-    /// * `EINVAL` - the value of len is 0 o
+    /// * `EINVAL` - the value of len is 0
     /// Other `EINVAL` errors are returned directly from the  call to
     /// `libc_mmap`
     ///

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -343,6 +343,280 @@ pub mod fs_tests {
     }
 
     #[test]
+    pub fn ut_lind_fs_mmap_zerolen() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init(); 
+
+        let cage = interface::cagetable_getref(1); 
+
+        //Creating a regular file with `O_RDWR` flag
+        //making it valid for any mapping.
+        let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
+        let filepath = "/mmapTestFile1";
+        let fd = cage.open_syscall(filepath, flags, S_IRWXA);
+        //Writing into that file's first 9 bytes.
+        assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9); 
+ 
+        //Checking if passing 0 as `len` to `mmap_syscall()`
+        //correctly results in 'The value of len is 0` error.
+        assert_eq!(cage.mmap_syscall(0 as *mut u8, 0, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0), -(Errno::EINVAL as i32)); 
+ 
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+  
+    #[test]
+    pub fn ut_lind_fs_mmap_invalid_flags_none() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        //Creating a regular file with `O_RDWR` flag
+        //making it valid for any mapping.
+        let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
+        let filepath = "/mmapTestFile1";
+        let fd = cage.open_syscall(filepath, flags, S_IRWXA);
+        //Writing into that file's first 9 bytes.
+        assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9);
+
+        //Checking if not passing any of the two `MAP_PRIVATE`
+        //or `MAP_SHARED` flags correctly results in `The value
+        //of flags is invalid (neither `MAP_PRIVATE` nor
+        //`MAP_SHARED` is set)` error.
+        assert_eq!(cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, 0, fd, 0), -(Errno::EINVAL as i32));
+
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    } 
+ 
+    #[test]
+    pub fn ut_lind_fs_mmap_invalid_flags_both() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        //Creating a regular file with `O_RDWR` flag
+        //making it valid for any mapping.
+        let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
+        let filepath = "/mmapTestFile1";
+        let fd = cage.open_syscall(filepath, flags, S_IRWXA);
+        //Writing into that file's first 9 bytes.
+        assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9);
+
+        //Checking if passing both `MAP_PRIVATE`
+        //and `MAP_SHARED` flags correctly results in `The value
+        //of flags is invalid (`MAP_PRIVATE` and `MAP_SHARED`
+        //cannot be both set)` error.
+        assert_eq!(cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_SHARED, fd, 0), -(Errno::EINVAL as i32));
+       
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+ 
+ 
+    #[test]
+    pub fn ut_lind_fs_mmap_no_read() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+  
+        //Creating a regular file without a reading flag
+        //making it invalid for any mapping.
+        let flags: i32 = O_TRUNC | O_CREAT | O_WRONLY;
+        let filepath = "/mmapTestFile1";
+        let fd = cage.open_syscall(filepath, flags, S_IRWXA);
+        //Writing into that file's first 9 bytes.
+        assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9); 
+ 
+        //Checking if trying to map a file that does not
+        //allow reading correctly results in `File descriptor
+        //is not open for reading` error.
+        assert_eq!(cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0), -(Errno::EACCES as i32));
+       
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    } 
+ 
+    #[test]
+    pub fn ut_lind_fs_mmap_no_write() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+  
+        let cage = interface::cagetable_getref(1); 
+ 
+        //Creating a regular file with flags for
+        //reading and writing
+        let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
+        let filepath = "/mmapTestFile1";
+        let fd = cage.open_syscall(filepath, flags, S_IRWXA);
+        //Writing into that file's first 9 bytes.
+        assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9); 
+ 
+        //Opening a file descriptor for the same file
+        //but now with a read flag and without a write
+        //flag making it invalid for shared mapping with
+        //write protection flag.
+        let testflags: i32 = O_RDONLY;
+        let testfd = cage.open_syscall(filepath, testflags, 0); 
+ 
+        //Checking if trying to map a file that does not
+        //allow writing for shared mapping with writing
+        //protection flag set correctly results in
+        //``MAP_SHARED` was requested and PROT_WRITE is
+        //set, but fd is not open in read/write (`O_RDWR`)
+        //mode` error.
+        assert_eq!(cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, testfd, 0), -(Errno::EACCES as i32));
+       
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+ 
+ 
+    #[test]
+    pub fn ut_lind_fs_mmap_invalid_offset_len() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init(); 
+ 
+        let cage = interface::cagetable_getref(1); 
+ 
+        //Creating a regular file with `O_RDWR` flag
+        //making it valid for any mapping.
+        let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
+        let filepath = "/mmapTestFile1";
+        let fd = cage.open_syscall(filepath, flags, S_IRWXA);
+        //Writing into that file's first 9 bytes.
+        assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9); 
+ 
+        //Checking if passing a negative offset correctly
+        //results in `Addresses in the range [off,off+len)
+        //are invalid for the object specified by `fildes`` error.
+        assert_eq!(cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, fd, -10), -(Errno::ENXIO as i32));
+  
+        //Checking if passing an offset that seeks beyond the end
+        //of the file correctly results in `Addresses in the
+        //range [off,off+len) are invalid for the object specified
+        //by `fildes`` error.
+        assert_eq!(cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 25), -(Errno::ENXIO as i32));
+  
+        //Checking if passing an offset and length that together
+        //seek beyond the end of the file correctly results in
+        //`Addresses in the range [off,off+len) are invalid for
+        //the object specified by `fildes`` error.
+        assert_eq!(cage.mmap_syscall(0 as *mut u8, 7, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 7), -(Errno::ENXIO as i32));
+       
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+ 
+ 
+    #[test]
+    pub fn ut_lind_fs_mmap_chardev() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init(); 
+ 
+        let cage = interface::cagetable_getref(1); 
+ 
+        //Opening a character device file `/dev/zero`.
+        let fd = cage.open_syscall("/dev/zero", O_RDWR, S_IRWXA);
+        //Writing into that file's first 9 bytes.
+        assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9);
+  
+        //Checking if calling `mmap_syscall()` on the character device
+        //file correctly results in `Lind currently does not support
+        //mapping character files` error.
+        assert_eq!(cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0), -(Errno::EOPNOTSUPP as i32));
+       
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+ 
+ 
+    #[test]
+    pub fn ut_lind_fs_mmap_unsupported_file() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init(); 
+ 
+        let cage = interface::cagetable_getref(1); 
+ 
+        //Creating a directory.
+        assert_eq!(cage.mkdir_syscall("/testdir", S_IRWXA), 0);
+        let fd = cage.open_syscall("/testdir", O_RDWR, S_IRWXA); 
+ 
+        //Checking if passing the created directory to
+        //`mmap_syscall()` correctly results in `The `fildes`
+        //argument refers to a file whose type is not
+        //supported by mmap` error.
+        assert_eq!(cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0), -(Errno::EACCES as i32));
+       
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+ 
+ 
+    #[test]
+    pub fn ut_lind_fs_mmap_invalid_fildes() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init(); 
+ 
+        let cage = interface::cagetable_getref(1); 
+ 
+        //Creating a regular file with `O_RDWR` flag
+        //making it valid for any mapping and then
+        //closing it, thereby making the obtained
+        //filede scriptor invalid because no other
+        //file is opened after it.
+        let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
+        let filepath = "/mmapTestFile1";
+        let fd = cage.open_syscall(filepath, flags, S_IRWXA);
+        assert_eq!(cage.close_syscall(fd), 0); 
+ 
+        //Checking if passing the invalid file descriptor
+        //correctly results in `Invalid file descriptor` error.
+        assert_eq!(cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0), -(Errno::EBADF as i32));
+       
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+ 
+ 
+    #[test]
+    pub fn ut_lind_fs_munmap_zerolen() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init(); 
+ 
+        let cage = interface::cagetable_getref(1); 
+ 
+        //Creating a regular file with `O_RDWR` flag
+        //making it valid for any mapping.
+        let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
+        let filepath = "/mmapTestFile1";
+        let fd = cage.open_syscall(filepath, flags, S_IRWXA);
+        //Writing into that file's first 9 bytes.
+        assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9); 
+ 
+        //Checking if passing 0 as `len` to `munmap_syscall()`
+        //correctly results in 'The value of len is 0` error.
+        assert_eq!(cage.munmap_syscall(0 as *mut u8, 0), -(Errno::EINVAL as i32)); 
+ 
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+ 
+
+    #[test]
     pub fn ut_lind_fs_dir_chdir() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -539,16 +539,7 @@ pub mod fs_tests {
             cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 25),
             -(Errno::ENXIO as i32)
         );
-
-        //Checking if passing an offset and length that together
-        //seek beyond the end of the file correctly results in
-        //`Addresses in the range [off,off+len) are invalid for
-        //the object specified by `fildes`` error.
-        assert_eq!(
-            cage.mmap_syscall(0 as *mut u8, 7, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 7),
-            -(Errno::ENXIO as i32)
-        );
-
+        
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
     }

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -346,9 +346,9 @@ pub mod fs_tests {
     pub fn ut_lind_fs_mmap_zerolen() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup
-        let _thelock = setup::lock_and_init(); 
+        let _thelock = setup::lock_and_init();
 
-        let cage = interface::cagetable_getref(1); 
+        let cage = interface::cagetable_getref(1);
 
         //Creating a regular file with `O_RDWR` flag
         //making it valid for any mapping.
@@ -356,16 +356,19 @@ pub mod fs_tests {
         let filepath = "/mmapTestFile1";
         let fd = cage.open_syscall(filepath, flags, S_IRWXA);
         //Writing into that file's first 9 bytes.
-        assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9); 
- 
+        assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9);
+
         //Checking if passing 0 as `len` to `mmap_syscall()`
         //correctly results in 'The value of len is 0` error.
-        assert_eq!(cage.mmap_syscall(0 as *mut u8, 0, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0), -(Errno::EINVAL as i32)); 
- 
+        assert_eq!(
+            cage.mmap_syscall(0 as *mut u8, 0, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0),
+            -(Errno::EINVAL as i32)
+        );
+
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
     }
-  
+
     #[test]
     pub fn ut_lind_fs_mmap_invalid_flags_none() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
@@ -386,12 +389,15 @@ pub mod fs_tests {
         //or `MAP_SHARED` flags correctly results in `The value
         //of flags is invalid (neither `MAP_PRIVATE` nor
         //`MAP_SHARED` is set)` error.
-        assert_eq!(cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, 0, fd, 0), -(Errno::EINVAL as i32));
+        assert_eq!(
+            cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, 0, fd, 0),
+            -(Errno::EINVAL as i32)
+        );
 
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
-    } 
- 
+    }
+
     #[test]
     pub fn ut_lind_fs_mmap_invalid_flags_both() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
@@ -412,12 +418,22 @@ pub mod fs_tests {
         //and `MAP_SHARED` flags correctly results in `The value
         //of flags is invalid (`MAP_PRIVATE` and `MAP_SHARED`
         //cannot be both set)` error.
-        assert_eq!(cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_SHARED, fd, 0), -(Errno::EINVAL as i32));
-       
+        assert_eq!(
+            cage.mmap_syscall(
+                0 as *mut u8,
+                5,
+                PROT_READ | PROT_WRITE,
+                MAP_PRIVATE | MAP_SHARED,
+                fd,
+                0
+            ),
+            -(Errno::EINVAL as i32)
+        );
+
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
-    } 
- 
+    }
+
     #[test]
     pub fn ut_lind_fs_mmap_no_read() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
@@ -425,148 +441,176 @@ pub mod fs_tests {
         let _thelock = setup::lock_and_init();
 
         let cage = interface::cagetable_getref(1);
-  
+
         //Creating a regular file without a reading flag
         //making it invalid for any mapping.
         let flags: i32 = O_TRUNC | O_CREAT | O_WRONLY;
         let filepath = "/mmapTestFile1";
         let fd = cage.open_syscall(filepath, flags, S_IRWXA);
         //Writing into that file's first 9 bytes.
-        assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9); 
- 
+        assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9);
+
         //Checking if trying to map a file that does not
         //allow reading correctly results in `File descriptor
         //is not open for reading` error.
-        assert_eq!(cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0), -(Errno::EACCES as i32));
-       
+        assert_eq!(
+            cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0),
+            -(Errno::EACCES as i32)
+        );
+
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
-    } 
- 
+    }
+
     #[test]
     pub fn ut_lind_fs_mmap_no_write() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup
         let _thelock = setup::lock_and_init();
-  
-        let cage = interface::cagetable_getref(1); 
- 
+
+        let cage = interface::cagetable_getref(1);
+
         //Creating a regular file with flags for
         //reading and writing
         let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
         let filepath = "/mmapTestFile1";
         let fd = cage.open_syscall(filepath, flags, S_IRWXA);
         //Writing into that file's first 9 bytes.
-        assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9); 
- 
+        assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9);
+
         //Opening a file descriptor for the same file
         //but now with a read flag and without a write
         //flag making it invalid for shared mapping with
         //write protection flag.
         let testflags: i32 = O_RDONLY;
-        let testfd = cage.open_syscall(filepath, testflags, 0); 
- 
+        let testfd = cage.open_syscall(filepath, testflags, 0);
+
         //Checking if trying to map a file that does not
         //allow writing for shared mapping with writing
         //protection flag set correctly results in
         //``MAP_SHARED` was requested and PROT_WRITE is
         //set, but fd is not open in read/write (`O_RDWR`)
         //mode` error.
-        assert_eq!(cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, testfd, 0), -(Errno::EACCES as i32));
-       
+        assert_eq!(
+            cage.mmap_syscall(
+                0 as *mut u8,
+                5,
+                PROT_READ | PROT_WRITE,
+                MAP_SHARED,
+                testfd,
+                0
+            ),
+            -(Errno::EACCES as i32)
+        );
+
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
-    } 
- 
+    }
+
     #[test]
     pub fn ut_lind_fs_mmap_invalid_offset_len() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup
-        let _thelock = setup::lock_and_init(); 
- 
-        let cage = interface::cagetable_getref(1); 
- 
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
         //Creating a regular file with `O_RDWR` flag
         //making it valid for any mapping.
         let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
         let filepath = "/mmapTestFile1";
         let fd = cage.open_syscall(filepath, flags, S_IRWXA);
         //Writing into that file's first 9 bytes.
-        assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9); 
- 
+        assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9);
+
         //Checking if passing a negative offset correctly
         //results in `Addresses in the range [off,off+len)
         //are invalid for the object specified by `fildes`` error.
-        assert_eq!(cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, fd, -10), -(Errno::ENXIO as i32));
-  
+        assert_eq!(
+            cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, fd, -10),
+            -(Errno::ENXIO as i32)
+        );
+
         //Checking if passing an offset that seeks beyond the end
         //of the file correctly results in `Addresses in the
         //range [off,off+len) are invalid for the object specified
         //by `fildes`` error.
-        assert_eq!(cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 25), -(Errno::ENXIO as i32));
-  
+        assert_eq!(
+            cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 25),
+            -(Errno::ENXIO as i32)
+        );
+
         //Checking if passing an offset and length that together
         //seek beyond the end of the file correctly results in
         //`Addresses in the range [off,off+len) are invalid for
         //the object specified by `fildes`` error.
-        assert_eq!(cage.mmap_syscall(0 as *mut u8, 7, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 7), -(Errno::ENXIO as i32));
-       
+        assert_eq!(
+            cage.mmap_syscall(0 as *mut u8, 7, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 7),
+            -(Errno::ENXIO as i32)
+        );
+
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
-    } 
- 
+    }
+
     #[test]
     pub fn ut_lind_fs_mmap_chardev() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup
-        let _thelock = setup::lock_and_init(); 
- 
-        let cage = interface::cagetable_getref(1); 
- 
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
         //Opening a character device file `/dev/zero`.
         let fd = cage.open_syscall("/dev/zero", O_RDWR, S_IRWXA);
         //Writing into that file's first 9 bytes.
         assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9);
-  
+
         //Checking if calling `mmap_syscall()` on the character device
         //file correctly results in `Lind currently does not support
         //mapping character files` error.
-        assert_eq!(cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0), -(Errno::EOPNOTSUPP as i32));
-       
+        assert_eq!(
+            cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0),
+            -(Errno::EOPNOTSUPP as i32)
+        );
+
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
-    } 
- 
+    }
+
     #[test]
     pub fn ut_lind_fs_mmap_unsupported_file() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup
-        let _thelock = setup::lock_and_init(); 
- 
-        let cage = interface::cagetable_getref(1); 
- 
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
         //Creating a directory.
         assert_eq!(cage.mkdir_syscall("/testdir", S_IRWXA), 0);
-        let fd = cage.open_syscall("/testdir", O_RDWR, S_IRWXA); 
- 
+        let fd = cage.open_syscall("/testdir", O_RDWR, S_IRWXA);
+
         //Checking if passing the created directory to
         //`mmap_syscall()` correctly results in `The `fildes`
         //argument refers to a file whose type is not
         //supported by mmap` error.
-        assert_eq!(cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0), -(Errno::EACCES as i32));
-       
+        assert_eq!(
+            cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0),
+            -(Errno::EACCES as i32)
+        );
+
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
-    } 
- 
+    }
+
     #[test]
     pub fn ut_lind_fs_mmap_invalid_fildes() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup
-        let _thelock = setup::lock_and_init(); 
- 
-        let cage = interface::cagetable_getref(1); 
- 
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
         //Creating a regular file with `O_RDWR` flag
         //making it valid for any mapping and then
         //closing it, thereby making the obtained
@@ -575,40 +619,46 @@ pub mod fs_tests {
         let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
         let filepath = "/mmapTestFile1";
         let fd = cage.open_syscall(filepath, flags, S_IRWXA);
-        assert_eq!(cage.close_syscall(fd), 0); 
- 
+        assert_eq!(cage.close_syscall(fd), 0);
+
         //Checking if passing the invalid file descriptor
         //correctly results in `Invalid file descriptor` error.
-        assert_eq!(cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0), -(Errno::EBADF as i32));
-       
+        assert_eq!(
+            cage.mmap_syscall(0 as *mut u8, 5, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0),
+            -(Errno::EBADF as i32)
+        );
+
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
-    } 
- 
+    }
+
     #[test]
     pub fn ut_lind_fs_munmap_zerolen() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup
-        let _thelock = setup::lock_and_init(); 
- 
-        let cage = interface::cagetable_getref(1); 
- 
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
         //Creating a regular file with `O_RDWR` flag
         //making it valid for any mapping.
         let flags: i32 = O_TRUNC | O_CREAT | O_RDWR;
         let filepath = "/mmapTestFile1";
         let fd = cage.open_syscall(filepath, flags, S_IRWXA);
         //Writing into that file's first 9 bytes.
-        assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9); 
- 
+        assert_eq!(cage.write_syscall(fd, str2cbuf("Test text"), 9), 9);
+
         //Checking if passing 0 as `len` to `munmap_syscall()`
         //correctly results in 'The value of len is 0` error.
-        assert_eq!(cage.munmap_syscall(0 as *mut u8, 0), -(Errno::EINVAL as i32)); 
- 
+        assert_eq!(
+            cage.munmap_syscall(0 as *mut u8, 0),
+            -(Errno::EINVAL as i32)
+        );
+
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
     }
- 
+
     #[test]
     pub fn ut_lind_fs_dir_chdir() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
@@ -898,53 +948,54 @@ pub mod fs_tests {
 
     #[test]
     fn ut_lind_fs_dup2_with_fork() {
-        // Acquiring a lock on TESTMUTEX prevents other tests from running concurrently, and also performs clean env setup.
+        // Acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup.
         let _thelock = setup::lock_and_init();
-    
+
         let cage = interface::cagetable_getref(1);
-    
+
         let flags: i32 = O_CREAT | O_RDWR;
         let filepath1 = "/dup2file_with_fork1";
         let filepath2 = "/dup2file_with_fork2";
-    
+
         // Open file descriptors
         let fd1 = cage.open_syscall(filepath1, flags, S_IRWXA);
         let fd2 = cage.open_syscall(filepath2, flags, S_IRWXA);
         assert!(fd1 >= 0);
         assert!(fd2 >= 0);
-    
+
         // Write data to the first file
         assert_eq!(cage.write_syscall(fd1, str2cbuf("parent data"), 11), 11);
-    
+
         // Fork the process
         assert_eq!(cage.fork_syscall(2), 0);
-    
+
         let child = std::thread::spawn(move || {
             let cage2 = interface::cagetable_getref(2);
-    
+
             // In the child process, duplicate fd1 to fd2
             assert!(cage2.dup2_syscall(fd1, fd2) >= 0);
-    
+
             // Write new data to the duplicated file descriptor
             assert_eq!(cage2.write_syscall(fd2, str2cbuf(" child data"), 11), 11);
-    
+
             assert_eq!(cage2.close_syscall(fd2), 0);
-    
+
             assert_eq!(cage2.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         });
-    
+
         child.join().unwrap();
-    
+
         let mut buffer = sizecbuf(22);
         assert_eq!(cage.lseek_syscall(fd1, 0, SEEK_SET), 0);
         assert_eq!(cage.read_syscall(fd1, buffer.as_mut_ptr(), 22), 22);
         assert_eq!(cbuf2str(&buffer), "parent data child data");
-    
+
         assert_eq!(cage.close_syscall(fd1), 0);
-    
+
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
-    }    
+    }
 
     #[test]
     pub fn ut_lind_fs_fcntl_valid_args() {
@@ -2313,7 +2364,8 @@ pub mod fs_tests {
         // Open the directory
         let fd = cage.open_syscall("/getdents", O_RDWR, S_IRWXA);
 
-        // Attempt to call `getdents_syscall` with a buffer size smaller than CLIPPED_DIRENT_SIZE
+        // Attempt to call `getdents_syscall` with a buffer size smaller than
+        // CLIPPED_DIRENT_SIZE
         let result = cage.getdents_syscall(fd, baseptr, bufsize as u32);
 
         // Assert that the return value is EINVAL (errno for "Invalid argument")

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -416,8 +416,7 @@ pub mod fs_tests {
        
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
-    }
- 
+    } 
  
     #[test]
     pub fn ut_lind_fs_mmap_no_read() {
@@ -477,8 +476,7 @@ pub mod fs_tests {
        
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
-    }
- 
+    } 
  
     #[test]
     pub fn ut_lind_fs_mmap_invalid_offset_len() {
@@ -515,8 +513,7 @@ pub mod fs_tests {
        
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
-    }
- 
+    } 
  
     #[test]
     pub fn ut_lind_fs_mmap_chardev() {
@@ -538,8 +535,7 @@ pub mod fs_tests {
        
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
-    }
- 
+    } 
  
     #[test]
     pub fn ut_lind_fs_mmap_unsupported_file() {
@@ -561,8 +557,7 @@ pub mod fs_tests {
        
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
-    }
- 
+    } 
  
     #[test]
     pub fn ut_lind_fs_mmap_invalid_fildes() {
@@ -588,8 +583,7 @@ pub mod fs_tests {
        
         assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
         lindrustfinalize();
-    }
- 
+    } 
  
     #[test]
     pub fn ut_lind_fs_munmap_zerolen() {
@@ -615,7 +609,6 @@ pub mod fs_tests {
         lindrustfinalize();
     }
  
-
     #[test]
     pub fn ut_lind_fs_dir_chdir() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,


### PR DESCRIPTION
## Description

Fixes # (issue)

The following changes include more elaborate comments and new unit tests for `mmap_syscall()` and `munmap_syscall()`.

### Type of change

- [ ] More detailed comments for `mmap_syscall()` and `munmap_syscall()`
- [ ] New unit tests for `mmap_syscall()` and `munmap_syscall()`

## How Has This Been Tested?

To run the tests, we need to run cargo test --lib command inside the safeposix-rust directory.

All the tests are present under this directory: lind_project/src/safeposix-rust/src/tests/fs_tests.rs

- Test A - `lut_lind_fs_mmap_zerolen()`
- Test B - `ut_lind_fs_mmap_invalid_flags_none()`
- Test C - `ut_lind_fs_mmap_invalid_flags_both()`
- Test D - `ut_lind_fs_mmap_no_read()`
- Test E - `ut_lind_fs_mmap_no_write()`
- Test F - `ut_lind_fs_mmap_invalid_offset_len()`
- Test G - `ut_lind_fs_mmap_chardev()`
- Test H - `ut_lind_fs_mmap_unsupported_file()`
- Test I - `ut_lind_fs_mmap_invalid_fildes()`
- Test J - `ut_lind_fs_munmap_zerolen()`

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)

