### PR TITLE
test and comments for netshutdown

### DIFF
--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -2051,7 +2051,7 @@ impl Cage {
     /// SHUT_RD, further receptions will be disallowed.  If how is SHUT_WR,
     /// further transmissions will be disallowed.  If how is SHUT_RDWR, further
     /// receptions and transmissions will be disallowed.
-
+    ///
     /// ### Function Arguments
     /// The `netshutdown_syscall()` receives two arguments:
     /// * `fd` - The socket file descriptor
@@ -2059,7 +2059,7 @@ impl Cage {
     ///   receptions will be disallowed.  If how is SHUT_WR, further
     ///   transmissions will be disallowed.  If how is SHUT_RDWR, further
     ///   receptions and transmissions will be disallowed.
-
+    ///
     /// ### Returns
     /// On success, zero is returned. Otherwise, errors or panics are returned
     /// for different scenarios.

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -2200,7 +2200,7 @@ impl Cage {
         // now change the connection state for all socket types
         match how {
             SHUT_RD => {
-                if sockhandle.state == ConnState::CONNWRONLY {
+                if sockhandle.state == ConnState::CONNRDONLY {
                     // shutdown RD on socket with RDONLY state means
                     // the socket is neither readable nor writable
                     sockhandle.state = ConnState::NOTCONNECTED;
@@ -2214,7 +2214,7 @@ impl Cage {
                 }
             }
             SHUT_WR => {
-                if sockhandle.state == ConnState::CONNRDONLY {
+                if sockhandle.state == ConnState::CONNWRONLY {
                     // shutdown WR on socket with WRONLY state means
                     // the socket is neither readable nor writable
                     sockhandle.state = ConnState::NOTCONNECTED;

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -2047,10 +2047,10 @@ impl Cage {
     /// ## ------------------SHUTDOWN SYSCALL------------------
     /// ### Description
     /// The `netshutdown_syscall()` call causes all or part of a full-duplex
-    /// connection on the socket associated with fd to be shut down. If how is
-    /// SHUT_RD, further receptions will be disallowed.  If how is SHUT_WR,
-    /// further transmissions will be disallowed.  If how is SHUT_RDWR, further
-    /// receptions and transmissions will be disallowed.
+    /// connection on the socket associated with fd to be shut down. If "how" is
+    /// SHUT_RD, further receptions will be disallowed.  If "how" is SHUT_WR,
+    /// further transmissions will be disallowed.  If "how" is SHUT_RDWR,
+    /// further receptions and transmissions will be disallowed.
     ///
     /// ### Function Arguments
     /// The `netshutdown_syscall()` receives two arguments:
@@ -2066,7 +2066,7 @@ impl Cage {
     ///
     /// ### Errors
     /// * EBADF - An invalid file descriptor was given in one of the sets
-    /// * EINVAL - An invalid value was specified in how
+    /// * EINVAL - An invalid value was specified in "how"
     /// * ENOTSOCK - The file descriptor sockfd does not refer to a socket.
     /// * ENOTCONN - The specified socket is not connected.
     ///

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -2044,13 +2044,53 @@ impl Cage {
         }
     }
 
+    /// ## ------------------SHUTDOWN SYSCALL------------------
+    /// ### Description
+    /// The `netshutdown_syscall()` call causes all or part of a full-duplex
+    /// connection on the socket associated with fd to be shut down. If how is
+    /// SHUT_RD, further receptions will be disallowed.  If how is SHUT_WR,
+    /// further transmissions will be disallowed.  If how is SHUT_RDWR, further
+    /// receptions and transmissions will be disallowed.
+
+    /// ### Function Arguments
+    /// The `netshutdown_syscall()` receives two arguments:
+    /// * `fd` - The socket file descriptor
+    /// * `how` -  how to shutdown the socket. If how is SHUT_RD, further
+    ///   receptions will be disallowed.  If how is SHUT_WR, further
+    ///   transmissions will be disallowed.  If how is SHUT_RDWR, further
+    ///   receptions and transmissions will be disallowed.
+
+    /// ### Returns
+    /// On success, zero is returned. Otherwise, errors or panics are returned
+    /// for different scenarios.
+    ///
+    /// ### Errors
+    /// * EBADF - An invalid file descriptor was given in one of the sets
+    /// * EINVAL - An invalid value was specified in how
+    /// * ENOTSOCK - The file descriptor sockfd does not refer to a socket.
+    /// * ENOTCONN - The specified socket is not connected.
+    ///
+    /// ### Panics
+    /// No panic is expected from this syscall
     pub fn netshutdown_syscall(&self, fd: i32, how: i32) -> i32 {
+        // BUG: we did not check if the specified socket is connected or not
+
+        // first let's check fd range
+        if fd < 0 || fd >= MAXFD {
+            return syscall_error(
+                Errno::EBADF,
+                "netshutdown",
+                "provided fd is not a valid file descriptor",
+            );
+        }
+
         match how {
             SHUT_RDWR | SHUT_RD | SHUT_WR => {
                 return Self::_cleanup_socket(self, fd, how);
             }
             _ => {
-                //See http://linux.die.net/man/2/shutdown for nuance to this error
+                // invalid how argument
+                // See http://linux.die.net/man/2/shutdown for nuance to this error
                 return syscall_error(
                     Errno::EINVAL,
                     "netshutdown",
@@ -2060,6 +2100,7 @@ impl Cage {
         }
     }
 
+    // this function handles the core logic of shutdown
     pub fn _cleanup_socket_inner_helper(
         sockhandle: &mut SocketHandle,
         how: i32,
@@ -2067,40 +2108,59 @@ impl Cage {
     ) -> i32 {
         // we need to do a bunch of actual socket cleanup for INET sockets
         if sockhandle.domain != AF_UNIX {
+            // this flag is used for marking if we want to release the resources of the
+            // socket
             let mut releaseflag = false;
             if let Some(ref sobj) = sockhandle.innersocket {
+                // get the innersocket
                 if shutdown {
+                    // shutdown the internal socket with libc shutdown
                     let shutresult = sobj.shutdown(how);
 
                     if shutresult < 0 {
+                        // in case of error from libc shutdown, return the errno
                         match Errno::from_discriminant(interface::get_errno()) {
                             Ok(i) => {
                                 return syscall_error(
                                     i,
                                     "shutdown",
-                                    "The libc call to setsockopt failed!",
+                                    "The libc call to shutdown failed!",
                                 );
                             }
-                            Err(()) => panic!("Unknown errno value from setsockopt returned!"),
+                            Err(()) => panic!("Unknown errno value from shutdown returned!"),
                         };
                     }
 
+                    // here we want to release the resources (port, innersocket) if the socket is
+                    // closed on RD and WR at the same time. however, BUG: this
+                    // is not something that is supposed to be done in shutdown, instead, they
+                    // should be handled in close
                     match how {
                         SHUT_RD => {
+                            // if we shutdown RD on a socket that is already in RDONLY state
+                            // that would mean the socket can neither read or write
+                            // so we want to release its resources
                             if sockhandle.state == ConnState::CONNRDONLY {
                                 releaseflag = true;
                             }
                         }
                         SHUT_WR => {
+                            // if we shutdown WR on a socket that is already in WRONLY state
+                            // that would mean the socket can neither read or write
+                            // so we want to release its resources
                             if sockhandle.state == ConnState::CONNWRONLY {
                                 releaseflag = true;
                             }
                         }
                         SHUT_RDWR => {
+                            // we shutdown RD and WR
+                            // that would mean the socket can neither read or write
+                            // so we want to release its resources
                             releaseflag = true;
                         }
                         _ => {
-                            //See http://linux.die.net/man/2/shutdown for nuance to this error
+                            // invalid how argument
+                            // See http://linux.die.net/man/2/shutdown for nuance to this error
                             return syscall_error(
                                 Errno::EINVAL,
                                 "netshutdown",
@@ -2109,51 +2169,69 @@ impl Cage {
                         }
                     }
                 } else {
-                    //Reaching this means that the socket is closed. Removing the sockobj
-                    //indicates that the sockobj will drop, and therefore close
+                    // Reaching this means that the socket is closed after close_syscall. Removing
+                    // the sockobj indicates that the sockobj will drop, and therefore close
                     releaseflag = true;
                     sockhandle.innersocket = None;
                 }
             }
 
+            // if we want to release the associated resources of the socket
             if releaseflag {
                 if let Some(localaddr) = sockhandle.localaddr.as_ref().clone() {
-                    //move to end
+                    // release the port
                     let release_ret_val = NET_METADATA._release_localport(
                         localaddr.addr(),
                         localaddr.port(),
                         sockhandle.protocol,
                         sockhandle.domain,
                     );
+                    // release the localaddr
                     sockhandle.localaddr = None;
                     if let Err(e) = release_ret_val {
+                        // in case of any error in releasing the port
+                        // return the error
                         return e;
                     }
                 }
             }
         }
 
-        // now change the connections for all socket types
+        // now change the connection state for all socket types
         match how {
             SHUT_RD => {
                 if sockhandle.state == ConnState::CONNWRONLY {
+                    // shutdown RD on socket with RDONLY state means
+                    // the socket is neither readable nor writable
                     sockhandle.state = ConnState::NOTCONNECTED;
                 } else {
+                    // otherwise, we only closed RD, and the socket can still write
+                    // however, BUG: Linux is handling shutdown for different state seperately.
+                    // shutdown on RD does not mean the socket would always be WRONLY. for example,
+                    // if the socket is in LISTEN state, shutdown on RD will cause the socket to
+                    // disconnect directly, without the need to shutdown on WR again.
                     sockhandle.state = ConnState::CONNWRONLY;
                 }
             }
             SHUT_WR => {
                 if sockhandle.state == ConnState::CONNRDONLY {
+                    // shutdown WR on socket with WRONLY state means
+                    // the socket is neither readable nor writable
                     sockhandle.state = ConnState::NOTCONNECTED;
                 } else {
+                    // otherwise, we only closed WR, and the socket can still read
+                    // however, see above BUG
                     sockhandle.state = ConnState::CONNRDONLY;
                 }
             }
             SHUT_RDWR => {
+                // the socket is neither readable nor writable
+                // we just set the state to not connected
                 sockhandle.state = ConnState::NOTCONNECTED;
             }
             _ => {
-                //See http://linux.die.net/man/2/shutdown for nuance to this error
+                // invalid how argument
+                // See http://linux.die.net/man/2/shutdown for nuance to this error
                 return syscall_error(
                     Errno::EINVAL,
                     "netshutdown",
@@ -2165,6 +2243,7 @@ impl Cage {
         return 0;
     }
 
+    // this function is an inner function of shutdown and checks for fd type
     pub fn _cleanup_socket_inner(
         &self,
         filedesc: &mut FileDescriptor,
@@ -2172,11 +2251,13 @@ impl Cage {
         shutdown: bool,
     ) -> i32 {
         if let Socket(sockfdobj) = filedesc {
+            // get write lock of sockhandle
             let sock_tmp = sockfdobj.handle.clone();
             let mut sockhandle = sock_tmp.write();
 
             Self::_cleanup_socket_inner_helper(&mut *sockhandle, how, shutdown)
         } else {
+            // this file descriptor is not a socket fd
             syscall_error(
                 Errno::ENOTSOCK,
                 "cleanup socket",
@@ -2185,19 +2266,27 @@ impl Cage {
         }
     }
 
+    // this function is an inner function of shutdown and checks for fd
     pub fn _cleanup_socket(&self, fd: i32, how: i32) -> i32 {
+        // get the file descriptor object
         let checkedfd = self.get_filedescriptor(fd).unwrap();
         let mut unlocked_fd = checkedfd.write();
         if let Some(ref mut filedesc_enum) = &mut *unlocked_fd {
             let inner_result = self._cleanup_socket_inner(filedesc_enum, how, true);
             if inner_result < 0 {
+                // in case of error, return the error
                 return inner_result;
             }
 
+            // if how is SHUT_RDWR, we clear this file descriptor
+            // however, BUG: according to standard, shutdown() doesn’t close the file
+            // descriptor, even if how is specified as SHUT_RDWR. To close the file
+            // descriptor, we must additionally call close().
             if how == SHUT_RDWR {
                 let _discarded_fd = unlocked_fd.take();
             }
         } else {
+            // file descriptor does not exist
             return syscall_error(Errno::EBADF, "cleanup socket", "invalid file descriptor");
         }
 

--- a/src/tests/networking_tests.rs
+++ b/src/tests/networking_tests.rs
@@ -2422,8 +2422,347 @@ pub mod net_tests {
     }
 
     #[test]
+    pub fn ut_lind_net_shutdown_bad_input() {
+        // this test is used for testing shutdown with error input
+
+        // acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        // unexist file descriptor error
+        assert_eq!(
+            cage.netshutdown_syscall(10, SHUT_RD),
+            -(Errno::EBADF as i32)
+        );
+
+        // out of range file descriptor error
+        assert_eq!(
+            cage.netshutdown_syscall(-1, SHUT_RD),
+            -(Errno::EBADF as i32)
+        );
+
+        let filefd = cage.open_syscall("/netshutdowntest.txt", O_CREAT | O_EXCL | O_RDWR, S_IRWXA);
+        assert!(filefd > 0);
+        // wrong fd type error
+        assert_eq!(
+            cage.netshutdown_syscall(filefd, SHUT_RD),
+            -(Errno::ENOTSOCK as i32)
+        );
+
+        let sockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
+        let port: u16 = generate_random_port();
+        //binding to a socket
+        let sockaddr = interface::SockaddrV4 {
+            sin_family: AF_INET as u16,
+            sin_port: port.to_be(),
+            sin_addr: interface::V4Addr {
+                s_addr: u32::from_ne_bytes([127, 0, 0, 1]),
+            },
+            padding: 0,
+        };
+        let socket = interface::GenSockaddr::V4(sockaddr); //127.0.0.1
+
+        // socket not connect error
+        // BUG: failed the test
+        // assert_eq!(
+        //     cage.netshutdown_syscall(sockfd, SHUT_RD),
+        //     -(Errno::ENOTCONN as i32)
+        // );
+
+        assert_eq!(cage.bind_syscall(sockfd, &socket), 0);
+        assert_eq!(cage.listen_syscall(sockfd, 10), 0);
+
+        // wrong how argument error
+        assert_eq!(
+            cage.netshutdown_syscall(sockfd, 10),
+            -(Errno::EINVAL as i32)
+        );
+
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    #[test]
+    pub fn ut_lind_net_shutdown_unix() {
+        // this test is used for testing shutdown with UNIX socket
+
+        // acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        let serverfd = cage.socket_syscall(AF_UNIX, SOCK_STREAM, 0);
+
+        let serveraddr = interface::new_sockaddr_unix(AF_UNIX as u16, "server_shutdown".as_bytes());
+        let serversocket = interface::GenSockaddr::Unix(serveraddr);
+
+        assert_eq!(cage.bind_syscall(serverfd, &serversocket), 0);
+        assert_eq!(cage.listen_syscall(serverfd, 10), 0);
+
+        assert_eq!(cage.fork_syscall(2), 0);
+        assert_eq!(cage.fork_syscall(3), 0);
+
+        let barrier = Arc::new(Barrier::new(2));
+        let barrier_clone = barrier.clone();
+
+        let barrier_shut = Arc::new(Barrier::new(2));
+        let barrier_shut_clone = barrier_shut.clone();
+
+        let thread = interface::helper_thread(move || {
+            let cage2 = interface::cagetable_getref(2);
+
+            let fd = cage2.socket_syscall(AF_UNIX, SOCK_STREAM, 0);
+            assert_eq!(cage2.connect_syscall(fd, &serversocket), 0);
+
+            // first make sure send and recv are working before shutdown
+            assert_eq!(cage2.send_syscall(fd, str2cbuf("client send"), 11, 0), 11);
+            let mut buf = sizecbuf(11);
+            assert_eq!(cage2.read_syscall(fd, buf.as_mut_ptr(), 11), 11);
+            assert_eq!(cbuf2str(&buf), "server send");
+
+            barrier_clone.wait();
+
+            // now let's shutdown RD
+            assert_eq!(cage2.netshutdown_syscall(fd, SHUT_RD), 0);
+
+            // BUG: read after SHUT_RD should not raise ENOTCONN error
+            // the desired behavior is to return end-of-file (0)
+            // assert_eq!(cage2.read_syscall(fd, buf.as_mut_ptr(), 8), 0);
+
+            barrier_shut_clone.wait();
+
+            // write should succeed
+            assert_eq!(
+                cage2.send_syscall(fd, str2cbuf("before SHUT_WR"), 14, 0),
+                14
+            );
+            assert_eq!(cage2.netshutdown_syscall(fd, SHUT_WR), 0);
+
+            assert_eq!(cage2.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        });
+
+        let mut sockgarbage = interface::GenSockaddr::V4(interface::SockaddrV4::default());
+        let fd = cage.accept_syscall(serverfd, &mut sockgarbage);
+        assert!(fd > 0);
+
+        // first make sure send and recv are working
+        let mut buf = sizecbuf(11);
+        assert_eq!(cage.read_syscall(fd, buf.as_mut_ptr(), 11), 11);
+        assert_eq!(cbuf2str(&buf), "client send");
+        assert_eq!(cage.send_syscall(fd, str2cbuf("server send"), 11, 0), 11);
+
+        assert_eq!(cage.send_syscall(fd, str2cbuf("shutdown"), 8, 0), 8);
+        barrier.wait();
+        barrier_shut.wait();
+        // BUG: peer already closed RD, now subsequent write should fail with EPIPE
+        // assert_ne!(cage.send_syscall(fd, str2cbuf("shutdown"), 8, 0), 8);
+
+        // after SHUT_WR, once the peer application has read all outstanding data, it
+        // will see end-of-file.
+        let mut buf = sizecbuf(14);
+        assert_eq!(cage.read_syscall(fd, buf.as_mut_ptr(), 14), 14);
+        assert_eq!(cbuf2str(&buf), "before SHUT_WR");
+        assert_eq!(cage.read_syscall(fd, buf.as_mut_ptr(), 14), 0);
+
+        assert_eq!(cage.close_syscall(fd), 0);
+
+        let barrier2 = Arc::new(Barrier::new(2));
+        let barrier2_clone = barrier2.clone();
+
+        let barrier2_shut = Arc::new(Barrier::new(2));
+        let barrier2_shut_clone = barrier2_shut.clone();
+
+        let thread2 = interface::helper_thread(move || {
+            let cage3 = interface::cagetable_getref(3);
+
+            let fd = cage3.socket_syscall(AF_UNIX, SOCK_STREAM, 0);
+            assert_eq!(cage3.connect_syscall(fd, &serversocket), 0);
+
+            // first make sure send and recv are working before shutdown
+            assert_eq!(cage3.send_syscall(fd, str2cbuf("client send"), 11, 0), 11);
+            let mut buf = sizecbuf(11);
+            assert_eq!(cage3.read_syscall(fd, buf.as_mut_ptr(), 11), 11);
+            assert_eq!(cbuf2str(&buf), "server send");
+
+            barrier2_clone.wait();
+
+            // now let's shutdown RD and WR
+            assert_eq!(cage3.netshutdown_syscall(fd, SHUT_RDWR), 0);
+
+            barrier2_shut_clone.wait();
+
+            // now neither send nor recv should succeed
+            assert_ne!(cage3.send_syscall(fd, str2cbuf("client send"), 11, 0), 11);
+            // BUG: should not raise ENOTCONN error
+            // the desired behavior is to return end-of-file (0)
+            // let mut buf = sizecbuf(11);
+            // assert_eq!(cage3.read_syscall(fd, buf.as_mut_ptr(), 11), 0);
+
+            assert_eq!(cage3.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        });
+
+        let fd = cage.accept_syscall(serverfd, &mut sockgarbage);
+        assert!(fd > 0);
+
+        // first make sure send and recv are working
+        let mut buf = sizecbuf(11);
+        assert_eq!(cage.read_syscall(fd, buf.as_mut_ptr(), 11), 11);
+        assert_eq!(cbuf2str(&buf), "client send");
+        assert_eq!(cage.send_syscall(fd, str2cbuf("server send"), 11, 0), 11);
+
+        barrier2.wait();
+        barrier2_shut.wait();
+
+        // peer just shutdown RD and WR
+        // now neither send nor recv should succeed
+        // BUG: failed the test below
+        // assert_ne!(cage.send_syscall(fd, str2cbuf("server send"), 11, 0), 11);
+
+        // BUG: peer already shutdown, read should not block
+        // let mut buf = sizecbuf(11);
+        // assert_eq!(cage.read_syscall(fd, buf.as_mut_ptr(), 11), 0);
+
+        thread.join().unwrap();
+        thread2.join().unwrap();
+
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    #[test]
+    pub fn ut_lind_net_shutdown_inet() {
+        // this test is used for testing shutdown with INET socket
+
+        // acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+
+        let serverfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
+
+        let port: u16 = generate_random_port();
+        //binding to a socket
+        let sockaddr = interface::SockaddrV4 {
+            sin_family: AF_INET as u16,
+            sin_port: port.to_be(),
+            sin_addr: interface::V4Addr {
+                s_addr: u32::from_ne_bytes([127, 0, 0, 1]),
+            },
+            padding: 0,
+        };
+        let socket = interface::GenSockaddr::V4(sockaddr); //127.0.0.1
+
+        assert_eq!(cage.bind_syscall(serverfd, &socket), 0);
+        assert_eq!(cage.listen_syscall(serverfd, 10), 0);
+
+        assert_eq!(cage.fork_syscall(2), 0);
+        assert_eq!(cage.fork_syscall(3), 0);
+
+        let barrier = Arc::new(Barrier::new(2));
+        let barrier_clone = barrier.clone();
+
+        let thread = interface::helper_thread(move || {
+            let cage2 = interface::cagetable_getref(2);
+
+            let fd = cage2.socket_syscall(AF_INET, SOCK_STREAM, 0);
+            assert_eq!(cage2.connect_syscall(fd, &socket), 0);
+
+            // first make sure send and recv are working before shutdown
+            assert_eq!(cage2.send_syscall(fd, str2cbuf("client send"), 11, 0), 11);
+            let mut buf = sizecbuf(11);
+            assert_eq!(cage2.read_syscall(fd, buf.as_mut_ptr(), 11), 11);
+            assert_eq!(cbuf2str(&buf), "server send");
+
+            assert_eq!(
+                cage2.send_syscall(fd, str2cbuf("before SHUT_WR"), 14, 0),
+                14
+            );
+            assert_eq!(cage2.netshutdown_syscall(fd, SHUT_WR), 0);
+
+            barrier_clone.wait();
+
+            assert_eq!(cage2.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        });
+
+        let mut sockgarbage = interface::GenSockaddr::V4(interface::SockaddrV4::default());
+        let fd = cage.accept_syscall(serverfd, &mut sockgarbage);
+        assert!(fd > 0);
+
+        // first make sure send and recv are working
+        let mut buf = sizecbuf(11);
+        assert_eq!(cage.read_syscall(fd, buf.as_mut_ptr(), 11), 11);
+        assert_eq!(cbuf2str(&buf), "client send");
+        assert_eq!(cage.send_syscall(fd, str2cbuf("server send"), 11, 0), 11);
+
+        // peer SHUT_WR
+        barrier.wait();
+        let mut buf = sizecbuf(14);
+        // data already sent should still be readable
+        assert_eq!(cage.read_syscall(fd, buf.as_mut_ptr(), 14), 14);
+        assert_eq!(cbuf2str(&buf), "before SHUT_WR");
+        // subsequent read should return end-of-file
+        assert_eq!(cage.read_syscall(fd, buf.as_mut_ptr(), 14), 0);
+
+        assert_eq!(cage.close_syscall(fd), 0);
+
+        let barrier2 = Arc::new(Barrier::new(2));
+        let barrier2_clone = barrier2.clone();
+
+        let thread2 = interface::helper_thread(move || {
+            let cage3 = interface::cagetable_getref(3);
+
+            let fd = cage3.socket_syscall(AF_INET, SOCK_STREAM, 0);
+            assert_eq!(cage3.connect_syscall(fd, &socket), 0);
+
+            // first make sure send and recv are working before shutdown
+            assert_eq!(cage3.send_syscall(fd, str2cbuf("client send"), 11, 0), 11);
+            let mut buf = sizecbuf(11);
+            assert_eq!(cage3.read_syscall(fd, buf.as_mut_ptr(), 11), 11);
+            assert_eq!(cbuf2str(&buf), "server send");
+
+            assert_eq!(
+                cage3.send_syscall(fd, str2cbuf("before SHUT_RDWR"), 16, 0),
+                16
+            );
+            assert_eq!(cage3.netshutdown_syscall(fd, SHUT_RDWR), 0);
+
+            barrier2_clone.wait();
+
+            assert_eq!(cage3.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        });
+
+        let fd = cage.accept_syscall(serverfd, &mut sockgarbage);
+        assert!(fd > 0);
+
+        // first make sure send and recv are working
+        let mut buf = sizecbuf(11);
+        assert_eq!(cage.read_syscall(fd, buf.as_mut_ptr(), 11), 11);
+        assert_eq!(cbuf2str(&buf), "client send");
+        assert_eq!(cage.send_syscall(fd, str2cbuf("server send"), 11, 0), 11);
+
+        // peer SHUT_RDWR
+        barrier2.wait();
+        let mut buf = sizecbuf(16);
+        // data already sent should still be readable
+        assert_eq!(cage.read_syscall(fd, buf.as_mut_ptr(), 16), 16);
+        assert_eq!(cbuf2str(&buf), "before SHUT_RDWR");
+        // subsequent read should return end-of-file
+        assert_eq!(cage.read_syscall(fd, buf.as_mut_ptr(), 16), 0);
+
+        thread.join().unwrap();
+        thread2.join().unwrap();
+
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
+    #[test]
     pub fn ut_lind_net_shutdown() {
-        //acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
         // and also performs clean env setup
         let _thelock = setup::lock_and_init();
 
@@ -2472,7 +2811,6 @@ pub mod net_tests {
             assert_eq!(cage2.netshutdown_syscall(fd, SHUT_RD), 0);
             assert_eq!(cage2.send_syscall(fd, str2cbuf("random string"), 13, 0), 13);
             assert_eq!(cage2.netshutdown_syscall(fd, SHUT_RDWR), 0);
-            assert_ne!(cage2.netshutdown_syscall(fd, SHUT_RDWR), 0); //should fail
 
             assert_eq!(cage2.close_syscall(serversockfd), 0);
             assert_eq!(cage2.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);


### PR DESCRIPTION
## Description

This PR adds some tests and comments for netshutdown_syscall. Current implementation of shutdown has several big [issues](https://github.com/Lind-Project/safeposix-rust/issues/312), so only some basic tests could be done on shutdown right now.

Fixes # (issue)
1. add fd range check at the beginning of the shutdown
2. fixed a minor issue in setting connection state under _cleanup_socket_inner_helper

<!-- Please include a summary of the changes and the related issue. --> 
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

- Test A - `ut_lind_net_shutdown_bad_input`
- Test B - `ut_lind_net_shutdown_unix`
- Test C - `ut_lind_net_shutdown_inet`

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
