### PR TITLE
Add Loopback Socket

### DIFF
--- a/src/interface/comm.rs
+++ b/src/interface/comm.rs
@@ -639,3 +639,10 @@ pub fn kernel_select(
 
     return result;
 }
+
+pub fn get_loopback_path(port: u16) -> String {
+    let mut path = String::from("tmp/loopback");
+    path.push_str(&port.to_string());
+
+    path
+}

--- a/src/safeposix/syscalls/net_calls.rs
+++ b/src/safeposix/syscalls/net_calls.rs
@@ -453,7 +453,7 @@ impl Cage {
                         if addr.s_addr == loopback_addr {
                             // this is the loopback address, and we need to fake it into a domain socket
 
-                            let mut path = interface::get_loopback_path(newsockaddr.port());
+                            let path = interface::get_loopback_path(newsockaddr.port());
                             newsockaddr = GenSockaddr::Unix(interface::new_sockaddr_unix(AF_UNIX as u16, path.as_bytes()));
 
                             sockhandle.domain = AF_UNIX;

--- a/src/tests/ipc_tests.rs
+++ b/src/tests/ipc_tests.rs
@@ -390,44 +390,32 @@ pub mod ipc_tests {
 
             let clientsockfd = cage2.socket_syscall(AF_INET, SOCK_STREAM, 0);
 
-            println!("client connect");
             // connect to server
             assert_eq!(cage2.connect_syscall(clientsockfd, &socket), 0);
-            println!("client connect done");
 
-            println!("client send");
             // send message to server
             assert_eq!(cage2.send_syscall(clientsockfd, str2cbuf("test"), 4, 0), 4);
-            println!("client send done");
 
             interface::sleep(interface::RustDuration::from_millis(1));
 
-            println!("client receive");
             // receive message from server
             let mut buf = sizecbuf(4);
             assert_eq!(cage2.recv_syscall(clientsockfd, buf.as_mut_ptr(), 4, 0), 4);
             assert_eq!(cbuf2str(&buf), "test");
-            println!("client receive done");
 
-            println!("client close");
             assert_eq!(cage2.close_syscall(clientsockfd), 0);
-            println!("client close done");
 
             barrier_clone.wait();
 
-            println!("client exit");
             cage2.exit_syscall(EXIT_SUCCESS);
         });
 
         let mut sockgarbage =
             interface::GenSockaddr::V4(interface::SockaddrV4::default());
 
-        println!("server accept");
         let sockfd = cage.accept_syscall(serversockfd as i32, &mut sockgarbage);
         assert!(sockfd > 0);
-        println!("server accept done");
         
-        println!("server receive");
         let mut buf = sizecbuf(4);
         let mut recvresult: i32;
         loop {
@@ -440,14 +428,10 @@ pub mod ipc_tests {
         }
 
         assert!(cbuf2str(&buf) == "test");
-        println!("server receive done");
 
-        println!("server send");
         // send message to server
         assert_eq!(cage.send_syscall(sockfd, str2cbuf("test"), 4, 0), 4);
-        println!("server send done");
 
-        println!("server wait");
         barrier.wait();
         
         threadclient.join().unwrap();

--- a/src/tests/ipc_tests.rs
+++ b/src/tests/ipc_tests.rs
@@ -352,6 +352,110 @@ pub mod ipc_tests {
         lindrustfinalize();
     }
 
+    #[test]
+    pub fn ut_lind_ipc_loopback_socket() {
+        // acquiring a lock on TESTMUTEX prevents other tests from running concurrently,
+        // and also performs clean env setup
+        let _thelock = setup::lock_and_init();
+
+        let cage = interface::cagetable_getref(1);
+        
+        let serversockfd = cage.socket_syscall(AF_INET, SOCK_STREAM, 0);
+
+        // create a INET address
+        let port: u16 = generate_random_port();
+
+        let sockaddr = interface::SockaddrV4 {
+            sin_family: AF_INET as u16,
+            sin_port: port.to_le(),
+            sin_addr: interface::V4Addr {
+                s_addr: u32::from_ne_bytes([127, 0, 0, 7]),
+            },
+            padding: 0,
+        };
+        let socket = interface::GenSockaddr::V4(sockaddr); //127.0.0.7 from bytes above
+
+        assert_eq!(cage.bind_syscall(serversockfd, &socket), 0);
+        assert_eq!(cage.listen_syscall(serversockfd, 4), 0);
+
+        let barrier = interface::RustRfc::new(std::sync::Barrier::new(2));
+        let barrier_clone = barrier.clone();
+
+        assert_eq!(cage.fork_syscall(2), 0); // used for pipe thread
+
+        // client 1 connects to the server to send and recv data
+        let threadclient = interface::helper_thread(move || {
+            let cage2 = interface::cagetable_getref(2);
+            // assert_eq!(cage2.close_syscall(serversockfd), 0);
+
+            let clientsockfd = cage2.socket_syscall(AF_INET, SOCK_STREAM, 0);
+
+            println!("client connect");
+            // connect to server
+            assert_eq!(cage2.connect_syscall(clientsockfd, &socket), 0);
+            println!("client connect done");
+
+            println!("client send");
+            // send message to server
+            assert_eq!(cage2.send_syscall(clientsockfd, str2cbuf("test"), 4, 0), 4);
+            println!("client send done");
+
+            interface::sleep(interface::RustDuration::from_millis(1));
+
+            println!("client receive");
+            // receive message from server
+            let mut buf = sizecbuf(4);
+            assert_eq!(cage2.recv_syscall(clientsockfd, buf.as_mut_ptr(), 4, 0), 4);
+            assert_eq!(cbuf2str(&buf), "test");
+            println!("client receive done");
+
+            println!("client close");
+            assert_eq!(cage2.close_syscall(clientsockfd), 0);
+            println!("client close done");
+
+            barrier_clone.wait();
+
+            println!("client exit");
+            cage2.exit_syscall(EXIT_SUCCESS);
+        });
+
+        let mut sockgarbage =
+            interface::GenSockaddr::V4(interface::SockaddrV4::default());
+
+        println!("server accept");
+        let sockfd = cage.accept_syscall(serversockfd as i32, &mut sockgarbage);
+        assert!(sockfd > 0);
+        println!("server accept done");
+        
+        println!("server receive");
+        let mut buf = sizecbuf(4);
+        let mut recvresult: i32;
+        loop {
+            // receive message from peer
+            recvresult = cage.recv_syscall(sockfd as i32, buf.as_mut_ptr(), 4, 0);
+            if recvresult != -libc::EINTR {
+                break; // if the error was EINTR, retry the
+                       // syscall
+            }
+        }
+
+        assert!(cbuf2str(&buf) == "test");
+        println!("server receive done");
+
+        println!("server send");
+        // send message to server
+        assert_eq!(cage.send_syscall(sockfd, str2cbuf("test"), 4, 0), 4);
+        println!("server send done");
+
+        println!("server wait");
+        barrier.wait();
+        
+        threadclient.join().unwrap();
+
+        assert_eq!(cage.exit_syscall(EXIT_SUCCESS), EXIT_SUCCESS);
+        lindrustfinalize();
+    }
+
     // support for retrying writes in case the system doesn't write all bytes at
     // once
     #[test]


### PR DESCRIPTION
## Description

This PR adds loopback socket (127.0.0.7) for rustposix
- When server calls bind_syscall to a loopback address, its socket will be implicitly replaced to a domain socket
- When client calls connect_syscall to a loopback address, its socket will be implicitly replaced to a domain socket

Fixes # (issue)

<!-- Please include a summary of the changes and the related issue. --> 
<!-- Please also include relevant motivation and context. Why is this change required? What problem does it solve? -->
<!-- List any dependencies that are required for this change. -->

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->

- Test A - `ipc_tests.rs/ut_lind_ipc_loopback_socket`

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (native-client, lind-glibc, lind-project)
