### PR TITLE
Exec syscall

### DIFF
--- a/src/safeposix/syscalls/sys_calls.rs
+++ b/src/safeposix/syscalls/sys_calls.rs
@@ -412,7 +412,7 @@ impl Cage {
     /// ### Description
     ///
     /// The exec system call replaces the current Cage object image with a new
-    /// Cage object exec is called immediately after a process(Cage) forks.
+    /// Cage object and exec is called immediately after a process(Cage) forks.
     /// For our purposes this translates to removing the parent cage object
     /// from the cagetable and adding the child object to it. We also close
     /// any file descriptors that the parent object holds if the `O_CLOEX`
@@ -474,11 +474,12 @@ impl Cage {
             self.close_syscall(fdnum);
         }
 
-        // We clone the parent cage's main threads and store them and index 0
+        // We clone the parent cage's main threads and store them at index 0
         // This is done since there isn't a thread established for the child Cage object
         // yet - And there is no threadId to store it at.
         // The child Cage object can then initialize and store the sigset appropriately
         // when it establishes its own main thread id.
+        // A sigset is a data structure that keeps track of which signals are affected by the process
         let newsigset = interface::RustHashMap::new();
         if !interface::RUSTPOSIX_TESTSUITE.load(interface::RustAtomicOrdering::Relaxed) {
             // When rustposix runs independently (not as Lind paired with NaCL runtime) we

--- a/src/safeposix/syscalls/sys_calls.rs
+++ b/src/safeposix/syscalls/sys_calls.rs
@@ -524,7 +524,7 @@ impl Cage {
             interval_timer: self.interval_timer.clone_with_new_cageid(child_cageid),
         };
 
-        // Insert new image with updated fd tables to be inserted in the cagetable
+        // Insert new cage with updated fd tables to be inserted in the cagetable
         interface::cagetable_insert(child_cageid, newcage);
         0
     }

--- a/src/safeposix/syscalls/sys_calls.rs
+++ b/src/safeposix/syscalls/sys_calls.rs
@@ -409,16 +409,49 @@ impl Cage {
         0
     }
 
+    /// ### Description
+    ///
+    /// The exec system call replaces the current Cage object image with a new
+    /// Cage object exec is called immediately after a process(Cage) forks.
+    /// For our purposes this translates to removing the parent cage object
+    /// from the cagetable and adding the child object to it. We also close
+    /// any file descriptors that the parent object holds if the `O_CLOEX`
+    /// flag has been set on that file descriptor  
+    ///
+    /// ### Arguments
+    ///
+    /// `child_cageid`: uid of the new child Cage object
+    ///
+    /// ### Returns
+    ///
+    /// Returns 0 upon successfully update the current running image
+    ///
+    /// ### Errors
+    ///
+    /// This syscall doesn't directly have any cases where it returns an error
+    ///
+    /// ### Panics
+    ///
+    /// This function doesn't directly panic - but the unmap memory mappings
+    /// function panics if it cannot create an shm entry
+    ///
+    /// For more information please refer to - [https://man7.org/linux/man-pages/man3/exec.3.html]
     pub fn exec_syscall(&self, child_cageid: u64) -> i32 {
+        // We remove the current running process from the cagetable
         interface::cagetable_remove(self.cageid);
-
+        // Function call to unmap shared memory mappings of the current process
         self.unmap_shm_mappings();
 
+        // Initialize an empty vector to hold file descriptors
         let mut cloexecvec = vec![];
         for fd in 0..MAXFD {
+            // Get mutex of the file descriptor
             let checkedfd = self.get_filedescriptor(fd).unwrap();
             let unlocked_fd = checkedfd.read();
             if let Some(filedesc_enum) = &*unlocked_fd {
+                // For each valid file descriptor we chech if the O_CLOEXEC flag is set or not
+                // The O_CLOEXEC flag determines whether the fd should be closed upon calling
+                // exec or not
                 if match filedesc_enum {
                     File(f) => f.flags & O_CLOEXEC,
                     Stream(s) => s.flags & O_CLOEXEC,
@@ -427,21 +460,29 @@ impl Cage {
                     Epoll(p) => p.flags & O_CLOEXEC,
                 } != 0
                 {
+                    // If the flag is set - we add the fd to our vector
                     cloexecvec.push(fd);
                 }
             }
         }
 
+        //For each fd in our close  vector list
+        //We call the close_syscall which takes in a file decsriptor
+        //and closes it
         for fdnum in cloexecvec {
             self.close_syscall(fdnum);
         }
 
-        // we grab the parent cages main threads sigset and store it at 0
-        // this way the child can initialize the sigset properly when it establishes its
-        // own mainthreadid
+        // We clone the parent cage's main threads and store them and index 0
+        // This is done since there isn't a thread established for the child Cage object
+        // yet - And there is no threadId to store it at.
+        // The child Cage object can then initialize and store the sigset appropriately
+        // when it establishes its own main thread id.
         let newsigset = interface::RustHashMap::new();
         if !interface::RUSTPOSIX_TESTSUITE.load(interface::RustAtomicOrdering::Relaxed) {
-            // we don't add these for the test suite
+            // When rustposix runs independently (not as Lind paired with NaCL runtime) we
+            // do not handle signals The test suite runs rustposix independently
+            // and hence we do not handle signals for the test suite
             let mainsigsetatomic = self
                 .sigset
                 .get(
@@ -456,6 +497,9 @@ impl Cage {
             newsigset.insert(0, mainsigset);
         }
 
+        // Initialize a new cage object to replace the current running image
+        // We set all the ids to -1 to indicate the loading phase
+        // We clone the fd table with the memories unmapped
         let newcage = Cage {
             cageid: child_cageid,
             cwd: interface::RustLock::new(self.cwd.read().clone()),
@@ -477,8 +521,8 @@ impl Cage {
             main_threadid: interface::RustAtomicU64::new(0),
             interval_timer: self.interval_timer.clone_with_new_cageid(child_cageid),
         };
-        //wasteful clone of fdtable, but mutability constraints exist
 
+        // Insert new image with updated fd tables to be inserted in the cagetable
         interface::cagetable_insert(child_cageid, newcage);
         0
     }

--- a/src/safeposix/syscalls/sys_calls.rs
+++ b/src/safeposix/syscalls/sys_calls.rs
@@ -433,7 +433,8 @@ impl Cage {
     /// ### Panics
     ///
     /// This function doesn't directly panic - but the unmap memory mappings
-    /// function panics if it cannot create an shm entry
+    /// function panics if it cannot create an shm entry or if the unwrapping 
+    /// on the file descriptor fails due to an invalid fd
     ///
     /// For more information please refer to - [https://man7.org/linux/man-pages/man3/exec.3.html]
     pub fn exec_syscall(&self, child_cageid: u64) -> i32 {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -4,6 +4,7 @@
 mod fs_tests;
 mod ipc_tests;
 mod networking_tests;
+mod sys_tests;
 use rand::Rng;
 use std::net::{TcpListener, UdpSocket};
 

--- a/src/tests/sys_tests.rs
+++ b/src/tests/sys_tests.rs
@@ -130,7 +130,7 @@ pub mod sys_tests {
         cage1.fork_syscall(2);
         let cage2 = interface::cagetable_getref(2);
         // Spawn exec and check if it returns 0
-        assert_eq!(cage2.exec_syscall(2), 0);
+        assert_eq!(cage1.exec_syscall(2), 0);
         lindrustfinalize();
     }
 }

--- a/src/tests/sys_tests.rs
+++ b/src/tests/sys_tests.rs
@@ -2,30 +2,26 @@
 
 #[allow(unused_parens)]
 #[cfg(test)] 
-pub mod test_sys {
+pub mod sys_tests {
     use super::super::*;
     use crate::interface;
-    use crate::safeposix::syscalls::sys_calls::*;
+    use crate::safeposix::{cage::*, dispatcher::*, filesystem};
 
-    pub fn test_sys() {
-        ut_lind_getpid(); 
-        ut_lind_getppid(); 
-        ut_lind_getegid();
-        ut_lind_getuid();
-        ut_lind_geteuid();
-        ut_lind_getgid();
-        ut_lind_fork();
-    } 
-
+    #[test]
     pub fn ut_lind_getpid() {
-        lindrustinit(0); 
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
         let cage =  interface::cagetable_getref(1); 
         assert_eq!(cage.getpid_syscall(),1); 
         lindrustfinalize();
     } 
 
+    #[test]
     pub fn ut_lind_getppid() {
-        lindrustinit(0); 
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
         let cage = interface::cagetable_getref(1); 
         cage.fork_syscall(2);
         let cage2 = interface::cagetable_getref(2);
@@ -34,72 +30,104 @@ pub mod test_sys {
         
     } 
 
+    #[test]
     pub fn ut_lind_getuid() {
-        lindrustinit(0);
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+        let cage = interface::cagetable_getref(1); 
         // The first call to geteuid always returns -1
         assert_eq!(cage.getuid_syscall(),-1);
         // Subsequent calls return the default value
-        assert_eq!(cage.getuid_syscall(),DEFAULT_UID);
+        assert_eq!(cage.getuid_syscall(),DEFAULT_UID as i32);
         lindrustfinalize()
     }
 
+    #[test]
     pub fn ut_lind_geteuid() {
-        lindrustinit(0);
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
         let cage = interface::cagetable_getref(1);
         // The first call to geteuid always returns -1
         assert_eq!(cage.geteuid_syscall(),-1);
         // Subsequent calls return the default value
-        assert_eq!(cage.geteuid_syscall(),DEFAULT_UID);
+        assert_eq!(cage.geteuid_syscall(),DEFAULT_UID as i32);
         lindrustfinalize()
     }
 
+    #[test]
     pub fn ut_lind_getgid() {
-        lindrustinit(0);
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
         let cage = interface::cagetable_getref(1);
         // The first call to geteuid always returns -1
         assert_eq!(cage.getgid_syscall(),-1);
         // Subsequent calls return the default value
-        assert_eq!(cage.getgid_syscall(),DEFAULT_GID);
+        assert_eq!(cage.getgid_syscall(),DEFAULT_GID as i32);
         lindrustfinalize()
     } 
 
+    #[test]
     pub fn ut_lind_getegid() {
-        lindrustinit(0);
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
         let cage = interface::cagetable_getref(1);
         // The first call to geteuid always returns -1
         assert_eq!(cage.getegid_syscall(),-1);
         // Subsequent calls return the default value
-        assert_eq!(cage.getegid_syscall(),DEFAULT_GID);
+        assert_eq!(cage.getegid_syscall(),DEFAULT_GID as i32);
         lindrustfinalize()
     } 
 
+    #[test]
     pub fn ut_lind_fork() {
         // Since the fork syscall is heavily tested in relation to other syscalls
         // we only perform simple checks for testing the sanity of the fork syscall
-        lindrustinit(0); 
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
         let cage = interface::cagetable_getref(1); 
         // Spawn a new child object using the fork syscall 
         cage.fork_syscall(2); 
         // Search for the new cage object with cage_id = 2
         let child_cage = interface::cagetable_getref(2); 
         // Assert the parent value is the the id of the first cage object
-        assert_eq!(child_cage.getpid_syscall(),1);
+        assert_eq!(child_cage.getppid_syscall(),1);
         // Assert that the cage id of the child is the value passed in the original fork syscall
-        assert_eq!(child_cage.getuid(),2);
-        // Assert that the cwd is the same as the parent cage object
-        assert_eq!(child_cage.cwd.read(),cage.cwd.read())
+        assert_eq!(child_cage.getuid_syscall(),-1);
+        assert_eq!(child_cage.getuid_syscall(),DEFAULT_UID as i32);
+        lindrustfinalize();
     }
 
+    #[test]
     pub fn ut_lind_exit() {
         // Since exit function is heavily used and tested in other syscalls and their tests 
         // We only perform preliminary checks for checking the sanity of this syscall
         // We don't check for cases such as exiting a cage twice - since the exiting process 
         // is handled by the NaCl runtime - and it ensures that a cage does not exit twice
-        lindrustinit(0);
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
         let cage = interface::cagetable_getref(1);
         // Call the exit call
-        assert_eq(cage.exit_syscall(EXIT_SUCCESS),EXIT_SUCCESS); 
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS),EXIT_SUCCESS); 
         lindrustfinalize(); 
     }
+
+    pub fn ut_lind_exec() {
+        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+        let cage1 = interface::cagetable_getref(1);
+        // Spawn a new child
+        cage1.fork_syscall(2);
+        let cage2 = interface::cagetable_getref(2);
+        // Spawn exec and check if it returns 0
+        assert_eq!(cage2.exec_syscall(2),0);
+        lindrustfinalize();
+    }   
 } 
 

--- a/src/tests/sys_tests.rs
+++ b/src/tests/sys_tests.rs
@@ -127,7 +127,11 @@ pub mod sys_tests {
         let _thelock = setup::lock_and_init();
         let cage1 = interface::cagetable_getref(1);
         // Spawn a new child
-        cage1.fork_syscall(2);
+        cage1.fork_syscall(2); 
+        // Assert that the fork was correct
+        let child_cage = interface::cagetable_getref(2);
+        assert_eq!(child_cage.getuid_syscall(), -1);
+        assert_eq!(child_cage.getuid_syscall(), DEFAULT_UID as i32);
         // Spawn exec and check if it returns 0
         assert_eq!(cage1.exec_syscall(2), 0);
         lindrustfinalize();

--- a/src/tests/sys_tests.rs
+++ b/src/tests/sys_tests.rs
@@ -128,7 +128,6 @@ pub mod sys_tests {
         let cage1 = interface::cagetable_getref(1);
         // Spawn a new child
         cage1.fork_syscall(2);
-        let cage2 = interface::cagetable_getref(2);
         // Spawn exec and check if it returns 0
         assert_eq!(cage1.exec_syscall(2), 0);
         lindrustfinalize();

--- a/src/tests/sys_tests.rs
+++ b/src/tests/sys_tests.rs
@@ -1,10 +1,12 @@
-#![allow(dead_code)] //suppress warning for these functions not being used in targets other than the tests
+#![allow(dead_code)] //suppress warning for these functions not being used in targets other than the
+                     // tests
 
 #[allow(unused_parens)]
-#[cfg(test)] 
+#[cfg(test)]
 pub mod sys_tests {
     use super::super::*;
     use crate::interface;
+    use crate::safeposix::cage::{FileDescriptor::*, *};
     use crate::safeposix::{cage::*, dispatcher::*, filesystem};
 
     #[test]
@@ -12,34 +14,33 @@ pub mod sys_tests {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup
         let _thelock = setup::lock_and_init();
-        let cage =  interface::cagetable_getref(1); 
-        assert_eq!(cage.getpid_syscall(),1); 
+        let cage = interface::cagetable_getref(1);
+        assert_eq!(cage.getpid_syscall(), 1);
         lindrustfinalize();
-    } 
+    }
 
     #[test]
     pub fn ut_lind_getppid() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup
         let _thelock = setup::lock_and_init();
-        let cage = interface::cagetable_getref(1); 
+        let cage = interface::cagetable_getref(1);
         cage.fork_syscall(2);
         let cage2 = interface::cagetable_getref(2);
-        assert_eq!(cage2.getppid_syscall(),1); 
-        lindrustfinalize(); 
-        
-    } 
+        assert_eq!(cage2.getppid_syscall(), 1);
+        lindrustfinalize();
+    }
 
     #[test]
     pub fn ut_lind_getuid() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup
         let _thelock = setup::lock_and_init();
-        let cage = interface::cagetable_getref(1); 
+        let cage = interface::cagetable_getref(1);
         // The first call to geteuid always returns -1
-        assert_eq!(cage.getuid_syscall(),-1);
+        assert_eq!(cage.getuid_syscall(), -1);
         // Subsequent calls return the default value
-        assert_eq!(cage.getuid_syscall(),DEFAULT_UID as i32);
+        assert_eq!(cage.getuid_syscall(), DEFAULT_UID as i32);
         lindrustfinalize()
     }
 
@@ -50,9 +51,9 @@ pub mod sys_tests {
         let _thelock = setup::lock_and_init();
         let cage = interface::cagetable_getref(1);
         // The first call to geteuid always returns -1
-        assert_eq!(cage.geteuid_syscall(),-1);
+        assert_eq!(cage.geteuid_syscall(), -1);
         // Subsequent calls return the default value
-        assert_eq!(cage.geteuid_syscall(),DEFAULT_UID as i32);
+        assert_eq!(cage.geteuid_syscall(), DEFAULT_UID as i32);
         lindrustfinalize()
     }
 
@@ -63,11 +64,11 @@ pub mod sys_tests {
         let _thelock = setup::lock_and_init();
         let cage = interface::cagetable_getref(1);
         // The first call to geteuid always returns -1
-        assert_eq!(cage.getgid_syscall(),-1);
+        assert_eq!(cage.getgid_syscall(), -1);
         // Subsequent calls return the default value
-        assert_eq!(cage.getgid_syscall(),DEFAULT_GID as i32);
+        assert_eq!(cage.getgid_syscall(), DEFAULT_GID as i32);
         lindrustfinalize()
-    } 
+    }
 
     #[test]
     pub fn ut_lind_getegid() {
@@ -76,11 +77,11 @@ pub mod sys_tests {
         let _thelock = setup::lock_and_init();
         let cage = interface::cagetable_getref(1);
         // The first call to geteuid always returns -1
-        assert_eq!(cage.getegid_syscall(),-1);
+        assert_eq!(cage.getegid_syscall(), -1);
         // Subsequent calls return the default value
-        assert_eq!(cage.getegid_syscall(),DEFAULT_GID as i32);
+        assert_eq!(cage.getegid_syscall(), DEFAULT_GID as i32);
         lindrustfinalize()
-    } 
+    }
 
     #[test]
     pub fn ut_lind_fork() {
@@ -89,34 +90,37 @@ pub mod sys_tests {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup
         let _thelock = setup::lock_and_init();
-        let cage = interface::cagetable_getref(1); 
-        // Spawn a new child object using the fork syscall 
-        cage.fork_syscall(2); 
+        let cage = interface::cagetable_getref(1);
+        // Spawn a new child object using the fork syscall
+        cage.fork_syscall(2);
         // Search for the new cage object with cage_id = 2
-        let child_cage = interface::cagetable_getref(2); 
+        let child_cage = interface::cagetable_getref(2);
         // Assert the parent value is the the id of the first cage object
-        assert_eq!(child_cage.getppid_syscall(),1);
-        // Assert that the cage id of the child is the value passed in the original fork syscall
-        assert_eq!(child_cage.getuid_syscall(),-1);
-        assert_eq!(child_cage.getuid_syscall(),DEFAULT_UID as i32);
+        assert_eq!(child_cage.getppid_syscall(), 1);
+        // Assert that the cage id of the child is the value passed in the original fork
+        // syscall
+        assert_eq!(child_cage.getuid_syscall(), -1);
+        assert_eq!(child_cage.getuid_syscall(), DEFAULT_UID as i32);
         lindrustfinalize();
     }
 
     #[test]
     pub fn ut_lind_exit() {
-        // Since exit function is heavily used and tested in other syscalls and their tests 
-        // We only perform preliminary checks for checking the sanity of this syscall
-        // We don't check for cases such as exiting a cage twice - since the exiting process 
-        // is handled by the NaCl runtime - and it ensures that a cage does not exit twice
-        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
-        // and also performs clean env setup
+        // Since exit function is heavily used and tested in other syscalls and their
+        // tests We only perform preliminary checks for checking the sanity of
+        // this syscall We don't check for cases such as exiting a cage twice -
+        // since the exiting process is handled by the NaCl runtime - and it
+        // ensures that a cage does not exit twice acquiring a lock on TESTMUTEX
+        // prevents other tests from running concurrently, and also performs
+        // clean env setup
         let _thelock = setup::lock_and_init();
         let cage = interface::cagetable_getref(1);
         // Call the exit call
-        assert_eq!(cage.exit_syscall(EXIT_SUCCESS),EXIT_SUCCESS); 
-        lindrustfinalize(); 
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
     }
 
+    #[test]
     pub fn ut_lind_exec() {
         //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup
@@ -126,8 +130,7 @@ pub mod sys_tests {
         cage1.fork_syscall(2);
         let cage2 = interface::cagetable_getref(2);
         // Spawn exec and check if it returns 0
-        assert_eq!(cage2.exec_syscall(2),0);
+        assert_eq!(cage2.exec_syscall(2), 0);
         lindrustfinalize();
-    }   
-} 
-
+    }
+}


### PR DESCRIPTION
## Description
This PR has comments and tests for the exec syscall
- [x] This change adds tests and comments for the exec syscall - along with solving issues with previous tests that used lindrustinitialize and caused problems during the testing and building. 

## How Has This Been Tested?

This has been tested by running the cargo test suite - under the `tests` folder

- Test A - `ut_lind_exec_syscall()`

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
