### PR TITLE
lseek_syscall and close_syscall updates

### DIFF
--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -3224,7 +3224,7 @@ impl Cage {
             // one less reference to the file.
             match filedesc_enum {
                 //if we are a socket, we dont change disk metadata
-                Stream(_) => {} // Stream closing not supported
+                Stream(_) => {} // Streams don't require any additional cleanup
                 Epoll(_) => {}  // TODO: Epoll closing not implemented yet
                 Socket(ref mut socket_filedesc_obj) => {
                     // Retrieve the socket file descriptor object and get the write

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -2465,9 +2465,9 @@ impl Cage {
     ///   particular reference point.
     /// * `whence` - It determines how the seek operation is performed. There
     ///   are three possible values for whence: `SEEK_SET`: The file offset is
-    ///   set to offset bytes. `SEEK_CUR`: The file offset is set to its current
-    ///   location plus offset bytes. `SEEK_END`: The file offset is set to the
-    ///   size of the file plus offset bytes.
+    ///   set to 0 + offset bytes. `SEEK_CUR`: The file offset is set to its
+    ///   current location plus offset bytes. `SEEK_END`: The file offset is set
+    ///   to the size of the file plus offset bytes.
     ///
     /// ### Returns
     ///
@@ -3170,7 +3170,7 @@ impl Cage {
     ///
     /// ### Panics
     ///
-    /// * There are no such panics which happen inside the function.
+    /// * This syscall indirectly panics when the helper function panics.
     ///
     /// For more detailed description of all the commands and return values, see
     /// [close(2)](https://man7.org/linux/man-pages/man2/close.2.html)
@@ -3267,11 +3267,15 @@ impl Cage {
                                     // Remove the socket from the inode table and the domain
                                     // socket paths if it is no longer needed.
                                     drop(inodeobj);
+                                    // Get the entire path of the socket which is used for removing
+                                    // it from the metadata file.
                                     let path = normpath(
                                         convpath(sockhandle.localaddr.unwrap().path()),
                                         self,
                                     );
+                                    // Remove the reference of the inode from the inodetable
                                     FS_METADATA.inodetable.remove(&inodenum);
+                                    // Remove any domain socket paths associated with the socket
                                     NET_METADATA.domsock_paths.remove(&path);
                                 }
                             }

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -4138,8 +4138,18 @@ pub mod fs_tests {
         assert!(fd >= 0);
 
         // Attempt to seek to a negative offset and check if it returns an error
+        // using "SEEK_SET" whence, where we are explicitly setting the file
+        // offset to -10 value.
         assert_eq!(
             cage.lseek_syscall(fd, -10, SEEK_SET),
+            -(Errno::EINVAL as i32)
+        );
+
+        // Attempt to seek to a negative offset and check if it returns an error
+        // using "SEEK_CUR" whence, where current position of the file is 0,
+        // as it's empty initially, and we are adding -10 to the offset.
+        assert_eq!(
+            cage.lseek_syscall(fd, -10, SEEK_CUR),
             -(Errno::EINVAL as i32)
         );
 


### PR DESCRIPTION
## Description

Fixes # (issue)
The following changes include the tests and comments in the code for the `lseek_syscall` and `close_syscall` file system calls under RustPosix.
The tests were added to cover all the possible scenarios that might happen when calling the file system_calls  `lseek_syscall` and `close_syscall`.

### Type of change
- []  This change just contains the tests for an existing file system call.
- []  This change contains the minor code changes and comments for lseek_syscall and close_syscall.
- []  This change contains code reformatting for existing file system calls. 

## How Has This Been Tested?
Inorder to run the tests, we need to run `cargo test --lib` command inside the `safeposix-rust` directory.

All the tests are present under this directory: `lind_project/src/safeposix-rust/src/tests/fs_tests.rs`

- Test A - `ut_lind_fs_lseek_on_file()`
- Test B - `ut_lind_fs_lseek_on_directory()`
- Test C - `ut_lind_fs_lseek_invalid_whence()`
- Test D - `ut_lind_fs_lseek_beyond_file_size()`
- Test E -  `ut_lind_fs_lseek_before_start_of_file()`
- Test F - `ut_lind_fs_lseek_on_pipe()`
- Test G - `ut_lind_fs_lseek_on_chardev()`
- Test H - `ut_lind_fs_lseek_on_epoll()`
- Test I - `ut_lind_fs_close_chardev()`
- Test J - `ut_lind_fs_close_pipe()`
- Test K - `ut_lind_fs_close_socket()`
- Test L - `ut_lind_fs_close_directory()`
- Test M - `ut_lind_fs_close_regular_file()`

## Checklist:
- [] My code follows the style guidelines of this project
- [] I have commented my code, particularly in hard-to-understand areas
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
