### PR TITLE
test and comment for sockopt syscalls

### DIFF
--- a/src/safeposix/syscalls/net_constants.rs
+++ b/src/safeposix/syscalls/net_constants.rs
@@ -334,6 +334,13 @@ pub const SO_ACCEPTCONN: i32 = 30;
 pub const SOL_TCP: i32 = IPPROTO_TCP;
 pub const SOL_UDP: i32 = IPPROTO_UDP;
 
+// some TCP flags below are not part of Linux standards
+// for example, TCP_NOPUSH is the flag used in FreeBSD/MacOS
+// while the actual flag in Linux that serves the similar purpose
+// is TCP_CORK
+// Besides, some other flags are also not found in Linux man page:
+// TCP_KEEPALIVE, TCP_CONNECTIONTIMEOUT, PERSIST_TIMEOUT, TCP_RXT_CONNDROPTIME
+// and TCP_RXT_FINDROP
 pub const TCP_NODELAY: i32 = 0x01; // don't delay send to coalesce packets
 pub const TCP_MAXSEG: i32 = 0x02; // set maximum segment size
 pub const TCP_NOPUSH: i32 = 0x04; // don't push last block of write


### PR DESCRIPTION
## Description

This PR adds test and comments for getsockopt_syscall and setsockopt_syscall. Current implementaion of sockopt syscalls have several big [issues](https://github.com/Lind-Project/safeposix-rust/issues/309) and may need a overhaul in the future. Only some basic tests were added.

Fixes # (issue)
1. add fd range check

<!-- Please include a summary of the changes and the related issue. --> 
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

- Test A - `ut_lind_net_sockopt_bad_input_optname`
- Test B - `ut_lind_net_getsockopt_bad_input`
- Test C - `ut_lind_net_setsockopt_bad_input`
- Test D - `ut_lind_net_socketoptions`

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
