### PR TITLE
FD issue

### DIFF
--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -186,268 +186,258 @@ impl Cage {
         if path.len() == 0 {
             return syscall_error(Errno::ENOENT, "open", "given path was null");
         }
-
+    
         // Retrieve the absolute path from the root directory. The absolute path is then
         // used to validate directory paths while navigating through
         // subdirectories and creating a new file or open existing file at the given
         // location.
         let truepath = normpath(convpath(path), self);
-
+    
         // Fetch the next file descriptor and its lock write guard to ensure the file
         // can be associated with the file descriptor
         let (fd, guardopt) = self.get_next_fd(None);
-        match fd {
-            // If the file descriptor is invalid, the return value is always an error with value
-            // (ENFILE).
-            fd if fd == (Errno::ENFILE as i32) => {
-                return syscall_error(
-                    Errno::ENFILE,
-                    "open_helper",
-                    "no available file descriptor number could be found",
-                );
-            }
-            // When the file descriptor is valid, we proceed with performing the remaining checks
-            // for open_syscall.
-            fd if fd > 0 => {
-                // File Descriptor Write Lock Guard
-                let fdoption = &mut *guardopt.unwrap();
-
-                // Walk through the absolute path which returns a tuple consisting of inode
-                // number of file (if it exists), and inode number of parent (if it exists)
-                match metawalkandparent(truepath.as_path()) {
-                    // Case 1: When the file doesn't exist but the parent directory exists
-                    (None, Some(pardirinode)) => {
-                        // Check if O_CREAT flag is not present, then a file can not be created and
-                        // error is returned.
-                        if 0 == (flags & O_CREAT) {
-                            return syscall_error(
-                                Errno::ENOENT,
-                                "open",
-                                "tried to open a file that did not exist, and O_CREAT was not specified",
-                            );
-                        }
-
-                        // Error is thrown when the input flags contain S_IFCHR flag representing a
-                        // special character file.
-                        if S_IFCHR == (S_IFCHR & flags) {
-                            return syscall_error(Errno::EINVAL, "open", "Invalid value in flags");
-                        }
-
-                        // S_FILETYPEFLAGS represents a bitmask that can be used to extract the file
-                        // type information from a file's mode. This code is
-                        // referenced from Lind-Repy codebase. Here, we are
-                        // checking whether the mode bits are sane by ensuring that only valid file
-                        // permission bits (S_IRWXA) and file type bits (S_FILETYPEFLAGS) are set.
-                        // Else, we return the error.
-                        if mode & (S_IRWXA | S_FILETYPEFLAGS as u32) != mode {
-                            return syscall_error(Errno::EPERM, "open", "Mode bits were not sane");
-                        }
-
-                        let filename = truepath.file_name().unwrap().to_str().unwrap().to_string(); //for now we assume this is sane, but maybe this should be checked later
-                        let time = interface::timestamp(); //We do a real timestamp now
-
-                        // S_IFREG is the flag for a regular file, so it's added to the mode to
-                        // indicate that the new file being created is a regular file.
-                        let effective_mode = S_IFREG as u32 | mode;
-
-                        // Create a new inode of type "File" representing a file and set the
-                        // required attributes
-                        let newinode = Inode::File(GenericInode {
-                            size: 0,
-                            uid: DEFAULT_UID,
-                            gid: DEFAULT_GID,
-                            mode: effective_mode,
-                            linkcount: 1, /* because when a new file is created, it has a single
-                                           * hard link, which is the directory entry that points
-                                           * to this file's inode. */
-                            refcount: 1, /* Because a new file descriptor will open and refer to
-                                          * this file */
-                            atime: time,
-                            ctime: time,
-                            mtime: time,
-                        });
-
-                        // Fetch the next available inode number using the FileSystem MetaData table
-                        let newinodenum = FS_METADATA
-                            .nextinode
-                            .fetch_add(1, interface::RustAtomicOrdering::Relaxed); //fetch_add returns the previous value, which is the inode number we want
-
-                        // Fetch the inode of the parent directory and only proceed when its type is
-                        // directory.
-                        if let Inode::Dir(ref mut ind) =
-                            *(FS_METADATA.inodetable.get_mut(&pardirinode).unwrap())
-                        {
-                            ind.filename_to_inode_dict.insert(filename, newinodenum);
-                            ind.linkcount += 1; // Since the parent is now associated to the new file, its linkcount
-                                                // will increment by 1
-                            ind.ctime = time; // Here, update the ctime and mtime for the parent directory as well
-                            ind.mtime = time;
-                        } else {
-                            return syscall_error(
-                                Errno::ENOTDIR,
-                                "open",
-                                "tried to create a file as a child of something that isn't a directory",
-                            );
-                        }
-                        // Update the inode table by inserting the newly formed inode mapped with
-                        // its inode number.
-                        FS_METADATA.inodetable.insert(newinodenum, newinode);
-                        log_metadata(&FS_METADATA, pardirinode);
-                        log_metadata(&FS_METADATA, newinodenum);
-
-                        // FileObjectTable stores the entries of the currently opened files in the
-                        // system Since, a new file is being opened here, an
-                        // entry corresponding to that newinode is made in the FileObjectTable
-                        // An entry in the table has the following representation:
-                        // Key - inode number
-                        // Value - Opened file with its size as 0
-                        if let interface::RustHashEntry::Vacant(vac) =
-                            FILEOBJECTTABLE.entry(newinodenum)
-                        {
-                            let sysfilename = format!("{}{}", FILEDATAPREFIX, newinodenum);
-                            vac.insert(interface::openfile(sysfilename, 0).unwrap());
-                            // new file of size 0
-                        }
-
-                        // The file object of size 0, associated with the newinode number is
-                        // inserted into the FileDescriptorTable associated with the cage using the
-                        // guard lock.
-                        let _insertval =
-                            fdoption.insert(File(self._file_initializer(newinodenum, flags, 0)));
-                    }
-
-                    // Case 2: When the file exists (we don't need to look at parent here)
-                    (Some(inodenum), ..) => {
-                        //If O_CREAT and O_EXCL flags are set in the input parameters,
-                        // open_syscall() fails if the file exists.
-                        // This is because the check for the existence of the file and the creation
-                        // of the file if it does not exist is atomic,
-                        // with respect to other threads executing open() naming the same filename
-                        // in the same directory with O_EXCL and O_CREAT set.
-                        if (O_CREAT | O_EXCL) == (flags & (O_CREAT | O_EXCL)) {
-                            return syscall_error(
-                                Errno::EEXIST,
-                                "open",
-                                "file already exists and O_CREAT and O_EXCL were used",
-                            );
-                        }
-                        let size;
-
-                        // Fetch the Inode Object associated with the inode number of the existing
-                        // file. There are different Inode types supported
-                        // by the open_syscall (i.e., File, Directory, Socket, CharDev).
-                        let mut inodeobj = FS_METADATA.inodetable.get_mut(&inodenum).unwrap();
-                        match *inodeobj {
-                            Inode::File(ref mut f) => {
-                                //This is a special case when the input flags contain "O_TRUNC"
-                                // flag, This flag truncates the
-                                // file size to 0, and the mode and owner are unchanged
-                                // and is only used when the file exists and is a regular file
-                                if O_TRUNC == (flags & O_TRUNC) {
-                                    // Close the existing file object and remove it from the
-                                    // FileObject Hashtable using the inodenumber
-                                    let entry = FILEOBJECTTABLE.entry(inodenum);
-                                    if let interface::RustHashEntry::Occupied(occ) = &entry {
-                                        occ.get().close().unwrap();
-                                    }
-
-                                    f.size = 0;
-
-                                    // Update the timestamps as well
-                                    let latest_time = interface::timestamp();
-                                    f.ctime = latest_time;
-                                    f.mtime = latest_time;
-
-                                    // Remove the previous file and add a new one of 0 length
-                                    if let interface::RustHashEntry::Occupied(occ) = entry {
-                                        occ.remove_entry();
-                                    }
-
-                                    // The current file is removed from the filesystem
-                                    let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
-                                    interface::removefile(sysfilename.clone()).unwrap();
-                                }
-
-                                // Once the metadata for the file is reset, a new file is inserted
-                                // in file system. Also, it is
-                                // inserted back to the FileObjectTable and associated with same
-                                // inodeNumber representing that the file is currently in open
-                                // state.
-                                if let interface::RustHashEntry::Vacant(vac) =
-                                    FILEOBJECTTABLE.entry(inodenum)
-                                {
-                                    let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
-                                    vac.insert(interface::openfile(sysfilename, f.size).unwrap());
-                                }
-
-                                // Update the final size and reference count for the file
-                                size = f.size;
-                                f.refcount += 1;
-
-                                // Current Implementation for File Truncate: The
-                                // previous entry of the file is removed from
-                                // the FileObjectTable, with a new file of size
-                                // 0 inserted back into the table.
-                                // Possible Bug: Why are we not simply adjusting
-                                // the file size and pointer of the existing
-                                // file?
-                            }
-
-                            // When the existing file type is of Directory or Character Device, only
-                            // the file size and the reference count is updated.
-                            Inode::Dir(ref mut f) => {
-                                size = f.size;
-                                f.refcount += 1;
-                            }
-                            Inode::CharDev(ref mut f) => {
-                                size = f.size;
-                                f.refcount += 1;
-                            }
-
-                            // If the existing file type is a socket, error is thrown as socket type
-                            // files are not supported by open_syscall
-                            Inode::Socket(_) => {
+        if fd < 0 {
+            // Handle case where no valid file descriptor could be found
+            return syscall_error(
+                Errno::ENFILE,
+                "open",
+                "no available file descriptor number could be found",
+            );
+        }
+    
+        // When the file descriptor is valid, we proceed with performing the remaining checks
+        // for open_syscall.
+        let fdoption = &mut *guardopt.unwrap_or_else(|| panic!("File descriptor couldn't be fetched!"));
+    
+                    // Walk through the absolute path which returns a tuple consisting of inode
+                    // number of file (if it exists), and inode number of parent (if it exists)
+                    match metawalkandparent(truepath.as_path()) {
+                        // Case 1: When the file doesn't exist but the parent directory exists
+                        (None, Some(pardirinode)) => {
+                            // Check if O_CREAT flag is not present, then a file can not be created and
+                            // error is returned.
+                            if 0 == (flags & O_CREAT) {
                                 return syscall_error(
-                                    Errno::ENXIO,
+                                    Errno::ENOENT,
                                     "open",
-                                    "file is a UNIX domain socket",
+                                    "tried to open a file that did not exist, and O_CREAT was not specified",
                                 );
                             }
+    
+                            // Error is thrown when the input flags contain S_IFCHR flag representing a
+                            // special character file.
+                            if S_IFCHR == (S_IFCHR & flags) {
+                                return syscall_error(Errno::EINVAL, "open", "Invalid value in flags");
+                            }
+    
+                            // S_FILETYPEFLAGS represents a bitmask that can be used to extract the file
+                            // type information from a file's mode. This code is
+                            // referenced from Lind-Repy codebase. Here, we are
+                            // checking whether the mode bits are sane by ensuring that only valid file
+                            // permission bits (S_IRWXA) and file type bits (S_FILETYPEFLAGS) are set.
+                            // Else, we return the error.
+                            if mode & (S_IRWXA | S_FILETYPEFLAGS as u32) != mode {
+                                return syscall_error(Errno::EPERM, "open", "Mode bits were not sane");
+                            }
+    
+                            let filename = truepath.file_name().unwrap().to_str().unwrap().to_string(); //for now we assume this is sane, but maybe this should be checked later
+                            let time = interface::timestamp(); //We do a real timestamp now
+    
+                            // S_IFREG is the flag for a regular file, so it's added to the mode to
+                            // indicate that the new file being created is a regular file.
+                            let effective_mode = S_IFREG as u32 | mode;
+    
+                            // Create a new inode of type "File" representing a file and set the
+                            // required attributes
+                            let newinode = Inode::File(GenericInode {
+                                size: 0,
+                                uid: DEFAULT_UID,
+                                gid: DEFAULT_GID,
+                                mode: effective_mode,
+                                linkcount: 1, /* because when a new file is created, it has a single
+                                               * hard link, which is the directory entry that points
+                                               * to this file's inode. */
+                                refcount: 1, /* Because a new file descriptor will open and refer to
+                                              * this file */
+                                atime: time,
+                                ctime: time,
+                                mtime: time,
+                            });
+    
+                            // Fetch the next available inode number using the FileSystem MetaData table
+                            let newinodenum = FS_METADATA
+                                .nextinode
+                                .fetch_add(1, interface::RustAtomicOrdering::Relaxed); //fetch_add returns the previous value, which is the inode number we want
+    
+                            // Fetch the inode of the parent directory and only proceed when its type is
+                            // directory.
+                            if let Inode::Dir(ref mut ind) =
+                                *(FS_METADATA.inodetable.get_mut(&pardirinode).unwrap())
+                            {
+                                ind.filename_to_inode_dict.insert(filename, newinodenum);
+                                ind.linkcount += 1; // Since the parent is now associated to the new file, its linkcount
+                                                    // will increment by 1
+                                ind.ctime = time; // Here, update the ctime and mtime for the parent directory as well
+                                ind.mtime = time;
+                            } else {
+                                return syscall_error(
+                                    Errno::ENOTDIR,
+                                    "open",
+                                    "tried to create a file as a child of something that isn't a directory",
+                                );
+                            }
+                            // Update the inode table by inserting the newly formed inode mapped with
+                            // its inode number.
+                            FS_METADATA.inodetable.insert(newinodenum, newinode);
+                            log_metadata(&FS_METADATA, pardirinode);
+                            log_metadata(&FS_METADATA, newinodenum);
+    
+                            // FileObjectTable stores the entries of the currently opened files in the
+                            // system Since, a new file is being opened here, an
+                            // entry corresponding to that newinode is made in the FileObjectTable
+                            // An entry in the table has the following representation:
+                            // Key - inode number
+                            // Value - Opened file with its size as 0
+                            if let interface::RustHashEntry::Vacant(vac) =
+                                FILEOBJECTTABLE.entry(newinodenum)
+                            {
+                                let sysfilename = format!("{}{}", FILEDATAPREFIX, newinodenum);
+                                vac.insert(interface::openfile(sysfilename, 0).unwrap());
+                                // new file of size 0
+                            }
+    
+                            // The file object of size 0, associated with the newinode number is
+                            // inserted into the FileDescriptorTable associated with the cage using the
+                            // guard lock.
+                            let _insertval =
+                                fdoption.insert(File(self._file_initializer(newinodenum, flags, 0)));
                         }
-
-                        // The file object of size 0, associated with the existing inode number is
-                        // inserted into the FileDescriptorTable associated with the cage using the
-                        // guard lock.
-                        let _insertval =
-                            fdoption.insert(File(self._file_initializer(inodenum, flags, size)));
-                    }
-
-                    // Case 3: When neither the file directory nor the parent directory exists
-                    (None, None) => {
-                        // O_CREAT flag is used to create a file if it doesn't exist.
-                        // If this flag is not present, then a file can not be created and error is
-                        // returned.
-                        if 0 == (flags & O_CREAT) {
-                            return syscall_error(
-                                Errno::ENOENT,
-                                "open",
-                                "tried to open a file that did not exist, and O_CREAT was not specified",
-                            );
+    
+                        // Case 2: When the file exists (we don't need to look at parent here)
+                        (Some(inodenum), ..) => {
+                            //If O_CREAT and O_EXCL flags are set in the input parameters,
+                            // open_syscall() fails if the file exists.
+                            // This is because the check for the existence of the file and the creation
+                            // of the file if it does not exist is atomic,
+                            // with respect to other threads executing open() naming the same filename
+                            // in the same directory with O_EXCL and O_CREAT set.
+                            if (O_CREAT | O_EXCL) == (flags & (O_CREAT | O_EXCL)) {
+                                return syscall_error(
+                                    Errno::EEXIST,
+                                    "open",
+                                    "file already exists and O_CREAT and O_EXCL were used",
+                                );
+                            }
+                            let size;
+    
+                            // Fetch the Inode Object associated with the inode number of the existing
+                            // file. There are different Inode types supported
+                            // by the open_syscall (i.e., File, Directory, Socket, CharDev).
+                            let mut inodeobj = FS_METADATA.inodetable.get_mut(&inodenum).unwrap();
+                            match *inodeobj {
+                                Inode::File(ref mut f) => {
+                                    //This is a special case when the input flags contain "O_TRUNC"
+                                    // flag, This flag truncates the
+                                    // file size to 0, and the mode and owner are unchanged
+                                    // and is only used when the file exists and is a regular file
+                                    if O_TRUNC == (flags & O_TRUNC) {
+                                        // Close the existing file object and remove it from the
+                                        // FileObject Hashtable using the inodenumber
+                                        let entry = FILEOBJECTTABLE.entry(inodenum);
+                                        if let interface::RustHashEntry::Occupied(occ) = &entry {
+                                            occ.get().close().unwrap();
+                                        }
+    
+                                        f.size = 0;
+    
+                                        // Update the timestamps as well
+                                        let latest_time = interface::timestamp();
+                                        f.ctime = latest_time;
+                                        f.mtime = latest_time;
+    
+                                        // Remove the previous file and add a new one of 0 length
+                                        if let interface::RustHashEntry::Occupied(occ) = entry {
+                                            occ.remove_entry();
+                                        }
+    
+                                        // The current file is removed from the filesystem
+                                        let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
+                                        interface::removefile(sysfilename.clone()).unwrap();
+                                    }
+    
+                                    // Once the metadata for the file is reset, a new file is inserted
+                                    // in file system. Also, it is
+                                    // inserted back to the FileObjectTable and associated with same
+                                    // inodeNumber representing that the file is currently in open
+                                    // state.
+                                    if let interface::RustHashEntry::Vacant(vac) =
+                                        FILEOBJECTTABLE.entry(inodenum)
+                                    {
+                                        let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
+                                        vac.insert(interface::openfile(sysfilename, f.size).unwrap());
+                                    }
+    
+                                    // Update the final size and reference count for the file
+                                    size = f.size;
+                                    f.refcount += 1;
+    
+                                    // Current Implementation for File Truncate: The
+                                    // previous entry of the file is removed from
+                                    // the FileObjectTable, with a new file of size
+                                    // 0 inserted back into the table.
+                                    // Possible Bug: Why are we not simply adjusting
+                                    // the file size and pointer of the existing
+                                    // file?
+                                }
+    
+                                // When the existing file type is of Directory or Character Device, only
+                                // the file size and the reference count is updated.
+                                Inode::Dir(ref mut f) => {
+                                    size = f.size;
+                                    f.refcount += 1;
+                                }
+                                Inode::CharDev(ref mut f) => {
+                                    size = f.size;
+                                    f.refcount += 1;
+                                }
+    
+                                // If the existing file type is a socket, error is thrown as socket type
+                                // files are not supported by open_syscall
+                                Inode::Socket(_) => {
+                                    return syscall_error(
+                                        Errno::ENXIO,
+                                        "open",
+                                        "file is a UNIX domain socket",
+                                    );
+                                }
+                            }
+    
+                            // The file object of size 0, associated with the existing inode number is
+                            // inserted into the FileDescriptorTable associated with the cage using the
+                            // guard lock.
+                            let _insertval =
+                                fdoption.insert(File(self._file_initializer(inodenum, flags, size)));
                         }
-                        // O_CREAT flag is set but the path doesn't exist, so return an error with a
-                        // different message string.
-                        return syscall_error(Errno::ENOENT, "open", "a directory component in pathname does not exist or is a dangling symbolic link");
+    
+                        // Case 3: When neither the file directory nor the parent directory exists
+                        (None, None) => {
+                            // O_CREAT flag is used to create a file if it doesn't exist.
+                            // If this flag is not present, then a file can not be created and error is
+                            // returned.
+                            if 0 == (flags & O_CREAT) {
+                                return syscall_error(
+                                    Errno::ENOENT,
+                                    "open",
+                                    "tried to open a file that did not exist, and O_CREAT was not specified",
+                                );
+                            }
+                            // O_CREAT flag is set but the path doesn't exist, so return an error with a
+                            // different message string.
+                            return syscall_error(Errno::ENOENT, "open", "a directory component in pathname does not exist or is a dangling symbolic link");
+                        }
                     }
-                }
-
-                // Once all the updates are done, the file descriptor value is returned
-                fd
-            }
-            // Panic when there is some other issue fetching the file descriptor.
-            _ => {
-                panic!("File descriptor couldn't be fetched!");
-            }
-        }
+        // Return the valid file descriptor
+        fd
     }
 
     /// ### Description

--- a/src/safeposix/syscalls/fs_calls.rs
+++ b/src/safeposix/syscalls/fs_calls.rs
@@ -205,240 +205,235 @@ impl Cage {
             );
         }
     
-        // When the file descriptor is valid, we proceed with performing the remaining checks
-        // for open_syscall.
+        // When the file descriptor is valid, we proceed with performing the remaining
+        // checks for open_syscall.
         let fdoption = &mut *guardopt.unwrap_or_else(|| panic!("File descriptor couldn't be fetched!"));
     
-                    // Walk through the absolute path which returns a tuple consisting of inode
-                    // number of file (if it exists), and inode number of parent (if it exists)
-                    match metawalkandparent(truepath.as_path()) {
-                        // Case 1: When the file doesn't exist but the parent directory exists
-                        (None, Some(pardirinode)) => {
-                            // Check if O_CREAT flag is not present, then a file can not be created and
-                            // error is returned.
-                            if 0 == (flags & O_CREAT) {
-                                return syscall_error(
-                                    Errno::ENOENT,
-                                    "open",
-                                    "tried to open a file that did not exist, and O_CREAT was not specified",
-                                );
+        // Walk through the absolute path which returns a tuple consisting of inode
+        // number of file (if it exists), and inode number of parent (if it exists)
+        match metawalkandparent(truepath.as_path()) {
+            // Case 1: When the file doesn't exist but the parent directory exists
+            (None, Some(pardirinode)) => {
+                // Check if O_CREAT flag is not present, then a file can not be created and
+                // error is returned.
+                if 0 == (flags & O_CREAT) {
+                    return syscall_error(
+                        Errno::ENOENT,
+                        "open",
+                        "tried to open a file that did not exist, and O_CREAT was not specified",
+                    );
+                }
+    
+                // Error is thrown when the input flags contain S_IFCHR flag representing a
+                // special character file.
+                if S_IFCHR == (S_IFCHR & flags) {
+                    return syscall_error(Errno::EINVAL, "open", "Invalid value in flags");
+                }
+    
+                // S_FILETYPEFLAGS represents a bitmask that can be used to extract the file
+                // type information from a file's mode. This code is
+                // referenced from Lind-Repy codebase. Here, we are
+                // checking whether the mode bits are sane by ensuring that only valid file
+                // permission bits (S_IRWXA) and file type bits (S_FILETYPEFLAGS) are set.
+                // Else, we return the error.
+                if mode & (S_IRWXA | S_FILETYPEFLAGS as u32) != mode {
+                    return syscall_error(Errno::EPERM, "open", "Mode bits were not sane");
+                }
+    
+                let filename = truepath.file_name().unwrap().to_str().unwrap().to_string(); //for now we assume this is sane, but maybe this should be checked later
+                let time = interface::timestamp(); //We do a real timestamp now
+    
+                // S_IFREG is the flag for a regular file, so it's added to the mode to
+                // indicate that the new file being created is a regular file.
+                let effective_mode = S_IFREG as u32 | mode;
+    
+                // Create a new inode of type "File" representing a file and set the
+                // required attributes
+                let newinode = Inode::File(GenericInode {
+                    size: 0,
+                    uid: DEFAULT_UID,
+                    gid: DEFAULT_GID,
+                    mode: effective_mode,
+                    linkcount: 1, /* because when a new file is created, it has a single
+                                   * hard link, which is the directory entry that points
+                                   * to this file's inode. */
+                    refcount: 1, /* Because a new file descriptor will open and refer to
+                                  * this file */
+                    atime: time,
+                    ctime: time,
+                    mtime: time,
+                });
+    
+                // Fetch the next available inode number using the FileSystem MetaData table
+                let newinodenum = FS_METADATA
+                    .nextinode
+                    .fetch_add(1, interface::RustAtomicOrdering::Relaxed); //fetch_add returns the previous value, which is the inode number we want
+    
+                // Fetch the inode of the parent directory and only proceed when its type is
+                // directory.
+                if let Inode::Dir(ref mut ind) =
+                    *(FS_METADATA.inodetable.get_mut(&pardirinode).unwrap())
+                {
+                    ind.filename_to_inode_dict.insert(filename, newinodenum);
+                    ind.linkcount += 1; // Since the parent is now associated to the new file, its linkcount
+                                        // will increment by 1
+                    ind.ctime = time; // Here, update the ctime and mtime for the parent directory as well
+                    ind.mtime = time;
+                } else {
+                    return syscall_error(
+                        Errno::ENOTDIR,
+                        "open",
+                        "tried to create a file as a child of something that isn't a directory",
+                    );
+                }
+                // Update the inode table by inserting the newly formed inode mapped with
+                // its inode number.
+                FS_METADATA.inodetable.insert(newinodenum, newinode);
+                log_metadata(&FS_METADATA, pardirinode);
+                log_metadata(&FS_METADATA, newinodenum);
+    
+                // FileObjectTable stores the entries of the currently opened files in the
+                // system Since, a new file is being opened here, an
+                // entry corresponding to that newinode is made in the FileObjectTable
+                // An entry in the table has the following representation:
+                // Key - inode number
+                // Value - Opened file with its size as 0
+                if let interface::RustHashEntry::Vacant(vac) = FILEOBJECTTABLE.entry(newinodenum) {
+                    let sysfilename = format!("{}{}", FILEDATAPREFIX, newinodenum);
+                    vac.insert(interface::openfile(sysfilename, 0).unwrap());
+                    // new file of size 0
+                }
+    
+                // The file object of size 0, associated with the newinode number is
+                // inserted into the FileDescriptorTable associated with the cage using the
+                // guard lock.
+                let _insertval = fdoption.insert(File(self._file_initializer(newinodenum, flags, 0)));
+            }
+    
+            // Case 2: When the file exists (we don't need to look at parent here)
+            (Some(inodenum), ..) => {
+                //If O_CREAT and O_EXCL flags are set in the input parameters,
+                // open_syscall() fails if the file exists.
+                // This is because the check for the existence of the file and the creation
+                // of the file if it does not exist is atomic,
+                // with respect to other threads executing open() naming the same filename
+                // in the same directory with O_EXCL and O_CREAT set.
+                if (O_CREAT | O_EXCL) == (flags & (O_CREAT | O_EXCL)) {
+                    return syscall_error(
+                        Errno::EEXIST,
+                        "open",
+                        "file already exists and O_CREAT and O_EXCL were used",
+                    );
+                }
+                let size;
+    
+                // Fetch the Inode Object associated with the inode number of the existing
+                // file. There are different Inode types supported
+                // by the open_syscall (i.e., File, Directory, Socket, CharDev).
+                let mut inodeobj = FS_METADATA.inodetable.get_mut(&inodenum).unwrap();
+                match *inodeobj {
+                    Inode::File(ref mut f) => {
+                        //This is a special case when the input flags contain "O_TRUNC"
+                        // flag, This flag truncates the
+                        // file size to 0, and the mode and owner are unchanged
+                        // and is only used when the file exists and is a regular file
+                        if O_TRUNC == (flags & O_TRUNC) {
+                            // Close the existing file object and remove it from the
+                            // FileObject Hashtable using the inodenumber
+                            let entry = FILEOBJECTTABLE.entry(inodenum);
+                            if let interface::RustHashEntry::Occupied(occ) = &entry {
+                                occ.get().close().unwrap();
                             }
     
-                            // Error is thrown when the input flags contain S_IFCHR flag representing a
-                            // special character file.
-                            if S_IFCHR == (S_IFCHR & flags) {
-                                return syscall_error(Errno::EINVAL, "open", "Invalid value in flags");
+                            f.size = 0;
+    
+                            // Update the timestamps as well
+                            let latest_time = interface::timestamp();
+                            f.ctime = latest_time;
+                            f.mtime = latest_time;
+    
+                            // Remove the previous file and add a new one of 0 length
+                            if let interface::RustHashEntry::Occupied(occ) = entry {
+                                occ.remove_entry();
                             }
     
-                            // S_FILETYPEFLAGS represents a bitmask that can be used to extract the file
-                            // type information from a file's mode. This code is
-                            // referenced from Lind-Repy codebase. Here, we are
-                            // checking whether the mode bits are sane by ensuring that only valid file
-                            // permission bits (S_IRWXA) and file type bits (S_FILETYPEFLAGS) are set.
-                            // Else, we return the error.
-                            if mode & (S_IRWXA | S_FILETYPEFLAGS as u32) != mode {
-                                return syscall_error(Errno::EPERM, "open", "Mode bits were not sane");
-                            }
-    
-                            let filename = truepath.file_name().unwrap().to_str().unwrap().to_string(); //for now we assume this is sane, but maybe this should be checked later
-                            let time = interface::timestamp(); //We do a real timestamp now
-    
-                            // S_IFREG is the flag for a regular file, so it's added to the mode to
-                            // indicate that the new file being created is a regular file.
-                            let effective_mode = S_IFREG as u32 | mode;
-    
-                            // Create a new inode of type "File" representing a file and set the
-                            // required attributes
-                            let newinode = Inode::File(GenericInode {
-                                size: 0,
-                                uid: DEFAULT_UID,
-                                gid: DEFAULT_GID,
-                                mode: effective_mode,
-                                linkcount: 1, /* because when a new file is created, it has a single
-                                               * hard link, which is the directory entry that points
-                                               * to this file's inode. */
-                                refcount: 1, /* Because a new file descriptor will open and refer to
-                                              * this file */
-                                atime: time,
-                                ctime: time,
-                                mtime: time,
-                            });
-    
-                            // Fetch the next available inode number using the FileSystem MetaData table
-                            let newinodenum = FS_METADATA
-                                .nextinode
-                                .fetch_add(1, interface::RustAtomicOrdering::Relaxed); //fetch_add returns the previous value, which is the inode number we want
-    
-                            // Fetch the inode of the parent directory and only proceed when its type is
-                            // directory.
-                            if let Inode::Dir(ref mut ind) =
-                                *(FS_METADATA.inodetable.get_mut(&pardirinode).unwrap())
-                            {
-                                ind.filename_to_inode_dict.insert(filename, newinodenum);
-                                ind.linkcount += 1; // Since the parent is now associated to the new file, its linkcount
-                                                    // will increment by 1
-                                ind.ctime = time; // Here, update the ctime and mtime for the parent directory as well
-                                ind.mtime = time;
-                            } else {
-                                return syscall_error(
-                                    Errno::ENOTDIR,
-                                    "open",
-                                    "tried to create a file as a child of something that isn't a directory",
-                                );
-                            }
-                            // Update the inode table by inserting the newly formed inode mapped with
-                            // its inode number.
-                            FS_METADATA.inodetable.insert(newinodenum, newinode);
-                            log_metadata(&FS_METADATA, pardirinode);
-                            log_metadata(&FS_METADATA, newinodenum);
-    
-                            // FileObjectTable stores the entries of the currently opened files in the
-                            // system Since, a new file is being opened here, an
-                            // entry corresponding to that newinode is made in the FileObjectTable
-                            // An entry in the table has the following representation:
-                            // Key - inode number
-                            // Value - Opened file with its size as 0
-                            if let interface::RustHashEntry::Vacant(vac) =
-                                FILEOBJECTTABLE.entry(newinodenum)
-                            {
-                                let sysfilename = format!("{}{}", FILEDATAPREFIX, newinodenum);
-                                vac.insert(interface::openfile(sysfilename, 0).unwrap());
-                                // new file of size 0
-                            }
-    
-                            // The file object of size 0, associated with the newinode number is
-                            // inserted into the FileDescriptorTable associated with the cage using the
-                            // guard lock.
-                            let _insertval =
-                                fdoption.insert(File(self._file_initializer(newinodenum, flags, 0)));
+                            // The current file is removed from the filesystem
+                            let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
+                            interface::removefile(sysfilename.clone()).unwrap();
                         }
     
-                        // Case 2: When the file exists (we don't need to look at parent here)
-                        (Some(inodenum), ..) => {
-                            //If O_CREAT and O_EXCL flags are set in the input parameters,
-                            // open_syscall() fails if the file exists.
-                            // This is because the check for the existence of the file and the creation
-                            // of the file if it does not exist is atomic,
-                            // with respect to other threads executing open() naming the same filename
-                            // in the same directory with O_EXCL and O_CREAT set.
-                            if (O_CREAT | O_EXCL) == (flags & (O_CREAT | O_EXCL)) {
-                                return syscall_error(
-                                    Errno::EEXIST,
-                                    "open",
-                                    "file already exists and O_CREAT and O_EXCL were used",
-                                );
-                            }
-                            let size;
-    
-                            // Fetch the Inode Object associated with the inode number of the existing
-                            // file. There are different Inode types supported
-                            // by the open_syscall (i.e., File, Directory, Socket, CharDev).
-                            let mut inodeobj = FS_METADATA.inodetable.get_mut(&inodenum).unwrap();
-                            match *inodeobj {
-                                Inode::File(ref mut f) => {
-                                    //This is a special case when the input flags contain "O_TRUNC"
-                                    // flag, This flag truncates the
-                                    // file size to 0, and the mode and owner are unchanged
-                                    // and is only used when the file exists and is a regular file
-                                    if O_TRUNC == (flags & O_TRUNC) {
-                                        // Close the existing file object and remove it from the
-                                        // FileObject Hashtable using the inodenumber
-                                        let entry = FILEOBJECTTABLE.entry(inodenum);
-                                        if let interface::RustHashEntry::Occupied(occ) = &entry {
-                                            occ.get().close().unwrap();
-                                        }
-    
-                                        f.size = 0;
-    
-                                        // Update the timestamps as well
-                                        let latest_time = interface::timestamp();
-                                        f.ctime = latest_time;
-                                        f.mtime = latest_time;
-    
-                                        // Remove the previous file and add a new one of 0 length
-                                        if let interface::RustHashEntry::Occupied(occ) = entry {
-                                            occ.remove_entry();
-                                        }
-    
-                                        // The current file is removed from the filesystem
-                                        let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
-                                        interface::removefile(sysfilename.clone()).unwrap();
-                                    }
-    
-                                    // Once the metadata for the file is reset, a new file is inserted
-                                    // in file system. Also, it is
-                                    // inserted back to the FileObjectTable and associated with same
-                                    // inodeNumber representing that the file is currently in open
-                                    // state.
-                                    if let interface::RustHashEntry::Vacant(vac) =
-                                        FILEOBJECTTABLE.entry(inodenum)
-                                    {
-                                        let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
-                                        vac.insert(interface::openfile(sysfilename, f.size).unwrap());
-                                    }
-    
-                                    // Update the final size and reference count for the file
-                                    size = f.size;
-                                    f.refcount += 1;
-    
-                                    // Current Implementation for File Truncate: The
-                                    // previous entry of the file is removed from
-                                    // the FileObjectTable, with a new file of size
-                                    // 0 inserted back into the table.
-                                    // Possible Bug: Why are we not simply adjusting
-                                    // the file size and pointer of the existing
-                                    // file?
-                                }
-    
-                                // When the existing file type is of Directory or Character Device, only
-                                // the file size and the reference count is updated.
-                                Inode::Dir(ref mut f) => {
-                                    size = f.size;
-                                    f.refcount += 1;
-                                }
-                                Inode::CharDev(ref mut f) => {
-                                    size = f.size;
-                                    f.refcount += 1;
-                                }
-    
-                                // If the existing file type is a socket, error is thrown as socket type
-                                // files are not supported by open_syscall
-                                Inode::Socket(_) => {
-                                    return syscall_error(
-                                        Errno::ENXIO,
-                                        "open",
-                                        "file is a UNIX domain socket",
-                                    );
-                                }
-                            }
-    
-                            // The file object of size 0, associated with the existing inode number is
-                            // inserted into the FileDescriptorTable associated with the cage using the
-                            // guard lock.
-                            let _insertval =
-                                fdoption.insert(File(self._file_initializer(inodenum, flags, size)));
+                        // Once the metadata for the file is reset, a new file is inserted
+                        // in file system. Also, it is
+                        // inserted back to the FileObjectTable and associated with same
+                        // inodeNumber representing that the file is currently in open
+                        // state.
+                        if let interface::RustHashEntry::Vacant(vac) = FILEOBJECTTABLE.entry(inodenum) {
+                            let sysfilename = format!("{}{}", FILEDATAPREFIX, inodenum);
+                            vac.insert(interface::openfile(sysfilename, f.size).unwrap());
                         }
     
-                        // Case 3: When neither the file directory nor the parent directory exists
-                        (None, None) => {
-                            // O_CREAT flag is used to create a file if it doesn't exist.
-                            // If this flag is not present, then a file can not be created and error is
-                            // returned.
-                            if 0 == (flags & O_CREAT) {
-                                return syscall_error(
-                                    Errno::ENOENT,
-                                    "open",
-                                    "tried to open a file that did not exist, and O_CREAT was not specified",
-                                );
-                            }
-                            // O_CREAT flag is set but the path doesn't exist, so return an error with a
-                            // different message string.
-                            return syscall_error(Errno::ENOENT, "open", "a directory component in pathname does not exist or is a dangling symbolic link");
-                        }
+                        // Update the final size and reference count for the file
+                        size = f.size;
+                        f.refcount += 1;
+    
+                        // Current Implementation for File Truncate: The
+                        // previous entry of the file is removed from
+                        // the FileObjectTable, with a new file of size
+                        // 0 inserted back into the table.
+                        // Possible Bug: Why are we not simply adjusting
+                        // the file size and pointer of the existing
+                        // file?
                     }
+    
+                    // When the existing file type is of Directory or Character Device, only
+                    // the file size and the reference count is updated.
+                    Inode::Dir(ref mut f) => {
+                        size = f.size;
+                        f.refcount += 1;
+                    }
+                    Inode::CharDev(ref mut f) => {
+                        size = f.size;
+                        f.refcount += 1;
+                    }
+    
+                    // If the existing file type is a socket, error is thrown as socket type
+                    // files are not supported by open_syscall
+                    Inode::Socket(_) => {
+                        return syscall_error(Errno::ENXIO, "open", "file is a UNIX domain socket");
+                    }
+                }
+    
+                // The file object of size 0, associated with the existing inode number is
+                // inserted into the FileDescriptorTable associated with the cage using the
+                // guard lock.
+                let _insertval = fdoption.insert(File(self._file_initializer(inodenum, flags, size)));
+            }
+    
+            // Case 3: When neither the file directory nor the parent directory exists
+            (None, None) => {
+                // O_CREAT flag is used to create a file if it doesn't exist.
+                // If this flag is not present, then a file can not be created and error is
+                // returned.
+                if 0 == (flags & O_CREAT) {
+                    return syscall_error(
+                        Errno::ENOENT,
+                        "open",
+                        "tried to open a file that did not exist, and O_CREAT was not specified",
+                    );
+                }
+                // O_CREAT flag is set but the path doesn't exist, so return an error with a
+                // different message string.
+                return syscall_error(
+                    Errno::ENOENT,
+                    "open",
+                    "a directory component in pathname does not exist or is a dangling symbolic link",
+                );
+            }
+        }
         // Return the valid file descriptor
         fd
     }
+    
 
     /// ### Description
     ///

--- a/src/tests/fs_tests.rs
+++ b/src/tests/fs_tests.rs
@@ -40,9 +40,8 @@ pub mod fs_tests {
         let _thelock = setup::lock_and_init();
         let cage = interface::cagetable_getref(1);
 
-        // Attempt to open up to 2048 unique file descriptors
-        for i in 0..23 {
-            // Vary the filename to avoid conflicts or state issues
+        for i in 0..1020 {
+            // Vary the filename 
             let path = format!("/dev/test_{}", i);
 
             // Open the file with the given path

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,7 +3,7 @@
 
 mod fs_tests;
 mod ipc_tests;
-mod networking_tests;
+// mod networking_tests;
 mod sys_tests;
 use rand::Rng;
 use std::net::{TcpListener, UdpSocket};

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,7 +3,7 @@
 
 mod fs_tests;
 mod ipc_tests;
-// mod networking_tests;
+mod networking_tests;
 mod sys_tests;
 use rand::Rng;
 use std::net::{TcpListener, UdpSocket};


### PR DESCRIPTION
## Description

Fixes # ([issue](https://github.com/Lind-Project/safeposix-rust/issues/322))

This pr fixes the fd issue caused by open_syscall

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

- Test A - `lind_project/tests/test_cases/test_a.c`
- Test B - `lind_project/tests/test_cases/test_b.c`

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
